### PR TITLE
fix doc side-nav text-overlapping

### DIFF
--- a/examples/components/side-nav.vue
+++ b/examples/components/side-nav.vue
@@ -12,7 +12,7 @@
       margin: 0;
       overflow: hidden;
     }
-    
+
     .nav-dropdown {
       margin-bottom: 6px;
       width: 100%;
@@ -73,6 +73,9 @@
           line-height: 40px;
           font-size: 13px;
           padding-left: 24px;
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
 
 
           &:hover {


### PR DESCRIPTION
1. 修复文档侧边导航文字重叠的问题, 在宽度(850px-1000px)时出现

![image](https://cloud.githubusercontent.com/assets/18493379/23759710/83923076-0528-11e7-9b42-e613e2a0d5b8.png)
