### PR TITLE
TimePicker: fixed #2071 change the time-picker style and fixed some bug has not issue yet

### DIFF
--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -80,22 +80,11 @@
     },
 
     watch: {
-      hours(newVal) {
-        this.ajustElTop('hour', newVal);
-      },
-
-      minutes(newVal) {
-        this.ajustElTop('minute', newVal);
-      },
-
-      seconds(newVal) {
-        this.ajustElTop('second', newVal);
-      },
-
       hoursPrivate(newVal, oldVal) {
         if (!(newVal >= 0 && newVal <= 23)) {
           this.hoursPrivate = oldVal;
         }
+        this.ajustElTop('hour', newVal);
         this.$emit('change', { hours: newVal });
       },
 
@@ -103,6 +92,7 @@
         if (!(newVal >= 0 && newVal <= 59)) {
           this.minutesPrivate = oldVal;
         }
+        this.ajustElTop('minute', newVal);
         this.$emit('change', { minutes: newVal });
       },
 
@@ -110,7 +100,7 @@
         if (!(newVal >= 0 && newVal <= 59)) {
           this.secondsPrivate = oldVal;
         }
-
+        this.ajustElTop('second', newVal);
         this.$emit('change', { seconds: newVal });
       }
     },

--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -2,7 +2,6 @@
   <div class="el-time-spinner" :class="{ 'has-seconds': showSeconds }">
     <el-scrollbar
       @mouseenter.native="emitSelectRange('hours')"
-      @mousewheel.native="handleScroll('hour')"
       class="el-time-spinner__wrapper"
       wrap-style="max-height: inherit;"
       view-class="el-time-spinner__list"
@@ -19,7 +18,6 @@
     </el-scrollbar>
     <el-scrollbar
       @mouseenter.native="emitSelectRange('minutes')"
-      @mousewheel.native="handleScroll('minute')"
       class="el-time-spinner__wrapper"
       wrap-style="max-height: inherit;"
       view-class="el-time-spinner__list"
@@ -36,7 +34,6 @@
     <el-scrollbar
       v-show="showSeconds"
       @mouseenter.native="emitSelectRange('seconds')"
-      @mousewheel.native="handleScroll('second')"
       class="el-time-spinner__wrapper"
       wrap-style="max-height: inherit;"
       view-class="el-time-spinner__list"
@@ -83,11 +80,22 @@
     },
 
     watch: {
+      hours(newVal) {
+        this.ajustElTop('hour', newVal);
+      },
+
+      minutes(newVal) {
+        this.ajustElTop('minute', newVal);
+      },
+
+      seconds(newVal) {
+        this.ajustElTop('second', newVal);
+      },
+
       hoursPrivate(newVal, oldVal) {
         if (!(newVal >= 0 && newVal <= 23)) {
           this.hoursPrivate = oldVal;
         }
-        this.hourEl.scrollTop = Math.max(0, (this.hoursPrivate - 2.5) * 32 + 80);
         this.$emit('change', { hours: newVal });
       },
 
@@ -95,7 +103,6 @@
         if (!(newVal >= 0 && newVal <= 59)) {
           this.minutesPrivate = oldVal;
         }
-        this.minuteEl.scrollTop = Math.max(0, (this.minutesPrivate - 2.5) * 32 + 80);
         this.$emit('change', { minutes: newVal });
       },
 
@@ -103,7 +110,7 @@
         if (!(newVal >= 0 && newVal <= 59)) {
           this.secondsPrivate = oldVal;
         }
-        this.secondEl.scrollTop = Math.max(0, (this.secondsPrivate - 2.5) * 32 + 80);
+
         this.$emit('change', { seconds: newVal });
       }
     },
@@ -135,6 +142,12 @@
       };
     },
 
