### PR TITLE
Clickoutside: prevent closing on drag click

### DIFF
--- a/src/utils/clickoutside.js
+++ b/src/utils/clickoutside.js
@@ -9,7 +9,7 @@ let startClick;
 !Vue.prototype.$isServer && on(document, 'mousedown', e => (startClick = e));
 
 !Vue.prototype.$isServer && on(document, 'mouseup', e => {
-  nodeList.forEach(node => node[ctx].documentHandler(e));
+  nodeList.forEach(node => node[ctx].documentHandler(e, startClick));
 });
 /**
  * v-clickoutside
@@ -22,13 +22,12 @@ let startClick;
 export default {
   bind(el, binding, vnode) {
     const id = nodeList.push(el) - 1;
-    const documentHandler = function(e) {
+    const documentHandler = function(mouseup, mousedown) {
       if (!vnode.context ||
-        el.contains(e.target) ||
-        el.contains(startClick.target) ||
+        el.contains(mouseup.target) ||
         (vnode.context.popperElm &&
-        (vnode.context.popperElm.contains(e.target)) ||
-        vnode.context.popperElm.contains(startClick.target))) return;
+        (vnode.context.popperElm.contains(mouseup.target) ||
+        vnode.context.popperElm.contains(mousedown.target)))) return;
 
       if (binding.expression &&
         el[ctx].methodName &&

--- a/src/utils/clickoutside.js
+++ b/src/utils/clickoutside.js
@@ -4,7 +4,11 @@ import { on } from 'element-ui/src/utils/dom';
 const nodeList = [];
 const ctx = '@@clickoutsideContext';
 
-!Vue.prototype.$isServer && on(document, 'click', e => {
+let startClick;
+
+!Vue.prototype.$isServer && on(document, 'mousedown', e => (startClick = e));
+
+!Vue.prototype.$isServer && on(document, 'mouseup', e => {
   nodeList.forEach(node => node[ctx].documentHandler(e));
 });
 /**
@@ -21,8 +25,10 @@ export default {
     const documentHandler = function(e) {
       if (!vnode.context ||
         el.contains(e.target) ||
+        el.contains(startClick.target) ||
         (vnode.context.popperElm &&
-        vnode.context.popperElm.contains(e.target))) return;
+        (vnode.context.popperElm.contains(e.target)) ||
+        vnode.context.popperElm.contains(startClick.target))) return;
 
       if (binding.expression &&
         el[ctx].methodName &&

--- a/test/unit/specs/autocomplete.spec.js
+++ b/test/unit/specs/autocomplete.spec.js
@@ -1,4 +1,4 @@
-import { createVue, destroyVM } from '../util';
+import { createVue, triggerClick, destroyVM } from '../util';
 
 describe('Autocomplete', () => {
   let vm;
@@ -59,7 +59,7 @@ describe('Autocomplete', () => {
       expect(suggestions.style.display).to.not.equal('none');
       expect(suggestions.querySelectorAll('.el-autocomplete-suggestion__list li').length).to.be.equal(4);
 
-      document.body.click();
+      triggerClick(document);
       setTimeout(_ => {
         expect(suggestions.style.display).to.be.equal('none');
         done();

--- a/test/unit/specs/input-number.spec.js
+++ b/test/unit/specs/input-number.spec.js
@@ -1,4 +1,4 @@
-import { createVue, triggerEvent, destroyVM } from '../util';
+import { createVue, triggerEvent, triggerClick, destroyVM } from '../util';
 
 describe('InputNumber', () => {
   let vm;
@@ -39,7 +39,7 @@ describe('InputNumber', () => {
     let btnDecrease = vm.$el.querySelector('.el-input-number__decrease');
 
     triggerEvent(btnDecrease, 'mousedown');
-    triggerEvent(document, 'mouseup');
+    triggerClick(document, 'mouseup');
 
     vm.$nextTick(_ => {
       expect(vm.value).to.be.equal(4);
@@ -64,7 +64,7 @@ describe('InputNumber', () => {
     let btnIncrease = vm.$el.querySelector('.el-input-number__increase');
 
     triggerEvent(btnIncrease, 'mousedown');
-    triggerEvent(document, 'mouseup');
+    triggerClick(document, 'mouseup');
 
     vm.$nextTick(_ => {
       expect(vm.value).to.be.equal(2.5);
@@ -90,14 +90,14 @@ describe('InputNumber', () => {
     let btnIncrease = vm.$el.querySelector('.el-input-number__increase');
 
     triggerEvent(btnDecrease, 'mousedown');
-    triggerEvent(document, 'mouseup');
+    triggerClick(document, 'mouseup');
 
     vm.$nextTick(_ => {
       expect(vm.value).to.be.equal(2);
       expect(input.value).to.be.equal('2');
 
       triggerEvent(btnIncrease, 'mousedown');
-      triggerEvent(document, 'mouseup');
+      triggerClick(document, 'mouseup');
 
       vm.$nextTick(_ => {
         expect(vm.value).to.be.equal(2);
@@ -124,14 +124,14 @@ describe('InputNumber', () => {
     let btnDecrease = vm.$el.querySelector('.el-input-number__decrease');
 
     triggerEvent(btnIncrease, 'mousedown');
-    triggerEvent(document, 'mouseup');
+    triggerClick(document, 'mouseup');
 
     vm.$nextTick(_ => {
       expect(vm.value).to.be.equal(8.2);
       expect(input.value).to.be.equal('8.2');
 
       triggerEvent(btnDecrease, 'mousedown');
-      triggerEvent(document, 'mouseup');
+      triggerClick(document, 'mouseup');
 
       vm.$nextTick(_ => {
         expect(vm.value).to.be.equal(5);
@@ -171,7 +171,7 @@ describe('InputNumber', () => {
     let btnDecrease = vm.$el.querySelector('.el-input-number__decrease');
 
     triggerEvent(btnDecrease, 'mousedown');
-    triggerEvent(document, 'mouseup');
+    triggerClick(document, 'mouseup');
 
     vm.$nextTick(_ => {
       expect(vm.value).to.be.equal(6);
@@ -210,7 +210,7 @@ describe('InputNumber', () => {
     let btnIncrease = vm.$el.querySelector('.el-input-number__increase');
 
     triggerEvent(btnIncrease, 'mousedown');
-    triggerEvent(document, 'mouseup');
+    triggerClick(document, 'mouseup');
 
     vm.$nextTick(_ => {
       expect(vm.value).to.be.equal(8);
@@ -282,7 +282,7 @@ describe('InputNumber', () => {
     vm.$refs.input.$on('change', spy);
 
     triggerEvent(btnIncrease, 'mousedown');
-    triggerEvent(document, 'mouseup');
+    triggerClick(document, 'mouseup');
 
     vm.$nextTick(_ => {
       expect(spy.withArgs(2.5, 1.5).calledOnce).to.be.true;

--- a/test/unit/specs/util.clickoutside.spec.js
+++ b/test/unit/specs/util.clickoutside.spec.js
@@ -1,6 +1,8 @@
 import Clickoutside from 'element-ui/src/utils/clickoutside';
 const ctx = '@@clickoutsideContext';
 
+import { triggerClick } from '../util';
+
 describe('Utils:Clickoutside', () => {
   it('create', () => {
     let count = 0;
@@ -42,7 +44,7 @@ describe('Utils:Clickoutside', () => {
     };
 
     Clickoutside.bind(el, binding, vnode);
-    document.body.click();
+    triggerClick(document);
     expect(count).to.equal(1);
   });
 
@@ -61,9 +63,9 @@ describe('Utils:Clickoutside', () => {
 
     el.appendChild(insideElm);
     Clickoutside.bind(el, binding, vnode);
-    insideElm.click();
+    triggerClick(insideElm);
     expect(count).to.equal(0);
-    document.body.click();
+    triggerClick(document);
     expect(count).to.equal(1);
   });
 
@@ -83,9 +85,9 @@ describe('Utils:Clickoutside', () => {
 
     vnode.context.popperElm.appendChild(insideElm);
     Clickoutside.bind(el, binding, vnode);
-    insideElm.click();
+    triggerClick(insideElm);
     expect(count).to.equal(0);
-    document.body.click();
+    triggerClick(document);
     expect(count).to.equal(1);
   });
 
@@ -101,7 +103,7 @@ describe('Utils:Clickoutside', () => {
 
     Clickoutside.bind(el, binding, vnode);
     expect(count).to.equal(0);
-    document.body.click();
+    triggerClick(document);
     expect(count).to.equal(1);
   });
 
@@ -139,9 +141,9 @@ describe('Utils:Clickoutside', () => {
     };
 
     Clickoutside.bind(el, binding, vnode);
-    document.body.click();
+    triggerClick(document);
     Clickoutside.unbind(el);
-    document.body.click();
+    triggerClick(document);
     expect(count).to.equal(1);
   });
 });

--- a/test/unit/specs/util.clickoutside.spec.js
+++ b/test/unit/specs/util.clickoutside.spec.js
@@ -1,7 +1,7 @@
 import Clickoutside from 'element-ui/src/utils/clickoutside';
 const ctx = '@@clickoutsideContext';
 
-import { triggerClick } from '../util';
+import { triggerEvent, triggerClick } from '../util';
 
 describe('Utils:Clickoutside', () => {
   it('create', () => {
@@ -146,4 +146,25 @@ describe('Utils:Clickoutside', () => {
     triggerClick(document);
     expect(count).to.equal(1);
   });
+
+  it('stays open on drag click', () => {
+    const el = document.createElement('div');
+    const insideElm = document.createElement('div');
+    let count = 0;
+    const vnode = {
+      context: {
+        handleClick: () => ++count
+      }
+    };
+    const binding = {
+      expression: 'handleClick'
+    };
+
+    el.appendChild(insideElm);
+    Clickoutside.bind(el, binding, vnode);
+    triggerEvent(insideElm, 'mousedown');
+    triggerEvent(document, 'mouseup');
+    expect(count).to.equal(1);
+  });
 });
+

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -83,3 +83,15 @@ exports.triggerEvent = function(elm, name, ...opts) {
 
   return elm;
 };
+
+/**
+ * 触发 “mouseup” 和 “mousedown” 事件
+ * @param {Element} elm
+ * @param {*} opts
+ */
+exports.triggerClick = function(elm, ...opts) {
+  exports.triggerEvent(elm, 'mousedown', ...opts);
+  exports.triggerEvent(elm, 'mouseup', ...opts);
+
+  return elm;
+};


### PR DESCRIPTION
When eg. having to choose a color at the edge of the Colorpicker component, it is easy to let your mouse get out of the components box. This will make the Colorpicker disappear which can be frustrating for the user.

![mar -12-2017 21-45-54](https://cloud.githubusercontent.com/assets/947230/23835772/63eada38-076d-11e7-8ed0-972f04178a7e.gif)

I've added a mousedown event in the Clickoutside directive to check whether the mouse' starting point is inside the "popperElm" and prevent the bindings method to be called if it is.

This might add some unwanted results in other components using the clickoutside but shouldn't really be an issue. 
If it is though, I propose adding a modifier to the directive to signal that drag clicking shouldn't call the bindings method. `<element v-clickoutside.allowdrag="hide">`

Note: The test utility method 'triggerClick's  description is translated with Google Translate. So you might want to correct me on this one 😄 

Let me know what you think.

\- Thanks for this awesome project

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
