### PR TITLE
Ensure inner el-upload uses name attribute

### DIFF
--- a/packages/upload/src/upload.vue
+++ b/packages/upload/src/upload.vue
@@ -56,7 +56,6 @@ export default {
 
       if (!files) return;
       this.uploadFiles(files);
-      this.$refs.input.value = null;
     },
     uploadFiles(files) {
       let postFiles = Array.prototype.slice.call(files);
@@ -120,6 +119,7 @@ export default {
     let {
       handleClick,
       drag,
+      name,
       handleChange,
       multiple,
       accept,
@@ -142,7 +142,7 @@ export default {
           ? <upload-dragger on-file={uploadFiles}>{this.$slots.default}</upload-dragger>
           : this.$slots.default
         }
-        <input class="el-upload__input" type="file" ref="input" on-change={handleChange} multiple={multiple} accept={accept}></input>
+        <input class="el-upload__input" type="file" ref="input" name={name} on-change={handleChange} multiple={multiple} accept={accept}></input>
       </div>
     );
   }


### PR DESCRIPTION
Without the name or id property the form field cannot be submitted as a regular non-xhr ajax request. I've opted for adding just the name attribute.

The only issue I see with this is that the `handleChange` event will not be called again if a user selects the same file (since path / name is unchanged).

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
