### PR TITLE
Fix filename of md file for en-US version

### DIFF
--- a/build/bin/new.js
+++ b/build/bin/new.js
@@ -74,7 +74,7 @@ export default {
     content: `## ${chineseName}`
   },
   {
-    filename: path.join('../../examples/docs/en-us', `${componentname}.md`),
+    filename: path.join('../../examples/docs/en-US', `${componentname}.md`),
     content: `## ${componentname}`
   },
   {


### PR DESCRIPTION
Initially it was `en-us`, but the folder is `en-US` .

When creating a new component, the build doesn't work because it hopes a file in the `en-US` folder.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
