### PR TITLE
Docs: Fix README links to contributing guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Modern browsers and Internet Explorer 9+.
 ## Development
 Skip this part if you just want to use Element.
 
-For those who are interested in contributing to Element, please refer to our contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)) to see how to run this project.
+For those who are interested in contributing to Element, please refer to our contributing guide ([中文](https://github.com/ElemeFE/element/blob/dev/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/dev/.github/CONTRIBUTING.en-US.md)) to see how to run this project.
 
 ## Changelog
 Detailed changes for each release are documented in the [release notes](https://github.com/ElemeFE/element/releases).
@@ -78,7 +78,7 @@ Detailed changes for each release are documented in the [release notes](https://
 We have collected some [frequently asked questions](https://github.com/ElemeFE/element/blob/master/FAQ.md). Before reporting an issue, please search if the FAQ has the answer to your problem.
 
 ## Contribution
-Please make sure to read the contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)) before making a pull request.
+Please make sure to read the contributing guide ([中文](https://github.com/ElemeFE/element/blob/dev/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/dev/.github/CONTRIBUTING.en-US.md)) before making a pull request.
 
 ## Special Thanks
 English documentation is brought to you by SwiftGG Translation Team. Our special thanks go to these fellows:


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Ironically, the contributing links in the above auto-generated checklist are also broken.

This fixes the broken links introduced in #2653.

Alternatively, the broken links will automatically work once you merge the new contributing guides (with new names) into master.
