### PR TITLE
Loading: keep loading text sync with element-loading-text attribute

### DIFF
--- a/packages/loading/src/directive.js
+++ b/packages/loading/src/directive.js
@@ -91,6 +91,7 @@ exports.install = Vue => {
 
     update: function(el, binding) {
       if (binding.oldValue !== binding.value) {
+        el.instance.setText(el.getAttribute('element-loading-text'));
         toggleLoading(el, binding);
       }
     },

--- a/packages/loading/src/directive.js
+++ b/packages/loading/src/directive.js
@@ -90,8 +90,8 @@ exports.install = Vue => {
     },
 
     update: function(el, binding) {
+      el.instance.setText(el.getAttribute('element-loading-text'));
       if (binding.oldValue !== binding.value) {
-        el.instance.setText(el.getAttribute('element-loading-text'));
         toggleLoading(el, binding);
       }
     },

--- a/packages/loading/src/loading.vue
+++ b/packages/loading/src/loading.vue
@@ -28,6 +28,9 @@
     methods: {
       handleAfterLeave() {
         this.$emit('after-leave');
+      },
+      setText(text) {
+        this.text = text;
       }
     }
   };


### PR DESCRIPTION
Get value from `element-loading-text` attribute on directive update hook, then we can update loading text dynamically.

Fix issue #2272.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
