### PR TITLE
fix autocomplete handleKeyEnter with index=-1

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -91,6 +91,7 @@
           this.loading = false;
           if (Array.isArray(suggestions)) {
             this.suggestions = suggestions;
+            this.highlight(0);
           } else {
             console.error('autocomplete suggestions must be an array');
           }


### PR DESCRIPTION
- 修复autocomplete按enter键报错
- 尝试在suggestions赋值的时候将index设为0，即自动勾选第一项

![image](https://cloud.githubusercontent.com/assets/6647633/22062815/ad000dbe-ddb6-11e6-8b1f-fb1d6d2302ee.png)

