### PR TITLE
remove popover's document click handler, related to #2561

### DIFF
--- a/packages/popover/src/main.vue
+++ b/packages/popover/src/main.vue
@@ -60,15 +60,7 @@ export default {
     }
     if (this.trigger === 'click') {
       on(reference, 'click', () => { this.showPopper = !this.showPopper; });
-      on(document, 'click', (e) => {
-        if (!this.$el ||
-            !reference ||
-            this.$el.contains(e.target) ||
-            reference.contains(e.target) ||
-            !popper ||
-            popper.contains(e.target)) return;
-        this.showPopper = false;
-      });
+      on(document, 'click', this.handleDocumentClick.bind(this, reference, popper));
     } else if (this.trigger === 'hover') {
       on(reference, 'mouseenter', this.handleMouseEnter);
       on(popper, 'mouseenter', this.handleMouseEnter);
@@ -111,6 +103,15 @@ export default {
       this._timer = setTimeout(() => {
         this.showPopper = false;
       }, 200);
+    },
+    handleDocumentClick(reference, popper, e) {
+      if (!this.$el ||
+        !reference ||
+        this.$el.contains(e.target) ||
+        reference.contains(e.target) ||
+        !popper ||
+        popper.contains(e.target)) return;
+      this.showPopper = false;
     }
   },
 
@@ -123,6 +124,7 @@ export default {
     off(reference, 'blur');
     off(reference, 'mouseleave');
     off(reference, 'mouseenter');
+    off(document, 'click', this.handleDocumentClick);
   }
 };
 </script>

--- a/packages/popover/src/main.vue
+++ b/packages/popover/src/main.vue
@@ -60,7 +60,7 @@ export default {
     }
     if (this.trigger === 'click') {
       on(reference, 'click', () => { this.showPopper = !this.showPopper; });
-      on(document, 'click', this.handleDocumentClick.bind(this, reference, popper));
+      on(document, 'click', this.handleDocumentClick);
     } else if (this.trigger === 'hover') {
       on(reference, 'mouseenter', this.handleMouseEnter);
       on(popper, 'mouseenter', this.handleMouseEnter);
@@ -104,7 +104,13 @@ export default {
         this.showPopper = false;
       }, 200);
     },
-    handleDocumentClick(reference, popper, e) {
+    handleDocumentClick(e) {
+      let reference = this.reference || this.$refs.reference;
+      const popper = this.popper || this.$refs.popper;
+
+      if (!reference && this.$slots.reference && this.$slots.reference[0]) {
+        reference = this.referenceElm = this.$slots.reference[0].elm;
+      }
       if (!this.$el ||
         !reference ||
         this.$el.contains(e.target) ||


### PR DESCRIPTION
This doesn't actually seem to fix the problem completely, but it should be a start.
There are still some VueComponents of the popovers in memory.