### PR TITLE
Table:  feature - default use last order when sort other column

### DIFF
--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -379,13 +379,12 @@ export default {
       document.body.style.cursor = '';
     },
 
-    toggleOrder(order) {
-      return !order ? 'ascending' : order === 'ascending' ? 'descending' : null;
+    toggleOrder(order, preOrder) {
+      return !order ? preOrder ? preOrder : 'ascending' : order === 'ascending' ? 'descending' : null;
     },
 
     handleSortClick(event, column, givenOrder) {
       event.stopPropagation();
-      let order = givenOrder || this.toggleOrder(column.order);
 
       let target = event.target;
       while (target && target.tagName !== 'TH') {
@@ -403,6 +402,8 @@ export default {
 
       const states = this.store.states;
       let sortProp = states.sortProp;
+      let preOrder = states.sortOrder;
+      let order = givenOrder || this.toggleOrder(column.order, preOrder);
       let sortOrder;
       const sortingColumn = states.sortingColumn;
 


### PR DESCRIPTION
首先，希望这次提交(https://github.com/ElemeFE/element/commit/e4fe26840ff2352ab420a6a40e1953d3dd023df8) 的改动能在文档说明，毕竟这是非常好但是不容易发现的体验优化。

但是现在的排序逻辑有点容易让人疑惑的地方，现在点击没在排序状态的列的时候，如果不是点击了小箭头，则默认是`升序`，这存在一点让人疑惑的地方：
* 如果当前有一列选择了`升序`，点击另外一列非箭头区域，则还是保持`升序`，这让我觉得这是保持了上一次所选排序的状态；
* 好了，现在当前有一列选择了`降序`，这时候我点击另外一列的非箭头区域的话，会变成`升序`，就和刚才第一点的预想不一致了；
* 类似的，如果用户一开始就选择了`降序`，而点击另外的列变成`升序`，会感觉是按照上次所选顺序的相反，但一旦列排序是升序，点其他列又还是升序，很疑惑（黑人问号）

所以改为保持和最后选择的排序状态相同即可，如果当前没有任何一列排序，则默认升序。

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
