### PR TITLE
Input-number: Add readonly attribute

### DIFF
--- a/examples/docs/zh-cn/input-number.md
+++ b/examples/docs/zh-cn/input-number.md
@@ -74,6 +74,7 @@
 | step     | 计数器步长           | number   | — | 1 |
 | size     | 计数器尺寸           | string   | large, small | — |
 | disabled | 是否禁用计数器        | boolean | — | false |
+| readonly | 是否只读输入栏        | boolean | — | false |
 
 ### Events
 | 事件名称 | 说明 | 回调参数 |

--- a/examples/docs/zh-cn/input.md
+++ b/examples/docs/zh-cn/input.md
@@ -637,6 +637,7 @@
 | minlength     | 最小输入长度      | number          | — | — |
 | placeholder   | 输入框占位文本    | string          | — | — |
 | disabled      | 禁用            | boolean         | — | false   |
+| readonly      | 只读            | boolean         | — | false   |
 | size          | 输入框尺寸，只在 `type!="textarea"` 时有效      | string          | large, small, mini  | — |
 | icon          | 输入框尾部图标    | string          | — | — |
 | rows          | 输入框行数，只对 `type="textarea"` 有效  |  number | — |  2   |

--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -7,6 +7,7 @@
   >
     <el-input
       v-model.number="currentValue"
+      :readonly="readonly"
       :disabled="disabled"
       :size="size"
       :class="{
@@ -54,6 +55,7 @@
         default: 0
       },
       disabled: Boolean,
+      readonly: Boolean,
       size: String
     },
     directives: {


### PR DESCRIPTION
- 添加input的`readonly`文档：input本身具备`readonly`属性，但是文档没有添加
- 添加input-number的`readonly`属性与文档：让计数器只能通过按钮来增加或者减少，并且直接调用input的`readonly`