### PR TITLE
DatePicker: fix, add test for default-value

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -354,7 +354,7 @@ export default {
     handleClickIcon() {
       if (this.readonly || this.disabled) return;
       if (this.showClose) {
-        this.currentValue = '';
+        this.currentValue = this.$options.defaultValue || '';
         this.showClose = false;
       } else {
         this.pickerVisible = !this.pickerVisible;
@@ -431,7 +431,7 @@ export default {
     },
 
     mountPicker() {
-      this.panel.defaultValue = this.currentValue;
+      this.panel.defaultValue = this.defaultValue || this.currentValue;
       this.picker = new Vue(this.panel).$mount();
       this.picker.popperClass = this.popperClass;
       this.popperElm = this.picker.$el;

--- a/test/unit/specs/date-picker.spec.js
+++ b/test/unit/specs/date-picker.spec.js
@@ -202,6 +202,44 @@ describe('DatePicker', () => {
     }, DELAY);
   });
 
+  it('default value', done => {
+    const toDateStr = date => {
+      let d = new Date(date);
+      return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+    };
+    let today = new Date();
+    let nextMonth = new Date(today);
+    nextMonth.setDate(1);
+    if (nextMonth.getMonth() === 12) {
+      nextMonth.setFullYear(today.getFullYear + 1);
+      nextMonth.setMonth(1);
+    } else {
+      nextMonth.setMonth(today.getMonth() + 1);
+    }
+    let nextMonthStr = toDateStr(nextMonth);
+
+    vm = createVue({
+      template: `<el-date-picker v-model="value" ref="compo" default-value="${nextMonthStr}" />`,
+      data() {
+        return {
+          value: ''
+        };
+      }
+    }, true);
+
+    const input = vm.$el.querySelector('input');
+
+    input.focus();
+    setTimeout(_ => {
+      const $el = vm.$refs.compo.picker.$el;
+      $el.querySelector('td.current').click();
+      setTimeout(_ => {
+        expect(vm.value).to.equal(nextMonthStr);
+      });
+      done();
+    });
+  });
+
   describe('keydown', () => {
     let input;
     let keyDown = function(el, keyCode) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

#### 做了什么
* 修复 DatePicker 的 default-value
* 增加 default-value 的测试脚本

导致default-value失效的commit ：https://github.com/ElemeFE/element/commit/4243920a176aa3e8780a5863c4a4cc00fcb91e50?diff=unified#diff-64b9be7ffdb5a45b56e51e091d251ce6R434

`this.panel.defaultValue` 未传递 `this.defaultValue`（DatePicker组件的`default-value`属性）

#### Demo
https://jsfiddle.net/wacky6/e07oh2om/