### PR TITLE
Tabs: update on resize, fixed (#3890)

### DIFF
--- a/packages/tabs/src/tab-nav.vue
+++ b/packages/tabs/src/tab-nav.vue
@@ -1,5 +1,6 @@
 <script>
   import TabBar from './tab-bar';
+  import { addResizeListener, removeResizeListener } from 'element-ui/src/utils/resize-event';
 
   function noop() {}
 
@@ -90,26 +91,31 @@
       },
       setOffset(value) {
         this.navStyle.transform = `translateX(-${value}px)`;
+      },
+      update() {
+        const navWidth = this.$refs.nav.offsetWidth;
+        const containerWidth = this.$refs.navScroll.offsetWidth;
+        const currentOffset = this.getCurrentScrollOffset();
+
+        if (containerWidth < navWidth) {
+          const currentOffset = this.getCurrentScrollOffset();
+          this.scrollable = this.scrollable || {};
+          this.scrollable.prev = currentOffset;
+          this.scrollable.next = currentOffset + containerWidth < navWidth;
+          if (navWidth - currentOffset < containerWidth) {
+            this.setOffset(navWidth - containerWidth);
+          }
+        } else {
+          this.scrollable = false;
+          if (currentOffset > 0) {
+            this.setOffset(0);
+          }
+        }
       }
     },
 
     updated() {
-      const navWidth = this.$refs.nav.offsetWidth;
-      const containerWidth = this.$refs.navScroll.offsetWidth;
-      const currentOffset = this.getCurrentScrollOffset();
-
-      if (containerWidth < navWidth) {
-        const currentOffset = this.getCurrentScrollOffset();
-        this.scrollable = this.scrollable || {};
-        this.scrollable.prev = currentOffset;
-        this.scrollable.next = currentOffset + containerWidth < navWidth;
-        if (navWidth - currentOffset < containerWidth) {
-          this.setOffset(navWidth - containerWidth);
-        }
-      } else if (currentOffset > 0) {
-        this.scrollable = false;
-        this.setOffset(0);
-      }
+      this.update();
     },
 
     render(h) {
@@ -170,6 +176,14 @@
           </div>
         </div>
       );
+    },
+
+    mounted() {
+      addResizeListener(this.$el, this.update);
+    },
+
+    destroyed() {
+      if (this.$el && this.update) removeResizeListener(this.$el, this.update);
     }
   };
 </script>

--- a/packages/tabs/src/tab-nav.vue
+++ b/packages/tabs/src/tab-nav.vue
@@ -182,7 +182,7 @@
       addResizeListener(this.$el, this.update);
     },
 
-    destroyed() {
+    beforeDestroy() {
       if (this.$el && this.update) removeResizeListener(this.$el, this.update);
     }
   };


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

最新的dev分支已经在 remove tab 时处理了显示逻辑， #3811 
然而还是做了两个微小的工作
- 组件resize时更新状态
- 在`currentOffset === 0`也隐藏箭头，因为用户有可能在有箭头时按左箭头使得`currentOffset === 0`

参考 #3890 
