### PR TITLE
TableBody: Tooltip used but not imported.

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -6,7 +6,7 @@ import debounce from 'throttle-debounce/debounce';
 export default {
   components: {
     ElCheckbox,
-    'el-tooltip': ElTooltip
+    ElTooltip
   },
 
   props: {

--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -1,10 +1,12 @@
 import { getCell, getColumnByCell, getRowIdentity } from './util';
 import ElCheckbox from 'element-ui/packages/checkbox';
+import ElTooltip from 'element-ui/packages/tooltip';
 import debounce from 'throttle-debounce/debounce';
 
 export default {
   components: {
-    ElCheckbox
+    ElCheckbox,
+    'el-tooltip': ElTooltip
   },
 
   props: {


### PR DESCRIPTION
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

TableBody uses el-tooltip but does not import the component.