### PR TITLE
Input: Add Keyup.Enter event

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -46,6 +46,7 @@
         @input="handleInput"
         @focus="handleFocus"
         @blur="handleBlur"
+        @keyup.enter="handleKeyupEnter"
       >
       <i class="el-input__icon el-icon-loading" v-if="validating"></i>
       <!-- 后置元素 -->
@@ -180,6 +181,9 @@
           this.onIconClick(event);
         }
         this.$emit('click', event);
+      },
+      handleKeyupEnter(event) {
+        this.$emit('keyup.enter', event);
       },
       setCurrentValue(value) {
         if (value === this.currentValue) return;


### PR DESCRIPTION
It is a common practice for input elements to have keyup.enter event available. For many instances it is handy to listen for this event as many user tends to use enter key for an action.