### PR TITLE
Close icon design adjustment for removable tags

### DIFF
--- a/packages/theme-default/src/icon.css
+++ b/packages/theme-default/src/icon.css
@@ -37,7 +37,7 @@
 .el-icon-circle-check:before { content: "\e609"; }
 .el-icon-circle-close:before { content: "\e60a"; }
 .el-icon-circle-cross:before { content: "\e60b"; }
-.el-icon-close:before { content: "\e60c"; }
+.el-icon-close:before { content: "\e60c"; font-size: 11px; }
 .el-icon-upload:before { content: "\e60d"; }
 .el-icon-d-arrow-left:before { content: "\e60e"; }
 .el-icon-d-arrow-right:before { content: "\e60f"; }


### PR DESCRIPTION
I noticed that when hovering over the close icon in a removable tag, the `x` is a little too close to the top right of the circle, to the point where it is touching the edge. This change makes it appear more centered in the circle. It still doesn't look perfectly centered but at least to me it is more visually appealing. 

Before: 
![tag_remove_before](https://cloud.githubusercontent.com/assets/423498/22307864/04877f48-e345-11e6-916a-fce30930319c.png)

After:
![tag_remove_after](https://cloud.githubusercontent.com/assets/423498/22307988/6cf74ce8-e345-11e6-850a-b98811e3fc1a.png)


