### PR TITLE
tags的层级过高

### DIFF
--- a/packages/theme-default/src/select.css
+++ b/packages/theme-default/src/select.css
@@ -107,7 +107,7 @@
       position: absolute;
       line-height: normal;
       white-space: normal;
-      z-index: var(--index-top);
+      z-index: 1;
       top: 50%;
       transform: translateY(-50%);
     }

--- a/packages/theme-default/src/select.css
+++ b/packages/theme-default/src/select.css
@@ -107,7 +107,7 @@
       position: absolute;
       line-height: normal;
       white-space: normal;
-      z-index: 1;
+      z-index: var(--index-normal);
       top: 50%;
       transform: translateY(-50%);
     }


### PR DESCRIPTION
tags的层级是1000，导致超出了自定义的一些Dialog的层级。
此处将tags的层级更改为```z-index:1;```，感觉已经够用了。

![image](https://cloud.githubusercontent.com/assets/342509/24185513/780c6eac-0f0e-11e7-9d69-b2e2714d0444.png)
