### PR TITLE
tab-pane的label属性支持Number类型

### DIFF
--- a/packages/tabs/src/tab-pane.vue
+++ b/packages/tabs/src/tab-pane.vue
@@ -10,7 +10,7 @@
     componentName: 'ElTabPane',
 
     props: {
-      label: String,
+      label: [String, Number],
       labelContent: Function,
       name: String,
       closable: Boolean,


### PR DESCRIPTION
# 【组件】tab-pane

label当前只支持String，项目中需要支持Number。