### PR TITLE
ElMenu: update activedIndex/openedMenus when items changes, fix #2670

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -49,17 +49,13 @@
     },
     watch: {
       defaultActive(value) {
-        const item = this.items[value];
-        if (item) {
-          this.activedIndex = item.index;
-          this.initOpenedMenu();
-        } else {
-          this.activedIndex = '';
-        }
-
+        this.updateActive(value);
       },
       defaultOpeneds(value) {
         this.openedMenus = value;
+      },
+      items(value) {
+        this.updateActive(this.defaultActive);
       }
     },
     methods: {
@@ -134,6 +130,15 @@
           this.$router.push(route);
         } catch (e) {
           console.error(e);
+        }
+      },
+      updateActive(value) {
+        const item = this.items[value];
+        if (item) {
+          this.activedIndex = item.index;
+          this.initOpenedMenu();
+        } else {
+          this.activedIndex = '';
         }
       }
     },

--- a/test/unit/specs/menu.spec.js
+++ b/test/unit/specs/menu.spec.js
@@ -17,13 +17,15 @@ describe('Menu', () => {
     }, true);
     var item1 = vm.$refs.item1;
     var item2 = vm.$refs.item2;
-    item1.$el.click();
     vm.$nextTick(_ => {
-      expect(item1.$el.classList.contains('is-active')).to.be.true;
-      item2.$el.click();
+      item1.$el.click();
       vm.$nextTick(_ => {
-        expect(item2.$el.classList.contains('is-active')).to.be.true;
-        done();
+        expect(item1.$el.classList.contains('is-active')).to.be.true;
+        item2.$el.click();
+        vm.$nextTick(_ => {
+          expect(item2.$el.classList.contains('is-active')).to.be.true;
+          done();
+        });
       });
     });
   });
@@ -66,11 +68,13 @@ describe('Menu', () => {
           </el-menu>
         `
       }, true);
-      expect(vm.$refs.item2.$el.classList.contains('is-active')).to.be.true;
-      vm.$refs.item1.$el.click();
       vm.$nextTick(_ => {
-        expect(vm.$refs.item1.$el.classList.contains('is-active')).to.be.true;
-        done();
+        expect(vm.$refs.item2.$el.classList.contains('is-active')).to.be.true;
+        vm.$refs.item1.$el.click();
+        vm.$nextTick(_ => {
+          expect(vm.$refs.item1.$el.classList.contains('is-active')).to.be.true;
+          done();
+        });
       });
     });
     it('dynamic active', done => {
@@ -257,10 +261,12 @@ describe('Menu', () => {
         };
       }
     }, true);
-    vm.$refs.submenu2.$el.querySelector('.el-submenu__title').click();
     vm.$nextTick(_ => {
-      expect(vm.$refs.submenu1.$el.classList.contains('is-opened')).to.not.true;
-      done();
+      vm.$refs.submenu2.$el.querySelector('.el-submenu__title').click();
+      vm.$nextTick(_ => {
+        expect(vm.$refs.submenu1.$el.classList.contains('is-opened')).to.not.true;
+        done();
+      });
     });
   });
   it('horizontal mode', done => {


### PR DESCRIPTION
The current problem is, many people need to dynamic generate menu-items. however, when one watch default-active, the menu may still not generated, when the menu generated, one need to change the value the default-active is and turn it back to make the watch work. eg.

```
this.currentPath = 'something else'
this.$nextTick(_ => {
  this.currentPath = 'the path you like'
})
```

its quite a dirty workaround. So maybe menu component should watch items change and apply updateActive automaticly.