### PR TITLE
DatePicker: Fix repository url

### DIFF
--- a/packages/date-picker/package.json
+++ b/packages/date-picker/package.json
@@ -8,7 +8,7 @@
     "component"
   ],
   "main": "./lib/index.js",
-  "repository": "https://github.com/ElemeFE/element/tree/master/packages/datepicker",
+  "repository": "https://github.com/ElemeFE/element/tree/master/packages/date-picker",
   "author": "long.zhang@ele.me",
   "license": "MIT",
   "dependencies": {}


### PR DESCRIPTION
The repository url for [the npm package `element-datepicker`](https://www.npmjs.com/package/element-datepicker) points to a non-existing page. Missing `-` between `date` and `picker`. Small fix.