### PR TITLE
Fix to the popover directive

### DIFF
--- a/packages/popover/src/main.vue
+++ b/packages/popover/src/main.vue
@@ -22,7 +22,9 @@ import { on, off } from 'wind-dom/src/event';
 
 Vue.directive('popover', {
   bind(el, binding, vnode) {
-    vnode.context.$refs[binding.arg].$refs.reference = el;
+    const parent = vnode.context.$refs[binding.arg]
+    if (parent)
+      parent.$refs.reference = el;
   }
 });
 


### PR DESCRIPTION
Now it won't produce an exception if we haven't registered a proper popover with `ref`. It may be convenient if we need to remove our popover completely on a condition.