### PR TITLE
Table: 将 striped table 的背景色设置在 td 元素上

### DIFF
--- a/packages/theme-default/src/table.css
+++ b/packages/theme-default/src/table.css
@@ -312,9 +312,11 @@
     @modifier striped {
       & .el-table__body {
         & tr:nth-child(2n) {
-          background: #FAFAFA;
+          td {
+            background: #FAFAFA;
+          }
 
-          &.current-row {
+          &.current-row td {
             background: #EFF7FF;
           }
         }


### PR DESCRIPTION
带多选功能的表格若同时设置了 `:striped="true"` 会导致 `tr` 的背景色异常，将背景色设置在 `td` 上可以解决这个问题。

![image](https://cloud.githubusercontent.com/assets/5035625/20095541/d55f9ae4-a5e0-11e6-8b26-8fff6b688690.png)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's [Contributing Guide](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.md).
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.