### PR TITLE
Tree: fix setCheckedKeys with `lazy` bug(#3410)

### DIFF
--- a/packages/tree/src/model/tree-store.js
+++ b/packages/tree/src/model/tree-store.js
@@ -195,7 +195,7 @@ export default class TreeStore {
     allNodes.forEach((node) => {
       let checked = keys.indexOf(node.data[key] + '') > -1;
 
-      if (!node.isLeaf) {
+      if (!node.isLeaf && !node.store.lazy) {
         if (!this.checkStrictly) {
           const childNodes = node.childNodes;
 
@@ -240,7 +240,11 @@ export default class TreeStore {
           traverse(node);
         }
       } else {
-        node.setChecked(checked, false);
+        if (!node.store.lazy) {
+          node.setChecked(checked, false);
+        } else {
+          node.setChecked(checked, !this.checkStrictly);
+        }
       }
     });
   }


### PR DESCRIPTION
1. 修复过程: 在 setCheckedKeys() 里对 lazy 做了一次判断
2. 尝试过从 isLeaf 入手,  因为问题在于 lazy 的节点无法判断它的 isLeaf 属性, 不过没成功, 觉得从那里修复可能比较好
3. 可能会有的问题: 对 lazy 属性的子节点使用 setCheckedKeys 可能仍会有问题, 不过 lazy 的子节点一般不设置 key?