### PR TITLE
general: normalize name in default export

### DIFF
--- a/packages/alert/src/main.vue
+++ b/packages/alert/src/main.vue
@@ -20,7 +20,7 @@
     'error': 'el-icon-circle-cross'
   };
   export default {
-    name: 'el-alert',
+    name: 'ElAlert',
 
     props: {
       title: {

--- a/packages/badge/src/main.vue
+++ b/packages/badge/src/main.vue
@@ -14,7 +14,7 @@
 
 <script>
 export default {
-  name: 'el-badge',
+  name: 'ElBadge',
 
   props: {
     value: {},

--- a/packages/card/src/main.vue
+++ b/packages/card/src/main.vue
@@ -11,7 +11,7 @@
 
 <script>
   export default {
-    name: 'el-card',
+    name: 'ElCard',
 
     props: ['header', 'bodyStyle']
   };

--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -25,7 +25,7 @@
   import Popup from 'element-ui/src/utils/popup';
 
   export default {
-    name: 'el-dialog',
+    name: 'ElDialog',
 
     mixins: [Popup],
 

--- a/packages/popover/src/main.vue
+++ b/packages/popover/src/main.vue
@@ -20,7 +20,7 @@ import Popper from 'element-ui/src/utils/vue-popper';
 import { on, off } from 'element-ui/src/utils/dom';
 
 export default {
-  name: 'el-popover',
+  name: 'ElPopover',
 
   mixins: [Popper],
 

--- a/packages/rate/src/main.vue
+++ b/packages/rate/src/main.vue
@@ -27,7 +27,7 @@
   import { hasClass } from 'element-ui/src/utils/dom';
 
   export default {
-    name: 'el-rate',
+    name: 'ElRate',
 
     data() {
       return {

--- a/packages/select/src/option-group.vue
+++ b/packages/select/src/option-group.vue
@@ -15,7 +15,7 @@
   export default {
     mixins: [Emitter],
 
-    name: 'el-option-group',
+    name: 'ElOptionGroup',
 
     componentName: 'ElOptionGroup',
 

--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -21,7 +21,7 @@
   export default {
     mixins: [Emitter],
 
-    name: 'el-option',
+    name: 'ElOption',
 
     componentName: 'ElOption',
 

--- a/packages/select/src/select-dropdown.vue
+++ b/packages/select/src/select-dropdown.vue
@@ -11,7 +11,7 @@
   import Popper from 'element-ui/src/utils/vue-popper';
 
   export default {
-    name: 'el-select-dropdown',
+    name: 'ElSelectDropdown',
 
     componentName: 'ElSelectDropdown',
 

--- a/packages/steps/src/step.vue
+++ b/packages/steps/src/step.vue
@@ -45,7 +45,7 @@
 
 <script>
 export default {
-  name: 'el-step',
+  name: 'ElStep',
 
   props: {
     title: String,

--- a/packages/steps/src/steps.vue
+++ b/packages/steps/src/steps.vue
@@ -4,7 +4,7 @@
 
 <script>
 export default {
-  name: 'el-steps',
+  name: 'ElSteps',
 
   props: {
     space: Number,

--- a/packages/switch/src/component.vue
+++ b/packages/switch/src/component.vue
@@ -34,7 +34,7 @@
 
 <script>
   export default {
-    name: 'el-switch',
+    name: 'ElSwitch',
     props: {
       value: {
         type: Boolean,

--- a/packages/table/src/filter-panel.vue
+++ b/packages/table/src/filter-panel.vue
@@ -39,7 +39,7 @@
   import ElCheckboxGroup from 'element-ui/packages/checkbox-group';
 
   export default {
-    name: 'el-table-filter-panel',
+    name: 'ElTableFilterPanel',
 
     mixins: [Popper, Locale],
 

--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -109,7 +109,7 @@ const DEFAULT_RENDER_CELL = function(h, { row, column }) {
 };
 
 export default {
-  name: 'el-table-column',
+  name: 'ElTableColumn',
 
   props: {
     type: {

--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -66,7 +66,7 @@ const convertToRows = (originColumns) => {
 };
 
 export default {
-  name: 'el-table-header',
+  name: 'ElTableHeader',
 
   render(h) {
     const originColumns = this.store.states.originColumns;

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -118,7 +118,7 @@
   let tableIdSeed = 1;
 
   export default {
-    name: 'el-table',
+    name: 'ElTable',
 
     mixins: [Locale],
 

--- a/packages/tabs/src/tab-pane.vue
+++ b/packages/tabs/src/tab-pane.vue
@@ -7,7 +7,7 @@
 </template>
 <script>
   module.exports = {
-    name: 'el-tab-pane',
+    name: 'ElTabPane',
 
     props: {
       label: String,

--- a/packages/tabs/src/tabs.vue
+++ b/packages/tabs/src/tabs.vue
@@ -1,6 +1,6 @@
 <script>
   module.exports = {
-    name: 'el-tabs',
+    name: 'ElTabs',
 
     props: {
       type: String,

--- a/packages/tooltip/src/main.vue
+++ b/packages/tooltip/src/main.vue
@@ -23,7 +23,7 @@
 import Popper from 'element-ui/src/utils/vue-popper';
 
 export default {
-  name: 'el-tooltip',
+  name: 'ElTooltip',
 
   mixins: [Popper],
 

--- a/packages/tree/src/tree-node.vue
+++ b/packages/tree/src/tree-node.vue
@@ -47,7 +47,7 @@
   import ElCheckbox from 'element-ui/packages/checkbox';
 
   export default {
-    name: 'el-tree-node',
+    name: 'ElTreeNode',
 
     props: {
       node: {

--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -18,7 +18,7 @@
   import {t} from 'element-ui/src/locale';
 
   export default {
-    name: 'el-tree',
+    name: 'ElTree',
 
     props: {
       data: {

--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -8,7 +8,7 @@ function noop() {
 }
 
 export default {
-  name: 'el-upload',
+  name: 'ElUpload',
 
   components: {
     ElProgress,


### PR DESCRIPTION
Thanks for bring us Element!

I'm using a DSL library to generate Vue VNode by method call. This works for most component in Element. For example, `vnodeHelper.elCol.elCol()` can correctly generate vnode in the format like `h('elCol')` .

However, some Element component has different naming schema so vnode helper fails to find corresponding components since Vue will not normalize snake case name. 

Given most component names in Element is CamelCase, I think it might be good practice to enforce the rule to every component.

Looking forward to your opinion and Happy new year!