### PR TITLE
table: setwidth for each td>div.cell.el-tooltip element(#2198,#3128)

### DIFF
--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -288,7 +288,7 @@ export default {
       }
 
       return _self.showOverflowTooltip || _self.showTooltipWhenOverflow
-        ? <div class="cell el-tooltip">{ renderCell(h, data) }</div>
+        ? <div class="cell el-tooltip" style={'width:' + (data.column.realWidth || data.column.width) + 'px'}>{ renderCell(h, data) }</div>
         : <div class="cell">{ renderCell(h, data) }</div>;
     };
   },

--- a/packages/theme-default/src/table.css
+++ b/packages/theme-default/src/table.css
@@ -40,6 +40,7 @@
 
     .el-tooltip.cell {
       white-space: nowrap;
+      min-width: 50px;
     }
 
     @e empty-block {


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

对设置了 `show-overflow-tooltip` 属性的元素强制设置宽度
解决 table 组件 `show-overflow-tooltip` 在 Safari 上无效的问题
#2198,#3128
