### PR TITLE
Popup(Dialog|MessageBox): friendly for accessibility

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="dialog-fade">
-    <div class="el-dialog__wrapper" v-show="visible" @click.self="handleWrapperClick">
+    <div class="el-dialog__wrapper" tabindex="-1" v-show="visible" @click.self="handleWrapperClick">
       <div
         class="el-dialog"
         :class="[sizeClass, customClass]"
@@ -10,9 +10,10 @@
           <slot name="title">
             <span class="el-dialog__title">{{title}}</span>
           </slot>
-          <div class="el-dialog__headerbtn">
-            <i v-if="showClose" class="el-dialog__close el-icon el-icon-close" @click='handleClose'></i>
-          </div>
+          <button type="button" class="el-dialog__headerbtn" aria-label="Close" 
+                  v-if="showClose" @click="handleClose">
+            <i class="el-dialog__close el-icon el-icon-close"></i>
+          </button>
         </div>
         <div class="el-dialog__body" v-if="rendered"><slot></slot></div>
         <div class="el-dialog__footer" v-if="$slots.footer">

--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -1,10 +1,13 @@
 <template>
   <transition name="msgbox-fade">
-    <div class="el-message-box__wrapper" v-show="visible" @click.self="handleWrapperClick">
+    <div class="el-message-box__wrapper" tabindex="-1" v-show="visible" @click.self="handleWrapperClick">
       <div class="el-message-box" :class="customClass">
         <div class="el-message-box__header" v-if="title !== undefined">
           <div class="el-message-box__title">{{ title || t('el.messagebox.title') }}</div>
-          <i class="el-message-box__close el-icon-close" @click="handleAction('cancel')" v-if="showClose"></i>
+          <button type="button" class="el-message-box__headerbtn" aria-label="Close" 
+                  v-if="showClose" @click="handleAction('cancel')">
+            <i class="el-message-box__close el-icon-close"></i>
+          </button>
         </div>
         <div class="el-message-box__content" v-if="message !== ''">
           <div class="el-message-box__status" :class="[ typeClass ]"></div>

--- a/packages/theme-default/src/dialog.css
+++ b/packages/theme-default/src/dialog.css
@@ -44,12 +44,22 @@
       padding: 20px 20px 0;
     }
 
-    @e close {
+    @e headerbtn {
+      float: right;
+      background: transparent;
+      border: none;
+      outline: none;
+      padding: 0;
       cursor: pointer;
-      color: var(--dialog-close-color);
 
-      &:hover {
-        color: var(--dialog-close-hover-color);
+      .el-dialog__close {
+        color: var(--dialog-close-color);
+      }
+      
+      &:focus, &:hover {
+        .el-dialog__close {
+          color: var(--dialog-close-hover-color);
+        }
       }
     }
 
@@ -64,10 +74,6 @@
       padding: 30px 20px;
       color: var(--color-extra-light-black);
       font-size: var(--dialog-font-size);
-    }
-
-    @e headerbtn {
-      float: right;
     }
 
     @e footer {

--- a/packages/theme-default/src/message-box.css
+++ b/packages/theme-default/src/message-box.css
@@ -37,26 +37,33 @@
       padding: 20px 20px 0;
     }
 
+    @e headerbtn {
+      position: absolute;
+      top: 19px;
+      right: 20px;
+      background: transparent;
+      border: none;
+      outline: none;
+      padding: 0;
+      cursor: pointer;
+
+      .el-message-box__close {
+        color: #999;
+      }
+      
+      &:focus, &:hover {
+        .el-message-box__close {
+          color: var(--color-primary);
+        }
+      }
+
+    }
+
     @e content {
       padding: 30px 20px;
       color: var(--msgbox-content-color);
       font-size: var(--msgbox-content-font-size);
       position: relative;
-    }
-
-    @e close {
-      display: inline-block;
-      position: absolute;
-      top: 19px;
-      right: 20px;
-      color: #999;
-      cursor: pointer;
-      line-height: 20px;
-      text-align: center;
-
-      &:hover {
-        color: var(--color-primary);
-      }
     }
 
     @e input {


### PR DESCRIPTION
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

**What's the problem**

[Dialog](http://element.eleme.io/#/en-US/component/dialog) and [MessageBox](http://element.eleme.io/#/en-US/component/message-box) is unfriendly for accessibility
1. Popup header `close` icon can't be focused.
2. When the popup is shown, with key `tab` pressed, the focus jump outside the popup, and move around the total page.

**What did I do**

1. Surround the `close` icon with button, rewrite the style.
2. Add document listener for `focusin` event to prevent focus jump outside the popup with `tab` key.