### PR TITLE
Fixed: dispatch params ignore array

### DIFF
--- a/src/mixins/emitter.js
+++ b/src/mixins/emitter.js
@@ -23,7 +23,7 @@ export default {
         }
       }
       if (parent) {
-        parent.$emit.apply(parent, [eventName].concat(params));
+        parent.$emit.apply(parent, [eventName].concat([params]));
       }
     },
     broadcast(componentName, eventName, params) {


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

看了一下 `emitter.js` ， 修复 `dispatch` 方法 的`params` 传递为数组的问题. 

