### PR TITLE
Slider: fix step not updating precision

### DIFF
--- a/packages/slider/src/main.vue
+++ b/packages/slider/src/main.vue
@@ -99,7 +99,6 @@
         firstValue: null,
         secondValue: null,
         oldValue: null,
-        precision: 0,
         dragging: false
       };
     },
@@ -113,10 +112,6 @@
           return;
         }
         this.setValues();
-      },
-
-      step() {
-        this.setPrecision();
       },
 
       dragging(val) {
@@ -210,14 +205,6 @@
         if (this.disabled || this.dragging) return;
         const sliderOffsetLeft = this.$refs.slider.getBoundingClientRect().left;
         this.setPosition((event.clientX - sliderOffsetLeft) / this.$sliderWidth * 100);
-      },
-
-      setPrecision() {
-        let precisions = [this.min, this.max, this.step].map(item => {
-          let decimal = ('' + item).split('.')[1];
-          return decimal ? decimal.length : 0;
-        });
-        this.precision = Math.max.apply(null, precisions);
       }
     },
 
@@ -261,6 +248,14 @@
         return this.range
           ? `${ 100 * (this.minValue - this.min) / (this.max - this.min) }%`
           : '0%';
+      },
+
+      precision() {
+        let precisions = [this.min, this.max, this.step].map(item => {
+          let decimal = ('' + item).split('.')[1];
+          return decimal ? decimal.length : 0;
+        });
+        return Math.max.apply(null, precisions);
       }
     },
 
@@ -282,7 +277,6 @@
         }
         this.oldValue = this.firstValue;
       }
-      this.setPrecision();
     }
   };
 </script>

--- a/packages/slider/src/main.vue
+++ b/packages/slider/src/main.vue
@@ -115,6 +115,10 @@
         this.setValues();
       },
 
+      step() {
+        this.setPrecision();
+      },
+
       dragging(val) {
         if (!val) {
           this.setValues();
@@ -206,6 +210,14 @@
         if (this.disabled || this.dragging) return;
         const sliderOffsetLeft = this.$refs.slider.getBoundingClientRect().left;
         this.setPosition((event.clientX - sliderOffsetLeft) / this.$sliderWidth * 100);
+      },
+
+      setPrecision() {
+        let precisions = [this.min, this.max, this.step].map(item => {
+          let decimal = ('' + item).split('.')[1];
+          return decimal ? decimal.length : 0;
+        });
+        this.precision = Math.max.apply(null, precisions);
       }
     },
 
@@ -270,11 +282,7 @@
         }
         this.oldValue = this.firstValue;
       }
-      let precisions = [this.min, this.max, this.step].map(item => {
-        let decimal = ('' + item).split('.')[1];
-        return decimal ? decimal.length : 0;
-      });
-      this.precision = Math.max.apply(null, precisions);
+      this.setPrecision();
     }
   };
 </script>


### PR DESCRIPTION
* [X] Make sure you follow Element's contributing guide
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.

Fixing #3473. When `step` was updated on parent component, Slider didn't update the precision, leading to some errors.