### PR TITLE
Checkbox group min max

### DIFF
--- a/examples/docs/en-US/checkbox.md
+++ b/examples/docs/en-US/checkbox.md
@@ -12,6 +12,7 @@
         checkAll: false,
         cities: cityOptions,
         checkedCities: ['Shanghai', 'Beijing'],
+        checkedCities1: ['Shanghai', 'Beijing'],
         isIndeterminate: true
       };
     },
@@ -147,6 +148,40 @@ The `indeterminate` property can help you to achieve a 'check all' effect.
         this.checkAll = checkedCount === this.cities.length;
         this.isIndeterminate = checkedCount > 0 && checkedCount < this.cities.length;
       }
+    }
+  };
+</script>
+```
+:::
+
+
+### Minimum / Maximum items checked
+
+The `minimum` and `maximum` properties can help you to limit the number of checked items.
+
+:::demo
+
+```html
+<template>
+  <el-checkbox-group 
+    v-model="checkedCities1"
+    minimum="1"
+    maximum="2">
+    <el-checkbox v-for="city in cities" :label="city">{{city}}</el-checkbox>
+  </el-checkbox-group>
+</template>
+<script>
+  const cityOptions = ['Shanghai', 'Beijing', 'Guangzhou', 'Shenzhen'];
+  let handlerLimitExceeded = (event) => {
+    currentEvent = event;
+    console.log(event);
+  }
+  export default {
+    data() {
+      return {
+        checkedCities1: ['Shanghai', 'Beijing'],
+        cities: cityOptions
+      };
     }
   };
 </script>

--- a/examples/docs/en-US/checkbox.md
+++ b/examples/docs/en-US/checkbox.md
@@ -157,7 +157,7 @@ The `indeterminate` property can help you to achieve a 'check all' effect.
 
 ### Minimum / Maximum items checked
 
-The `minimum` and `maximum` properties can help you to limit the number of checked items.
+The `min` and `max` properties can help you to limit the number of checked items.
 
 :::demo
 
@@ -165,8 +165,8 @@ The `minimum` and `maximum` properties can help you to limit the number of check
 <template>
   <el-checkbox-group 
     v-model="checkedCities1"
-    minimum="1"
-    maximum="2">
+    :min="1"
+    :max="2">
     <el-checkbox v-for="city in cities" :label="city">{{city}}</el-checkbox>
   </el-checkbox-group>
 </template>
@@ -198,6 +198,12 @@ The `minimum` and `maximum` properties can help you to limit the number of check
 | disabled  | if the checkbox is disabled   | boolean   |  — | false   |
 | checked  | if the checkbox is checked   | boolean   |  — | false   |
 | indeterminate  | same as `indeterminate` in native checkbox | boolean   |  — | false   |
+
+### Checkbox-group Attributes
+| Attribute      | Description         | Type    | Options                         | Default|
+|---------- |-------- |---------- |-------------  |-------- |
+| min     | minimum number of checkbox checked   | number    |       —        |     —    |
+| max     | maximum number of checkbox checked   | number    |       —        |     —    |
 
 ### Checkbox-group Events
 | Event Name | Description | Parameters |

--- a/examples/docs/zh-CN/checkbox.md
+++ b/examples/docs/zh-CN/checkbox.md
@@ -166,7 +166,7 @@
 
 ### Minimum / Maximum items checked (to be translated)
 
-The `minimum` and `maximum` properties can help you to limit the number of checked items.
+The `min` and `max` properties can help you to limit the number of checked items.
 
 :::demo
 
@@ -174,8 +174,8 @@ The `minimum` and `maximum` properties can help you to limit the number of check
 <template>
   <el-checkbox-group 
     v-model="checkedCities1"
-    minimum="1"
-    maximum="2">
+    :min="1"
+    :max="2">
     <el-checkbox v-for="city in cities" :label="city">{{city}}</el-checkbox>
   </el-checkbox-group>
 </template>
@@ -206,6 +206,13 @@ The `minimum` and `maximum` properties can help you to limit the number of check
 | disabled  | 按钮禁用    | boolean   |  — | false   |
 | checked  | 当前是否勾选    | boolean   |  — | false   |
 | indeterminate  | 设置 indeterminate 状态，只负责样式控制    | boolean   |  — | false   |
+
+### Checkbox-group Attributes (to be translated)
+| Attribute      | Description         | Type    | Options                         | Default|
+|---------- |-------- |---------- |-------------  |-------- |
+| min     | minimum number of checkbox checked   | number    |       —        |     —    |
+| max     | maximum number of checkbox checked   | number    |       —        |     —    |
+
 
 ### Checkbox-group Events
 | 事件名称      | 说明    | 回调参数      |

--- a/examples/docs/zh-CN/checkbox.md
+++ b/examples/docs/zh-CN/checkbox.md
@@ -12,6 +12,7 @@
         checkAll: false,
         cities: cityOptions,
         checkedCities: ['上海', '北京'],
+        checkedCities1: ['上海', '北京'],
         isIndeterminate: true
       };
     },
