### PR TITLE
Input: fix Input sync (#3595)

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -172,8 +172,12 @@
       handleInput(event) {
         const value = event.target.value;
         this.$emit('input', value);
-        this.setCurrentValue(value);
         this.$emit('change', value);
+        if (this.type === 'text') {
+          this.$refs.input.value = this.currentValue;
+        } else {
+          this.$refs.textarea.value = this.currentValue;
+        }
       },
       handleIconClick(event) {
         if (this.onIconClick) {


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

- 不管是input事件或者是change事件，上级组件都有可能使得绑定在Input组件value属性上的值不变。导致watch函数不被触发。
- 而在Input组件的handleInput函数内，执行了`this.setCurrentValue(value);`使currentValue与原生input内的值保持一致。
- 因此在js的事件队列中执行`this.setCurrentValue(value);`，使得`this.currentValue = this.value`。

参考 #3595 