### PR TITLE
menu: fix init in horizontal mode  doesn't modify parent submenu active prop

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -129,6 +129,14 @@
     },
     mounted() {
       this.openActiveItemMenus();
+
+      const index = this.activeIndex;
+      const menuItem = this.menuItems[index];
+
+      if (this.mode === 'horizontal' && menuItem) {
+        const indexPath = menuItem.indexPath;
+        this.broadcast('ElSubmenu', 'item-select', [index, indexPath]);
+      }
     }
   };
 </script>


### PR DESCRIPTION
#### menu: fix init in horizontal mode  doesn't modify parent submenu active prop

```
<el-menu theme="dark" default-active="2-2" class="el-menu-demo" mode="horizontal" @select="handleSelect">
  <el-menu-item index="1">处理中心</el-menu-item>
  <el-submenu index="2">
    <template slot="title">我的工作台</template>
    <el-menu-item index="2-1">选项1</el-menu-item>
    <el-menu-item index="2-2">选项2</el-menu-item>
    <el-menu-item index="2-3">选项3</el-menu-item>
  </el-submenu>
  <el-menu-item index="3">订单管理</el-menu-item>
</el-menu>
```

this code doesn't init the index 2 submenu 's active so it doesn't has highlight border line;

this pr fix the bug, in mounted function add broadcast event:

```
const index = this.activeIndex;
const menuItem = this.menuItems[index];

if (this.mode === 'horizontal' && menuItem) {
  const indexPath = menuItem.indexPath;
  this.broadcast('ElSubmenu', 'item-select', [index, indexPath]);
}

```