### PR TITLE
Cacasder: feature - add parent-select prop

### DIFF
--- a/packages/cascader/src/main.vue
+++ b/packages/cascader/src/main.vue
@@ -139,7 +139,8 @@ export default {
     debounce: {
       type: Number,
       default: 300
-    }
+    },
+    parentSelectable: Boolean
   },
 
   data() {
@@ -208,6 +209,7 @@ export default {
       this.menu.expandTrigger = this.expandTrigger;
       this.menu.changeOnSelect = this.changeOnSelect;
       this.menu.popperClass = this.popperClass;
+      this.menu.parentSelectable = this.parentSelectable;
       this.popperElm = this.menu.$el;
       this.menu.$on('pick', this.handlePick);
       this.menu.$on('activeItemChange', this.handleActiveItemChange);

--- a/packages/cascader/src/menu.vue
+++ b/packages/cascader/src/menu.vue
@@ -12,7 +12,8 @@
         value: [],
         expandTrigger: 'click',
         changeOnSelect: false,
-        popperClass: ''
+        popperClass: '',
+        parentSelectable: false
       };
     },
 
@@ -119,7 +120,11 @@
                 click: 'click',
                 hover: 'mouseenter'
               }[expandTrigger];
+
               events.on[triggerEvent] = () => { this.activeItem(item, menuIndex); };
+              if (this.parentSelectable && expandTrigger === 'hover') {
+                events.on.click = () => { this.select(item, menuIndex); };
+              }
             } else {
               events.on.click = () => { this.select(item, menuIndex); };
             }


### PR DESCRIPTION
### Cascader 级联选择器添加props: parent-selectable

- 需求场景：省市区选择，在有children的情况下也能选择parent，即存在区的选项也能选择省／市
- 解决方案：在expand-trigger为hover，parent-selectable为true给parent元素添加点击事件(select)，否则不添加

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
