### PR TITLE
Select: Blur non-filterable select to avoid keyboard on mobile like i…

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -421,6 +421,10 @@
 
       handleFocus() {
         this.visible = true;
+
+        if (!this.filterable && this.$refs.reference.$el) {
+          this.$refs.reference.$el.blur();
+        }
       },
 
       handleIconClick(event) {


### PR DESCRIPTION
Select: Blur non-filterable select to avoid keyboard on mobile like iOS or Firefox Mobile.

On mobile devices (iOS e.g. iPhone, Firefox Mobile), even if SELECT is not filterable, keyboard bar activates. This commit resolves this issue.


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
