### PR TITLE
Tooltip: add tips to docs, fixed #3894

### DIFF
--- a/examples/docs/en-US/tooltip.md
+++ b/examples/docs/en-US/tooltip.md
@@ -192,6 +192,8 @@ In fact, Tooltip is an extension based on [Vue-popper](https://github.com/elemen
 
 :::tip
 The `router-link` component is not supported in tooltip, please use `vm.$router.push`.
+
+Disabled form elements are not supported in tooltip, see more information at [MDN](https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter), please wrap disabled form elements.
 :::
 
 

--- a/examples/docs/zh-CN/tooltip.md
+++ b/examples/docs/zh-CN/tooltip.md
@@ -195,6 +195,8 @@ Tooltip 组件提供了两个不同的主题：`dark`和`light`。
 
 :::tip
 tooltip 内不支持 `router-link` 组件，请使用 `vm.$router.push` 代替。
+
+tooltip 内不支持 disabled form 元素，参考[MDN](https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter)，请在 disabled form 元素外层添加一层包裹元素。
 :::
 
 ### Attributes


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

- tooltip内部的form元素为disabled时，只有火狐会触发mouseenter事件（ https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter ）；
- 而el-button最外层的标签就是button，所以会有这个问题。el-input最外层不是input所以没问题；
- 这么改也不知道会不会触发其他问题，或者不改代码在文档处加个提示？


参考#3894
