### PR TITLE
picker: fix time and bug for value validate

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -12,6 +12,7 @@
     @keydown.native="handleKeydown"
     :value="displayValue"
     @change.native="displayValue = $event.target.value"
+    :validateEvent="false"
     ref="reference">
     <i slot="icon"
       class="el-input__icon"
@@ -222,6 +223,7 @@ export default {
 
   watch: {
     pickerVisible(val) {
+      if (!val) this.dispatch('ElFormItem', 'el.form.blur');
       if (this.readonly || this.disabled) return;
       val ? this.showPicker() : this.hidePicker();
     },
@@ -241,6 +243,7 @@ export default {
     },
     displayValue(val) {
       this.$emit('change', val);
+      this.dispatch('ElFormItem', 'el.form.change');
     }
   },
 
@@ -383,7 +386,6 @@ export default {
 
     handleBlur() {
       this.$emit('blur', this);
-      this.dispatch('ElFormItem', 'el.form.blur');
     },
 
     handleKeydown(event) {


### PR DESCRIPTION
#Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

* bug: 主分支在 picker 内部 el-input 中没有阻止其本身 blur 事件（已修复）。
* blur触发时机: 主分支在 el-input 组件 blur 且 浮动层存在时就会触发 picker 的 blur （用户尚未点击浮动层“确认”按钮），这里的 blur 应该在浮动层关闭时触发（已修改）。