### PR TITLE
中文文档样式问题

### DIFF
--- a/examples/docs/zh-CN/layout.md
+++ b/examples/docs/zh-CN/layout.md
@@ -308,7 +308,7 @@
 
 ### 响应式布局
 
-参照了 Bootstrap 的 响应式设计，预设了四个响应尺寸：`xs` `sm` `md` `lg`。
+参照了 Bootstrap 的 响应式设计，预设了四个响应尺寸：`xs`、`sm`、`md`和`lg`。
 
 ::: demo
 ```html


### PR DESCRIPTION
## 问题
官方中文文档的[布局组件](http://element.eleme.io/#/zh-CN/component/layout) 部分，`xs` `sm` `md` `lg`这四个词紧贴，没有用于分隔的样式，阅读时无法准确分词。
## 解决方案
插入标点符号，和英文文档保持格式一致。