### PR TITLE
Option: Fix #3728 bug

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -84,10 +84,10 @@
 
     watch: {
       currentLabel() {
-        if (!this.created) this.dispatch('ElSelect', 'setSelected');
+        if (!this.created && !this.parent.remote) this.dispatch('ElSelect', 'setSelected');
       },
       value() {
-        if (!this.created) this.dispatch('ElSelect', 'setSelected');
+        if (!this.created && !this.parent.remote) this.dispatch('ElSelect', 'setSelected');
       }
     },
 


### PR DESCRIPTION
Select component with remote search clears what you typed when the value for each el-option is an object [#3728](https://github.com/ElemeFE/element/issues/3728)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
