### PR TITLE
[DatePicker]: fix #1506 - allow any visible date to be selected in ra…

### DIFF
--- a/packages/date-picker/src/basic/date-table.vue
+++ b/packages/date-picker/src/basic/date-table.vue
@@ -366,8 +366,6 @@
 
         const newDate = new Date(this.year, this.month, 1);
 
-        const clickNormalCell = className.indexOf('prev') === -1 && className.indexOf('next') === -1;
-
         if (className.indexOf('prev') !== -1) {
           if (month === 0) {
             year = year - 1;
@@ -390,7 +388,7 @@
 
         newDate.setDate(parseInt(text, 10));
 
-        if (clickNormalCell && this.selectionMode === 'range') {
+        if (this.selectionMode === 'range') {
           if (this.minDate && this.maxDate) {
             const minDate = new Date(newDate.getTime());
             const maxDate = null;
@@ -419,9 +417,7 @@
             this.rangeState.selecting = true;
             this.markRange(this.minDate);
           }
-        }
-
-        if (selectionMode === 'day') {
+        } else if (selectionMode === 'day') {
           this.$emit('pick', newDate);
         } else if (selectionMode === 'week') {
           var weekNumber = getWeekNumber(newDate);


### PR DESCRIPTION
Changes allow selecting any of visible date (those who belongs to prev or next month) when selecting a range. Date range picker will work as following:
- when date from end of prev month or start of next month is clicked it becomes selected,
- if selected date belongs to a month that isn't fully visible (is not shown in one of two current date-tables) it won't be highlighted,
- if selected date belongs to a month that is shown in one of two current date-tables, it becomes highlighted.