### PR TITLE
DatePicker: When "format" prop of DateTimePicker doesn't include "ss" for seconds, user doesn't need to choose seconds

### DIFF
--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -41,7 +41,8 @@
                 :date="date"
                 :picker-width="pickerWidth"
                 @pick="handleTimePick"
-                :visible="timePickerVisible">
+                :visible="timePickerVisible"
+                @mounted="$refs.timepicker.format=timeFormat">
               </time-picker>
             </span>
           </div>
@@ -371,7 +372,8 @@
         week: null,
         showWeekNumber: false,
         timePickerVisible: false,
-        width: 0
+        width: 0,
+        format: ''
       };
     },
 
@@ -382,12 +384,12 @@
 
       visibleTime: {
         get() {
-          return formatDate(this.date, 'HH:mm:ss');
+          return formatDate(this.date, this.timeFormat);
         },
 
         set(val) {
           if (val) {
-            const date = parseDate(val, 'HH:mm:ss');
+            const date = parseDate(val, this.timeFormat);
             if (date) {
               date.setFullYear(this.date.getFullYear());
               date.setMonth(this.date.getMonth());
@@ -433,6 +435,14 @@
           return startYear + ' - ' + (startYear + 9);
         }
         return this.year + ' ' + yearTranslation;
+      },
+
+      timeFormat() {
+        if (this.format && this.format.indexOf('ss') === -1) {
+          return 'HH:mm';
+        } else {
+          return 'HH:mm:ss';
+        }
       }
     }
   };

--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -441,7 +441,7 @@
         if (this.format && this.format.indexOf('ss') === -1) {
           return 'HH:mm';
         } else {
-          return 'HH:mm:ss333';
+          return 'HH:mm:ss';
         }
       }
     }

--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -441,7 +441,7 @@
         if (this.format && this.format.indexOf('ss') === -1) {
           return 'HH:mm';
         } else {
-          return 'HH:mm:ss';
+          return 'HH:mm:ss333';
         }
       }
     }

--- a/packages/date-picker/src/panel/time.vue
+++ b/packages/date-picker/src/panel/time.vue
@@ -151,6 +151,7 @@
 
     mounted() {
       this.$nextTick(() => this.handleConfirm(true, true));
+      this.$emit('mounted');
     }
   };
 </script>


### PR DESCRIPTION
[Impovement]
Currently, user has to choose seconds even "format" prop of DateTimePicker doesn't include "ss". It is strange that when user click confirm button, seconds doesn't show on the input.

This PR intends to hide the seconds column in the time spinner by passing timeFormat to timePicker.

[jsfiddle](https://jsfiddle.net/wgmnpqwc/)

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
