### PR TITLE
Col: Fix issue where xs is overridden by general

### DIFF
--- a/packages/theme-default/src/col.css
+++ b/packages/theme-default/src/col.css
@@ -7,20 +7,33 @@
 }
 
 @for $i from 1 to 24 {
-  .el-col-$i,
+  .el-col-$i {
+    width: calc(1 / 24 * $(i) * 100)%;
+  }
+  .el-col-offset-$i {
+    margin-left: calc(1 / 24 * $(i) * 100)%;
+  }
+  .el-col-pull-$i {
+    position: relative;
+    right: calc(1 / 24 * $(i) * 100)%;
+  }
+  .el-col-push-$i {
+    position: relative;
+    left: calc(1 / 24 * $(i) * 100)%;
+  }
+}
+
+@for $i from 1 to 24 {
   .el-col-xs-$i {
     width: calc(1 / 24 * $(i) * 100)%;
   }
-  .el-col-offset-$i,
   .el-col-xs-offset-$i {
     margin-left: calc(1 / 24 * $(i) * 100)%;
   }
-  .el-col-pull-$i,
   .el-col-xs-pull-$i {
     position: relative;
     right: calc(1 / 24 * $(i) * 100)%;
   }
-  .el-col-push-$i,
   .el-col-xs-push-$i {
     position: relative;
     left: calc(1 / 24 * $(i) * 100)%;


### PR DESCRIPTION
The programmatic generation of xs and general column widths together causes .el-col-24 (and other higher column numbers) to override basically all (lower column number) .el-col-xs-XX styles. Separating them fixes this issue.
