### PR TITLE
Quickstart.md: Fixed missing component imports in the Quickstart exam…

### DIFF
--- a/examples/docs/en-US/quickstart.md
+++ b/examples/docs/en-US/quickstart.md
@@ -258,7 +258,10 @@ import {
   Collapse,
   CollapseItem,
   Cascader,
-  ColorPicker
+  ColorPicker,
+  Loading,
+  MessageBox,
+  Message
 } from 'element-ui'
 
 Vue.use(Pagination)

--- a/examples/docs/zh-CN/quickstart.md
+++ b/examples/docs/zh-CN/quickstart.md
@@ -258,7 +258,10 @@ import {
   Collapse,
   CollapseItem,
   Cascader,
-  ColorPicker
+  ColorPicker,
+  Loading,
+  MessageBox,
+  Message
 } from 'element-ui'
 
 Vue.use(Pagination)


### PR DESCRIPTION
Fixed the missing component imports in the Quick Start example page (http://element.eleme.io/#/en-US/component/quickstart), without them the client page gets js errors that prevent vue components from loading.
