### PR TITLE
datetimepicker: fix clear panel date and time show when clear

### DIFF
--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -176,19 +176,19 @@
       },
 
       minVisibleDate() {
-        return formatDate(this.minDate);
+        return this.minDate ? formatDate(this.minDate) : '';
       },
 
       maxVisibleDate() {
-        return formatDate(this.maxDate || this.minDate);
+        return (this.maxDate || this.minDate) ? formatDate(this.maxDate || this.minDate) : '';
       },
 
       minVisibleTime() {
-        return formatDate(this.minDate, 'HH:mm:ss');
+        return this.minDate ? formatDate(this.minDate, 'HH:mm:ss') : '';
       },
 
       maxVisibleTime() {
-        return formatDate(this.maxDate, 'HH:mm:ss');
+        return (this.maxDate || this.minDate) ? formatDate(this.maxDate || this.minDate, 'HH:mm:ss') : '';
       },
 
       rightDate() {


### PR DESCRIPTION
就是现在清除datetimerange picker的日期时总会在panel editor显示那里留下1970.。。。什么的，
顺便，让时间和日期在panel editor表现一致一些

看测试挂了，，不是我的错。。。12月到了