### PR TITLE
InputNumber: prevent cursor from moving to head when pressing up on c…

### DIFF
--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -22,8 +22,8 @@
     </span>
     <el-input
       :value="currentValue"
-      @keydown.up.native="increase"
-      @keydown.down.native="decrease"
+      @keydown.up.native.prevent="increase"
+      @keydown.down.native.prevent="decrease"
       @blur="handleBlur"
       @input="handleInput"
       :disabled="disabled"


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's [Contributing Guide](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.md).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

input-number组件在chrome和safari下，按上箭头键增加数字时，光标会移动到开头，阻止这个默认行为