### PR TITLE
Update vue-i18n@6x support

### DIFF
--- a/examples/docs/en-US/i18n.md
+++ b/examples/docs/en-US/i18n.md
@@ -102,7 +102,7 @@ const i18n = new VueI18n({
 })
 
 Vue.use(Element, {
-  i18n: key => i18n.vm._t(key)
+  i18n: key => i18n.t(key)
 })
 
 new Vue({ i18n }).$mount('#app')


### PR DESCRIPTION
i18n returns renderSlot (vm._t) function instead i18n.t
https://kazupon.github.io/vue-i18n/en/api.html
