### PR TITLE
ColorPicker: empty value by v-model, fix #4662

### DIFF
--- a/packages/color-picker/src/main.vue
+++ b/packages/color-picker/src/main.vue
@@ -59,7 +59,9 @@
 
     watch: {
       value(val) {
-        if (val && val !== this.color.value) {
+        if (!val) {
+          this.showPanelColor = false;
+        } else if (val && val !== this.color.value) {
           this.color.fromString(val);
         }
       },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

- when prop `value` change to a false value, `this.showPanelColor` should be `false`

see #4662 