### PR TITLE
DatePicker: Fix year label space in year picker

### DIFF
--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -436,7 +436,10 @@
         const yearTranslation = this.t('el.datepicker.year');
         if (this.currentView === 'year') {
           const startYear = Math.floor(year / 10) * 10;
-          return startYear + ' ' + yearTranslation + '-' + (startYear + 9) + ' ' + yearTranslation;
+          if (yearTranslation) {
+            return startYear + ' ' + yearTranslation + ' - ' + (startYear + 9) + ' ' + yearTranslation;
+          }
+          return startYear + ' - ' + (startYear + 9);
         }
         return this.year + ' ' + yearTranslation;
       }


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's [Contributing Guide](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.md).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Changed year label to prevent hyphen immediately followed by a year. Example:
![screen shot 2017-01-05 at 14 47 24](https://cloud.githubusercontent.com/assets/1722352/21687819/9bc5caa6-d362-11e6-994a-a5a42e00320f.png)

