### PR TITLE
Step: Modify Step styling

### DIFF
--- a/packages/theme-default/src/step.css
+++ b/packages/theme-default/src/step.css
@@ -19,10 +19,6 @@
       & .el-step__main {
         padding-left: 10px;
       }
-
-      & .el-step__description {
-        width: 300px;
-      }
     }
 
     @e line {
@@ -149,7 +145,7 @@
 
     @e title {
       font-size: 14px;
-      margin-top: 5px;
+      line-height: 32px;
       display: inline-block;
 
       @when process {


### PR DESCRIPTION
PR内容：
- 去掉竖形步骤条description的`300px`长度：不建议定义这个长度，而且如果不定义`word-wrap: break-word`，里面的文字其实会一直延伸下去。
- 去掉title的`margin-top`而用`line-height`取代：这个视觉效果更好一些