### PR TITLE
Table: manage tooltip state better, fixed #4044

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -216,12 +216,17 @@ export default {
         tooltip.referenceElm = cell;
         tooltip.$refs.popper.style.display = 'none';
         tooltip.doDestroy();
+        tooltip.setExpectedState(true);
         this.activateTooltip(tooltip);
       }
     },
 
     handleCellMouseLeave(event) {
-      this.$refs.tooltip && this.$refs.tooltip.handleClosePopper();
+      const tooltip = this.$refs.tooltip;
+      if (tooltip) {
+        tooltip.setExpectedState(false);
+        tooltip.handleClosePopper();
+      }
       const cell = getCell(event);
       if (!cell) return;
 

--- a/packages/tooltip/src/main.js
+++ b/packages/tooltip/src/main.js
@@ -58,8 +58,8 @@ export default {
           name={ this.transition }
           onAfterLeave={ this.doDestroy }>
           <div
-            onMouseleave={ () => { this.debounceClose(); this.togglePreventClose(); } }
-            onMouseenter= { this.togglePreventClose }
+            onMouseleave={ () => { this.setExpectedState(false); this.debounceClose(); } }
+            onMouseenter= { () => { this.setExpectedState(true); } }
             ref="popper"
             v-show={!this.disabled && this.showPopper}
             class={
@@ -77,8 +77,8 @@ export default {
     const data = vnode.data = vnode.data || {};
     const on = vnode.data.on = vnode.data.on || {};
 
-    on.mouseenter = this.addEventHandle(on.mouseenter, this.handleShowPopper);
-    on.mouseleave = this.addEventHandle(on.mouseleave, this.debounceClose);
+    on.mouseenter = this.addEventHandle(on.mouseenter, () => { this.setExpectedState(true); this.handleShowPopper(); });
+    on.mouseleave = this.addEventHandle(on.mouseleave, () => { this.setExpectedState(false); this.debounceClose(); });
     data.staticClass = this.concatClass(data.staticClass, 'el-tooltip');
 
     return vnode;
@@ -99,7 +99,7 @@ export default {
     },
 
     handleShowPopper() {
-      if (this.manual) return;
+      if (!this.expectedState || this.manual) return;
       clearTimeout(this.timeout);
       this.timeout = setTimeout(() => {
         this.showPopper = true;
@@ -107,13 +107,13 @@ export default {
     },
 
     handleClosePopper() {
-      if (this.preventClose || this.manual) return;
+      if (this.expectedState || this.manual) return;
       clearTimeout(this.timeout);
       this.showPopper = false;
     },
 
-    togglePreventClose() {
-      this.preventClose = !this.preventClose;
+    setExpectedState(expectedState) {
+      this.expectedState = expectedState;
     }
   }
 };


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

- 修复 Tooltip 组件现有的问题：在文档示例上将鼠标从 Tooltip 快速移动回 button 上，Tooltip 会消失。
- Tooltip 组件中 `togglePreventClose` 方法存在的意义为 `handleClosePopper` 是异步的，而在 Table 组件中 `handleShowPopper` 是异步的，因此势必要添加 `togglePreventShow` 方法，但这样一来代码会很乱，因此用 `setExpectedState` 来设置期望的状态。
- 除了 Table 组件，Slide 组件也用到了 Tooltip， 但是没有用到 `handleShowPopper` 和 `handleClosePopper` 方法，因此应该不会有影响。

参考 #4044 
