### PR TITLE
当table组件同时设置border和stripe属性时，linux系统FF浏览器border显示不全

### DIFF
--- a/packages/theme-default/src/table.css
+++ b/packages/theme-default/src/table.css
@@ -361,6 +361,7 @@
         & tr:nth-child(2n) {
           td {
             background: #FAFAFA;
+            background-clip: padding-box;
           }
 
           &.current-row td {
@@ -416,6 +417,7 @@
     @modifier enable-row-hover {
       .el-table__body tr:hover > td {
         background-color: var(--color-extra-light-gray);
+        background-clip: padding-box;
       }
     }
 


### PR DESCRIPTION
当table组件同时设置border和stripe属性时，linux系统FF浏览器border显示不全.
解决办法是 修改td的背景裁剪规则。

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
