### PR TITLE
Dialog: Fix documentation errors

### DIFF
--- a/examples/docs/en-US/dialog.md
+++ b/examples/docs/en-US/dialog.md
@@ -84,7 +84,7 @@ The content of Dialog can be anything, even a table or a form. This example show
 
 ```html
 <!-- Table -->
-<el-button type="text" @click="dialogTableVisible = true" type="text">open a Table nested Dialog</el-button>
+<el-button type="text" @click="dialogTableVisible = true">open a Table nested Dialog</el-button>
 
 <el-dialog title="Shipping address" v-model="dialogTableVisible">
   <el-table :data="gridData">
@@ -95,7 +95,7 @@ The content of Dialog can be anything, even a table or a form. This example show
 </el-dialog>
 
 <!-- Form -->
-<el-button type="text" @click="dialogFormVisible = true" type="text">open a Form nested Dialog</el-button>
+<el-button type="text" @click="dialogFormVisible = true">open a Form nested Dialog</el-button>
 
 <el-dialog title="Shipping address" v-model="dialogFormVisible">
   <el-form :model="form">
@@ -180,7 +180,7 @@ The content of Dialog can be anything, even a table or a form. This example show
 | footer | content of the Dialog footer |
 
 ### Methods
-Each `el-dialog` instance has the following methods that can be used to open/close the instance without explicitly changing the value of `v-model`: 
+Each `el-dialog` instance has the following methods that can be used to open/close the instance without explicitly changing the value of `v-model`:
 
 | Method | Description |
 |------|--------|


### PR DESCRIPTION
`<el-button>`s for the Dialog component examples in the [documentation ](http://element.eleme.io/#/en-US/component/dialog#customizations)had repeated `text` attributes.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
