### PR TITLE
Message, Notification: fix transitionend bug

### DIFF
--- a/packages/message/src/main.vue
+++ b/packages/message/src/main.vue
@@ -35,15 +35,18 @@
       closed(newVal) {
         if (newVal) {
           this.visible = false;
-          this.$el.addEventListener('transitionend', () => {
-            this.$destroy(true);
-            this.$el.parentNode.removeChild(this.$el);
-          });
+          this.$el.addEventListener('transitionend', this.destroyElement);
         }
       }
     },
 
     methods: {
+      destroyElement() {
+        this.$el.removeEventListener('transitionend', this.destroyElement);
+        this.$destroy(true);
+        this.$el.parentNode.removeChild(this.$el);
+      },
+
       handleClose() {
         this.closed = true;
         if (typeof this.onClose === 'function') {

--- a/packages/notification/src/main.vue
+++ b/packages/notification/src/main.vue
@@ -44,15 +44,18 @@
       closed(newVal) {
         if (newVal) {
           this.visible = false;
-          this.$el.addEventListener('transitionend', () => {
-            this.$destroy(true);
-            this.$el.parentNode.removeChild(this.$el);
-          });
+          this.$el.addEventListener('transitionend', this.destroyElement);
         }
       }
     },
 
     methods: {
+      destroyElement() {
+        this.$el.removeEventListener('transitionend', this.destroyElement);
+        this.$destroy(true);
+        this.$el.parentNode.removeChild(this.$el);
+      },
+
       handleClose() {
         this.closed = true;
         if (typeof this.onClose === 'function') {


### PR DESCRIPTION
问题描述：
如果我在组件中加入不同的transition或者transition: all duration的形式，
那么this.$el.addEventListener(‘transitioned’,
handeler)就会监听到多次事件，从而导致多次删除，因为节点已经从dom中删除，
所以最后报错：
’main.vue?8f52:44 Uncaught TypeError: Cannot read property 'removeChild' of null’
解决办法：
就是在第一次监听到动画结束事件时，将监听器移除即可。