### PR TITLE
Tag: Fix text wrap

### DIFF
--- a/packages/theme-default/src/tag.css
+++ b/packages/theme-default/src/tag.css
@@ -14,6 +14,7 @@
     border-radius: var(--tag-border-radius);
     box-sizing: border-box;
     border: 1px solid transparent;
+    white-space: nowrap;
 
     & .el-icon-close {
       border-radius: 50%;


### PR DESCRIPTION
When the width of parent container is too narrow, text in tag will be
break into lines.
當父容器寬度不足時，Tag 文字會產生換行的現象