### PR TITLE
Table: add csvExport method

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "async-validator": "^1.6.6",
     "babel-helper-vue-jsx-merge-props": "^2.0.0",
     "deepmerge": "^1.2.0",
+    "json2csv": "^3.7.3",
     "throttle-debounce": "^1.0.1"
   },
   "peerDependencies": {

--- a/packages/table/src/CsvExport.js
+++ b/packages/table/src/CsvExport.js
@@ -1,0 +1,21 @@
+import json2csv from 'json2csv'
+
+export default (data, fields, fieldNames, fileName) => {
+  try {
+    var result = json2csv({
+      data: data,
+      fields: fields,
+      fieldNames: fieldNames
+    });
+    var csvContent = 'data:text/csv;charset=GBK,\uFEFF' + result;
+    var encodedUri = encodeURI(csvContent);
+    var link = document.createElement('a');
+    link.setAttribute('href', encodedUri);
+    link.setAttribute('download', `${(fileName || 'file')}.csv`);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/packages/table/src/CsvExport.js
+++ b/packages/table/src/CsvExport.js
@@ -1,4 +1,4 @@
-import json2csv from 'json2csv'
+import json2csv from 'json2csv';
 
 export default (data, fields, fieldNames, fileName) => {
   try {
@@ -18,4 +18,4 @@ export default (data, fields, fieldNames, fileName) => {
   } catch (err) {
     console.error(err);
   }
-}
+};

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -180,6 +180,12 @@
     },
 
     methods: {
+      exportCsv(fileName){
+        let columns = this.$children.filter(t => t.prop != null)
+        const fields = columns.map(t => t.prop)
+        const fieldNames = columns.map(t => t.label)
+        CsvExport(this.data, fields, fieldNames, fileName)
+      },
       toggleRowSelection(row, selected) {
         this.store.toggleRowSelection(row, selected);
         this.store.updateAllSelected();

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -116,6 +116,7 @@
   import TableBody from './table-body';
   import TableHeader from './table-header';
   import { mousewheel } from './util';
+  import CsvExport from './CsvExport';
 
   let tableIdSeed = 1;
 

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -180,11 +180,11 @@
     },
 
     methods: {
-      exportCsv(fileName){
-        let columns = this.$children.filter(t => t.prop != null)
-        const fields = columns.map(t => t.prop)
-        const fieldNames = columns.map(t => t.label)
-        CsvExport(this.data, fields, fieldNames, fileName)
+      exportCsv(fileName) {
+        let columns = this.$children.filter(t => t.prop != null);
+        const fields = columns.map(t => t.prop);
+        const fieldNames = columns.map(t => t.label);
+        CsvExport(this.data, fields, fieldNames, fileName);
       },
       toggleRowSelection(row, selected) {
         this.store.toggleRowSelection(row, selected);


### PR DESCRIPTION
在使用element的时候，发现table没有导出数据的功能，自己写起来也会比较麻烦，就写了一个，这样直接调用方法即可。

### 使用方法：

在table组件定义ref，用于获取组件，在需要下载的按钮上添加点击事件，在方法里调用组件方法即可
```
<template>
<div>
  <el-table :data="tableData" style="width: 100%" ref="table">
    <el-table-column prop="date" label="日期" width="180" label-class-name="test">
    </el-table-column>
    <el-table-column prop="name" label="姓名" width="180">
    </el-table-column>
    <el-table-column prop="address" label="地址">
    </el-table-column>
  </el-table>
  <el-button  @click="exportCsv"></el-button>
</div>
</template>
<script type="text/ecmascript-6">
export default {
  methods:{
     exportCsv(){
        // 调用组件方法。目前只有一个参数，传入导出文件名称。
        this.$refs.table.exportCsv('tableName');
     }
  }
}
</script>
```