+    mounted() {
+      this.$nextTick(() => {
+        this.bindScrollEvent();
+      });
+    },
+
     methods: {
       handleClick(type, value, disabled) {
         if (value.disabled) {
@@ -156,17 +169,29 @@
         }
       },
 
+      bindScrollEvent() {
+        const bindFuntion = (type) => {
+          this[`${type}El`].onscroll = (e) => this.handleScroll(type, e);
+        };
+        bindFuntion('hour');
+        bindFuntion('minute');
+        bindFuntion('second');
+      },
+
       handleScroll(type) {
         const ajust = {};
-
         ajust[`${type}s`] = Math.min(Math.floor((this[`${type}El`].scrollTop - 80) / 32 + 3), 59);
         this.$emit('change', ajust);
       },
 
       ajustScrollTop() {
-        this.hourEl.scrollTop = Math.max(0, (this.hours - 2.5) * 32 + 80);
-        this.minuteEl.scrollTop = Math.max(0, (this.minutes - 2.5) * 32 + 80);
-        this.secondEl.scrollTop = Math.max(0, (this.seconds - 2.5) * 32 + 80);
+        this.ajustElTop('hour', this.hours);
+        this.ajustElTop('minute', this.minutes);
+        this.ajustElTop('second', this.seconds);
+      },
+
+      ajustElTop(type, value) {
+        this[`${type}El`].scrollTop = Math.max(0, (value - 2.5) * 32 + 80);
       }
     }
   };

--- a/packages/date-picker/src/panel/time-range.vue
+++ b/packages/date-picker/src/panel/time-range.vue
@@ -150,6 +150,9 @@
 
       handleChange() {
         if (this.minTime > this.maxTime) return;
+        MIN_TIME.setFullYear(this.minTime.getFullYear());
+        MIN_TIME.setMonth(this.minTime.getMonth());
+        MIN_TIME.setDate(this.minTime.getDate());
         this.$refs.minSpinner.selectableRange = [[MIN_TIME, this.maxTime]];
         this.$refs.maxSpinner.selectableRange = [[this.minTime, MAX_TIME]];
         this.handleConfirm(true);

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -448,7 +448,7 @@ export default {
 
         this.picker.$on('dodestroy', this.doDestroy);
         this.picker.$on('pick', (date, visible = false) => {
-          if (this.dateChanged(date, this.value)) this.$emit('input', date);
+          this.$emit('input', date);
           this.pickerVisible = this.picker.visible = visible;
           this.picker.resetView && this.picker.resetView();
         });

--- a/packages/date-picker/src/util/index.js
+++ b/packages/date-picker/src/util/index.js
@@ -145,7 +145,7 @@ export const limitRange = function(date, ranges) {
   if (!ranges || !ranges.length) return date;
 
   const len = ranges.length;
-  const format = 'HH:mm:ss';
+  const format = 'yyyy-MM-dd HH:mm:ss';
 
   date = dateUtil.parse(dateUtil.format(date, format), format);
   for (let i = 0; i < len; i++) {

--- a/packages/theme-default/src/date-picker/time-picker.css
+++ b/packages/theme-default/src/date-picker/time-picker.css
@@ -24,7 +24,7 @@
         color: var(--color-white);
         position: absolute;
         font-size: 14px;
-        margin-top: -15px;
+        margin-top: -7px;
         line-height: 16px;
         background-color: var(--datepicker-active-color);
         height: 32px;


### PR DESCRIPTION
fixed #2071 change the time-picker style and scroll compute 
Instand the mousewheel event to scroll.
Cause the mousewheel event trigger is on `mousewheel` not `after mousewheel`.

### update.readme -2017-2-18 10:25
> `index.js` 
```js
const format = 'HH:mm:ss';
date = dateUtil.parse(dateUtil.format(date, format), format);
```
In this way. the date will lost year-month-day info.  like [2016-9-10 8:40:00] after parse. That change to  [currentYear-currentMonth-currentDay 8:40:00],  that well affect the logic behind. So we need to save the Y M D info.


> `time-range.vue`

The `MIN_TIME` default value is `currentYear-currentMonth-currentDay 00:00:00`. When we got a default value like `[new Date(2016, 9, 10, 8, 40), new Date(2016, 9, 10, 9, 40)]`. The MIN_TIME great than we default, that's not ture. We have to change the MIN_TIME less than we `default value[0]`. Or that's bug will be show. when you first pick, the time well be `00:00:00` on `input`
![element-time-picker-range-bug](https://cloud.githubusercontent.com/assets/4620878/23089621/cba9647c-f5c6-11e6-8f08-06abfb92d2f8.gif)
