### PR TITLE
[Popup] Fix popup-manager to call beforeClose() when closeOnClickModal

### DIFF
--- a/src/utils/popup/popup-manager.js
+++ b/src/utils/popup/popup-manager.js
@@ -62,7 +62,9 @@ const PopupManager = {
 
     const instance = PopupManager.getInstance(topItem.id);
     if (instance && instance.closeOnClickModal) {
-      instance.close();
+      instance.handleClose
+        ? instance.handleClose()
+        : (instance.handleAction ? instance.handleAction('cancel') : instance.close());
     }
   },
 


### PR DESCRIPTION
This is to fix a bug I've experienced since 1.3.0 where I can't close dialogs by clicking on the mask/background.

I don't know if this is the right approach, I just copied it from #4819 - the fix to call beforeClose() when closeOnPressEscape.

This might help the following issues: #4458, #4492, #4642, #4644, #4699, #4700, #4701, #4784
