### PR TITLE
Fix: typo in date.js, assign "DD" to itself.

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -195,7 +195,7 @@
       }
     }]
   };
-  parseFlags.DD = parseFlags.DD;
+  parseFlags.DD = parseFlags.D;
   parseFlags.dddd = parseFlags.ddd;
   parseFlags.Do = parseFlags.dd = parseFlags.d;
   parseFlags.mm = parseFlags.m;


### PR DESCRIPTION
`src/utils/date.js L237`
typo: `parseFlags.DD = parseFlags.DD;`