### PR TITLE
Select: restore focus and erase query

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -505,10 +505,13 @@
             this.value.push(option.value);
           }
           if (option.created) {
-            this.query = '';
             this.inputLength = 20;
-            this.$refs.input.focus();
           }
+
+          // after an option be select/created the focus must be retored and the
+          // query erased
+          this.$refs.input.focus();
+          this.query = '';
         }
       },
 


### PR DESCRIPTION
After an option selection/creation the focus must be restored and the query erased. This problem was repeated on the issue #2332.

----

This works, but I tried run the tests and I get this message. How can I fix this?

```text
TypeError: undefined is not an object (evaluating 'this.$refs.input.focus') (webpack:///packages/select/src/select.vue?79b8:9:0 <- index.js:9696)
```