### PR TITLE
Remove `--ext` and use globs for extension names

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "pub": "sh build/release.sh",
     "pub:all": "npm run dist:all && lerna publish",
     "build:utils": "babel src/utils --out-dir lib/utils",
-    "lint": "eslint src/** packages/** build/** --ext .js,.vue --quiet"
+    "lint": "eslint src/**/*.js packages/**/*.{js,vue} build/**/*.js --quiet"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Option `--ext` is not expected to work with globs, see
http://eslint.org/docs/user-guide/command-line-interface#ext.