### PR TITLE
resolve cross package dependency for theme-default

### DIFF
--- a/packages/theme-default/src/dialog.css
+++ b/packages/theme-default/src/dialog.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 @import "./common/var.css";
-@import '../../dialog/node_modules/vue-popup/lib/popup.css';
+@import '../../../node_modules/vue-popup/lib/popup.css';
 
 @component-namespace el {
 


### PR DESCRIPTION
`popup.css` in package `theme-default` depends on `dialog` package dependencies. `vue-popup` is already required in global context. so this PR removes this dependency :)