### PR TITLE
Upload: fix uploader can't disable

### DIFF
--- a/packages/upload/src/upload.vue
+++ b/packages/upload/src/upload.vue
@@ -135,12 +135,19 @@ export default {
     const data = {
       class: {
         'el-upload': true
-      },
-      on: {
-        click: handleClick
       }
     };
     data.class[`el-upload--${listType}`] = true;
+    if (drag) {
+      data.on = {
+        click: handleClick
+      };
+    } else {
+      this.$slots.default.forEach(comp => {
+        comp.data.on || (comp.data.on = {});
+        comp.data.on.click = handleClick;
+      });
+    }
     return (
       <div {...data}>
         {


### PR DESCRIPTION
Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.


The upload component attched the clickHandler to the parent el so the disabled button can't work properly. This commit fixed this by add clickHanlder on slot.

A more elegant way to disable the uploader is adding disable prop to the uploader, but that may be an another feature request.
