### PR TITLE
theme-default: fix form-item label-top style

### DIFF
--- a/packages/theme-default/src/form.css
+++ b/packages/theme-default/src/form.css
@@ -12,6 +12,7 @@
       & .el-form-item__label {
         float: none;
         display: inline-block;
+        text-align: left;
         padding: 0 0 10px 0;
       }
     }


### PR DESCRIPTION
use `text-align: left` to display line-wrapped labels properly

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

### 做了什么：
form的label-position为"top"时，让label文字靠左对齐。

### 为什么：
label文字过长，发生换行时，对齐方式与预期的不一致

### 修改前：
![before fix](https://cloud.githubusercontent.com/assets/9319556/23909588/15150c48-0912-11e7-9f88-382a1f3c943d.png)

### 修改后：
![after-fix](https://cloud.githubusercontent.com/assets/9319556/23909605/28b05c9e-0912-11e7-8aad-52bc3eaeb0b4.png)