@@ -163,6 +164,38 @@
 ```
 :::
 
+### Minimum / Maximum items checked (to be translated)
+
+The `minimum` and `maximum` properties can help you to limit the number of checked items.
+
+:::demo
+
+```html
+<template>
+  <el-checkbox-group 
+    v-model="checkedCities1"
+    minimum="1"
+    maximum="2">
+    <el-checkbox v-for="city in cities" :label="city">{{city}}</el-checkbox>
+  </el-checkbox-group>
+</template>
+<script>
+  const cityOptions = ['上海', '北京', '广州', '深圳'];
+  let handlerLimitExceeded = (event) => {
+    currentEvent = event;
+    console.log(event);
+  }
+  export default {
+    data() {
+      return {
+        checkedCities1: ['上海', '北京'],
+        cities: cityOptions
+      };
+    }
+  };
+</script>
+```
+:::
 ### Checkbox Attributes
 | 参数      | 说明    | 类型      | 可选值       | 默认值   |
 |---------- |-------- |---------- |-------------  |-------- |

--- a/packages/checkbox/src/checkbox-group.vue
+++ b/packages/checkbox/src/checkbox-group.vue
@@ -9,7 +9,9 @@
     mixins: [Emitter],
 
     props: {
-      value: {}
+      value: {},
+      minimum: String,
+      maximum: String
     },
 
     watch: {

--- a/packages/checkbox/src/checkbox-group.vue
+++ b/packages/checkbox/src/checkbox-group.vue
@@ -10,8 +10,8 @@
 
     props: {
       value: {},
-      minimum: String,
-      maximum: String
+      min: Number,
+      max: Number
     },
 
     watch: {

--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -67,12 +67,12 @@
         set(val) {
           if (this.isGroup) {
             let isLimitExceeded = false;
-            (this._checkboxGroup.minimum !== undefined &&
-              val.length < this._checkboxGroup.minimum &&
+            (this._checkboxGroup.min !== undefined &&
+              val.length < this._checkboxGroup.min &&
               (isLimitExceeded = true));
 
-            (this._checkboxGroup.maximum !== undefined &&
-              val.length > this._checkboxGroup.maximum &&
+            (this._checkboxGroup.max !== undefined &&
+              val.length > this._checkboxGroup.max &&
               (isLimitExceeded = true));
 
             isLimitExceeded === false &&

--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -66,7 +66,18 @@
 
         set(val) {
           if (this.isGroup) {
+            let isLimitExceeded = false;
+            (this._checkboxGroup.minimum !== undefined &&
+              val.length < this._checkboxGroup.minimum &&
+              (isLimitExceeded = true));
+
+            (this._checkboxGroup.maximum !== undefined &&
+              val.length > this._checkboxGroup.maximum &&
+              (isLimitExceeded = true));
+
+            isLimitExceeded === false &&
             this.dispatch('ElCheckboxGroup', 'input', [val]);
+
           } else if (this.value !== undefined) {
             this.$emit('input', val);
           } else {

--- a/test/unit/specs/checkbox.spec.js
+++ b/test/unit/specs/checkbox.spec.js
@@ -68,6 +68,45 @@ describe('Checkbox', () => {
     });
   });
 
+  it('checkbox group minimum and maximum', done => {
+    vm = createVue({
+      template: `
+        <el-checkbox-group 
+          v-model="checkList" 
+          minimum="1" 
+          maximum="2"
+        >
+          <el-checkbox label="a" ref="a"></el-checkbox>
+          <el-checkbox label="b" ref="b"></el-checkbox>
+          <el-checkbox label="c" ref="c"></el-checkbox>
+          <el-checkbox label="d" ref="d"></el-checkbox>
+        </el-checkbox-group>
+      `,
+      data() {
+        return {
+          checkList: ['a'],
+          lastEvent: null
+        };
+      }
+    }, true);
+    expect(vm.checkList.length === 1).to.be.true;
+    vm.$refs.a.$el.click();
+    vm.$nextTick(() => {
+      expect(vm.checkList.indexOf('a') !== -1).to.be.true;
+      vm.$refs.b.$el.click();
+      vm.$nextTick(() => {
+        expect(vm.checkList.indexOf('a') !== -1).to.be.true;
+        expect(vm.checkList.indexOf('b') !== -1).to.be.true;
+        vm.$refs.c.$el.click();
+        vm.$nextTick(() => {
+          expect(vm.checkList.indexOf('c') !== -1).to.be.false;
+          expect(vm.checkList.indexOf('d') !== -1).to.be.false;
+          done();
+        });
+      });
+    });
+  });
+
   it('nested group', done => {
     vm = createVue({
       template: `

--- a/test/unit/specs/checkbox.spec.js
+++ b/test/unit/specs/checkbox.spec.js
@@ -73,8 +73,8 @@ describe('Checkbox', () => {
       template: `
         <el-checkbox-group 
           v-model="checkList" 
-          minimum="1" 
-          maximum="2"
+          :min="1" 
+          :max="2"
         >
           <el-checkbox label="a" ref="a"></el-checkbox>
           <el-checkbox label="b" ref="b"></el-checkbox>


### PR DESCRIPTION
Related to #3602 

By adding two props, `minimum` and `maximum` to `checkbox-group` component,

We can now define a range of checkbox to be checked.

I've added a use case in spec.

Please tell me if this PR seems ok for you, or if I have to make some changes.

Hope it will help !

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
