### PR TITLE
fix-bug-of-unable-to-toggle-in-any-box-of-group

### DIFF
--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -89,7 +89,7 @@
     data() {
       return {
         store: [],
-        isGroup: false
+        isGroup: this.$parent.$options.componentName === 'ElCheckboxGroup'
       };
     },
 


### PR DESCRIPTION
修复了CheckboxGroup里的checkbox框无法toggle切换的问题。

ElCheckboxGroup初始化时会设子项Checkbox的isGroup为真，但是CheckboxGroup的children项是在该Group渲染后才渲染的，生命周期错乱了，导致ElCheckboxGroup组件不能对里面的checkbox进行点击toggle。
应该在所有children子项渲染完后，再对isGroup设为真，
或者恢复1.0.2的写法，在data初始时，有针对性地判断，
isGroup: this.$parent.$options.componentName === 'ElCheckboxGroup'，
这里我恢复成了1.0.2时版本的写法。