### PR TITLE
Dropdown: fix #194 bug

### DIFF
--- a/packages/dropdown/src/dropdown-menu.vue
+++ b/packages/dropdown/src/dropdown-menu.vue
@@ -31,6 +31,7 @@
     },
 
     destroyed() {
+      this.$el.remove();
       setTimeout(() => {
         this.popper.destroy();
       }, 300);


### PR DESCRIPTION
修复https://github.com/ElemeFE/element/issues/194 bug，在下拉框销毁时将其从body中删除

