### PR TITLE
Docs: fix custom theme import path

### DIFF
--- a/examples/docs/en-US/custom-theme.md
+++ b/examples/docs/en-US/custom-theme.md
@@ -63,7 +63,7 @@ node_modules/.bin/et
 By default the build theme file is placed inside `./theme`. You can specify its output directory with parameter `-o`. Importing your own theme is just like importing the default theme, only this time you import the file you just built:
 
 ```javascript
-import './theme/index.css'
+import '../theme/index.css'
 import ElementUI from 'element-ui'
 import Vue from 'vue'
 

--- a/examples/docs/zh-CN/custom-theme.md
+++ b/examples/docs/zh-CN/custom-theme.md
@@ -63,7 +63,7 @@ node_modules/.bin/et
 默认情况下编译的主题目录是放在 `./theme` 下，你可以通过 `-o` 参数指定打包目录。像引入默认主题一样，在代码里直接引用 `theme/index.css` 文件即可。
 
 ```javascript
-import './theme/index.css'
+import '../theme/index.css'
 import ElementUI from 'element-ui'
 import Vue from 'vue'
 


### PR DESCRIPTION
When `src/main.js` imports `theme/index.css`, the import statement should import `'../theme/index.css'`, not `'./theme/index.css'`.