### PR TITLE
Form submit causes page reload

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -2,7 +2,7 @@
   <form class="el-form" :class="[
     labelPosition ? 'el-form--label-' + labelPosition : '',
     { 'el-form--inline': inline }
-  ]">
+  ]" onsubmit="return false;">
     <slot></slot>
   </form>
 </template>


### PR DESCRIPTION

**Problem case 1:**
We have `<el-button native-type="submit" .... >` inside `el-form`. Then after hiting enter while editing some text input, browser tries to submit the form hence the page is reloaded becuse we do not have submit event handler attached to el-form.

**Problem case 2:**
We have `<el-button native-type="button" .... >` inside `el-form` hence there is no submit input/button. Then hiting enter while editing some input does nothing and we must use button click to submit form (in JavaScript).

**To sum up:** `el-form` does not have @submit event support. Solution in this pull request is not elegant but, solves the problem with regular form submit and allows to use submit input inside form.

Better solution would be to add @submit and @submit.prevent handler to use as parameter.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
