### PR TITLE
collapse-transition: fix strange transition behaviour in safari

### DIFF
--- a/packages/theme-default/src/collapse.css
+++ b/packages/theme-default/src/collapse.css
@@ -26,7 +26,6 @@
     @e wrap {
       will-change: height;
       background-color: var(--collapse-content-fill);
-      transition: height .3s cubic-bezier(0.215, 0.61, 0.355, 1);
       overflow: hidden;
       box-sizing: border-box;
       border-bottom: 1px solid var(--collapse-border-color);

--- a/packages/theme-default/src/common/transition.css
+++ b/packages/theme-default/src/common/transition.css
@@ -55,3 +55,7 @@
   opacity: 0;
   transform: scaleY(0);
 }
+
+.collapse-transition {
+    transition: 0.3s height ease-in-out, 0.3s padding-top ease-in-out, 0.3s padding-bottom ease-in-out;
+}

--- a/packages/theme-default/src/tree.css
+++ b/packages/theme-default/src/tree.css
@@ -101,7 +101,3 @@
 .el-tree--highlight-current .el-tree-node.is-current > .el-tree-node__content {
   background-color: color(var(--color-primary) tint(92%));
 }
-
-.collapse-transition {
-    transition: 0.3s height ease-in-out, 0.3s padding-top ease-in-out, 0.3s padding-bottom ease-in-out;
-}

--- a/src/transitions/collapse-transition.js
+++ b/src/transitions/collapse-transition.js
@@ -1,6 +1,8 @@
+import { addClass, removeClass } from 'element-ui/src/utils/dom';
+
 class Transition {
   beforeEnter(el) {
-    el.classList.add('collapse-transition');
+    addClass(el, 'collapse-transition');
     if (!el.dataset) el.dataset = {};
 
     el.dataset.oldPaddingTop = el.style.paddingTop;
@@ -28,7 +30,7 @@ class Transition {
 
   afterEnter(el) {
     // for safari: remove class then reset height is necessary
-    el.classList.remove('collapse-transition');
+    removeClass(el, 'collapse-transition');
     el.style.height = '';
     el.style.overflow = el.dataset.oldOverflow;
   }
@@ -46,7 +48,7 @@ class Transition {
   leave(el) {
     if (el.scrollHeight !== 0) {
       // for safari: add class after set height, or it will jump to zero height suddenly, weired
-      el.classList.add('collapse-transition');
+      addClass(el, 'collapse-transition');
       el.style.height = 0;
       el.style.paddingTop = 0;
       el.style.paddingBottom = 0;
@@ -54,7 +56,7 @@ class Transition {
   }
 
   afterLeave(el) {
-    el.classList.remove('collapse-transition');
+    removeClass(el, 'collapse-transition');
     el.style.height = '';
     el.style.overflow = el.dataset.oldOverflow;
     el.style.paddingTop = el.dataset.oldPaddingTop;

--- a/src/transitions/collapse-transition.js
+++ b/src/transitions/collapse-transition.js
@@ -1,5 +1,6 @@
 class Transition {
   beforeEnter(el) {
+    el.classList.add('collapse-transition');
     if (!el.dataset) el.dataset = {};
 
     el.dataset.oldPaddingTop = el.style.paddingTop;
@@ -26,6 +27,8 @@ class Transition {
   }
 
   afterEnter(el) {
+    // for safari: remove class then reset height is necessary
+    el.classList.remove('collapse-transition');
     el.style.height = '';
     el.style.overflow = el.dataset.oldOverflow;
   }
@@ -42,6 +45,8 @@ class Transition {
 
   leave(el) {
     if (el.scrollHeight !== 0) {
+      // for safari: add class after set height, or it will jump to zero height suddenly, weired
+      el.classList.add('collapse-transition');
       el.style.height = 0;
       el.style.paddingTop = 0;
       el.style.paddingBottom = 0;
@@ -49,6 +54,7 @@ class Transition {
   }
 
   afterLeave(el) {
+    el.classList.remove('collapse-transition');
     el.style.height = '';
     el.style.overflow = el.dataset.oldOverflow;
     el.style.paddingTop = el.dataset.oldPaddingTop;
@@ -62,11 +68,6 @@ export default {
     const data = {
       on: new Transition()
     };
-
-    children = children.map(item => {
-      item.data.class = ['collapse-transition'];
-      return item;
-    });
 
     return h('transition', data, children);
   }


### PR DESCRIPTION
有两个问题，仅针对safari （Version 9.1 (11601.5.17.1)）

首先是如果元素上有css transition，el.style.height=""重置高度时，safari中transition动画会先到0，再到auto的高度。因此需要在重置高度之前移除css transition。（按理说，没有height不该触发transition）

其次，如果元素上有css transition，如果设置height，nextTick再设置为0，safari中会直接变成0并不触发css动画，但是设置height，在nextTIck加上css transition，再设置height为0，则触发过渡动画。


参考：

对比其他浏览器和safari

http://codepen.io/reverland/pen/PWWedw

ps: 听说可能有定制款＝ ＝ https://github.com/ElemeFE/element/issues/2498#issuecomment-273411891 @Kingwl 
