### PR TITLE
Carousel: Update docs accuracy

### DIFF
--- a/examples/docs/en-US/carousel.md
+++ b/examples/docs/en-US/carousel.md
@@ -164,7 +164,7 @@ When a page is wide enough but has limited height, you can activate card mode fo
 |---------- |-------------- |---------- |--------------------------------  |-------- |
 | height | height of the carousel | number | — | 300 |
 | initial-index | index of the initially active slide (starting from 0) | number | — | 0 |
-| trigger | how indicators are triggered | string | click | — |
+| trigger | how indicators are triggered | string | hover/click | hover |
 | autoplay | whether automatically loop the slides | boolean | — | true |
 | interval | interval of the auto loop, in milliseconds | number | — | 3000 |
 | indicator-position | position of the indicators | string | outside/none | — |


### PR DESCRIPTION
Carousel's default trigger is actually "hover", not "—". Updated accepted values in case anyone gets confused like I did when the documentation didn't match the actual state of the carousel component.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
