### PR TITLE
why not offer a specific size prop unit by px?

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -462,7 +462,7 @@
         this.$nextTick(() => {
           let inputChildNodes = this.$refs.reference.$el.childNodes;
           let input = [].filter.call(inputChildNodes, item => item.tagName === 'INPUT')[0];
-          input.style.height = Math.max(this.$refs.tags.clientHeight + 6, sizeMap[this.size] || 36) + 'px';
+          input.style.height = parseInt(this.size) || Math.max(this.$refs.tags.clientHeight + 6, sizeMap[this.size] || 36) + 'px';
           if (this.visible && this.emptyText !== false) {
             this.broadcast('ElSelectDropdown', 'updatePopper');
           }


### PR DESCRIPTION
Should blame these hard coded snippet?
```js
const sizeMap = {
    'large': 42,
    'small': 30,
    'mini': 22
  };
````

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
