### PR TITLE
Steps: add vertical-align: middle

### DIFF
--- a/packages/theme-default/src/step.css
+++ b/packages/theme-default/src/step.css
@@ -64,6 +64,7 @@
 
       > * {
         line-height: inherit;
+        vertical-align: middle;
       }
     }
 


### PR DESCRIPTION
让Steps里面图标居中 （默认是[base-line](https://github.com/ElemeFE/element/blob/master/packages/theme-default/src/icon.css#L20)）