### PR TITLE
breadcrumb: add a class when no `to` property assigned (#3140)

### DIFF
--- a/packages/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/breadcrumb/src/breadcrumb-item.vue
@@ -30,8 +30,11 @@
           }
         });
       } else {
-        this.$refs.link.style.color = '#97a8be';
-        this.$refs.link.style.cursor = 'text';
+        if (this.$refs.link.classList) {
+          this.$refs.link.classList.add('el-breadcrumb__item__nolink');
+        } else {
+          this.$refs.link.className += ' el-breadcrumb__item__nolink';
+        }
       }
     }
   };

--- a/packages/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/breadcrumb/src/breadcrumb-item.vue
@@ -1,6 +1,7 @@
 <template>
   <span class="el-breadcrumb__item">
-    <span class="el-breadcrumb__item__inner" ref="link"><slot></slot></span><span class="el-breadcrumb__separator">{{separator}}</span>
+    <span class="el-breadcrumb__item__inner" ref="link"><slot></slot></span>
+    <span class="el-breadcrumb__separator">{{separator}}</span>
   </span>
 </template>
 <script>
@@ -17,14 +18,20 @@
     },
     mounted() {
       this.separator = this.$parent.separator;
-      var self = this;
       if (this.to) {
-        let link = this.$refs.link;
+        const link = this.$refs.link;
         link.addEventListener('click', _ => {
-          let to = this.to;
-          self.replace ? self.$router.replace(to)
-                       : self.$router.push(to);
+          const to = this.to;
+          if (this.$router) {
+            this.replace ? this.$router.replace(to)
+                         : this.$router.push(to);
+          } else {
+            console.warn('Vue-Router Not Found');
+          }
         });
+      } else {
+        this.$refs.link.style.color = '#97a8be';
+        this.$refs.link.style.cursor = 'text';
       }
     }
   };

--- a/packages/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/breadcrumb/src/breadcrumb-item.vue
@@ -5,6 +5,7 @@
   </span>
 </template>
 <script>
+  import { addClass } from 'element-ui/src/utils/dom';
   export default {
     name: 'ElBreadcrumbItem',
     props: {
@@ -30,11 +31,7 @@
           }
         });
       } else {
-        if (this.$refs.link.classList) {
-          this.$refs.link.classList.add('el-breadcrumb__item__nolink');
-        } else {
-          this.$refs.link.className += ' el-breadcrumb__item__nolink';
-        }
+        addClass(this.$refs.link, 'el-breadcrumb__item__nolink');
       }
     }
   };


### PR DESCRIPTION
1. breadcrumb: change the link style when no `to` property assigned (#3140)
2. when Vue-router is not found, warn in the console instead of throwing a error