### PR TITLE
Switch: 简化内部实现

### DIFF
--- a/packages/switch/src/component.vue
+++ b/packages/switch/src/component.vue
@@ -1,11 +1,11 @@
 <template>
-  <label class="el-switch" :class="{ 'is-disabled': disabled, 'el-switch--wide': hasText }">
+  <label class="el-switch" :class="{ 'is-disabled': disabled, 'el-switch--wide': hasText, 'is-checked': checked }">
     <div class="el-switch__mask" v-show="disabled"></div>
     <input
       class="el-switch__input"
       type="checkbox"
       @change="handleChange"
-      v-model="_value"
+      ref="input"
       :name="name"
       :true-value="onValue"
       :false-value="offValue"
@@ -105,20 +105,12 @@
         /* istanbul ignore next */
         return this.onText || this.offText;
       },
-      _value: {
-        get() {
-          return this.value;
-        },
-        set(val) {
-          this.$emit('input', val);
-        }
-      },
       transform() {
         return this.checked ? `translate(${ this.coreWidth - 20 }px, 2px)` : 'translate(2px, 2px)';
       }
     },
     watch: {
-      value() {
+      checked() {
         if (this.onColor || this.offColor) {
           this.setBackgroundColor();
         }
@@ -126,7 +118,13 @@
     },
     methods: {
       handleChange(event) {
-        this.$emit('change', event.currentTarget.checked ? this.onValue : this.offValue);
+        this.$emit('change', !this.checked ? this.onValue : this.offValue);
+        this.$emit('input', !this.checked ? this.onValue : this.offValue);
+        this.$nextTick(() => {
+          // set input's checked property
+          // in case parent refuses to change component's value
+          this.$refs.input.checked = this.checked;
+        });
       },
       setBackgroundColor() {
         let newColor = this.checked ? this.onColor : this.offColor;
@@ -142,6 +140,7 @@
       if (this.onColor || this.offColor) {
         this.setBackgroundColor();
       }
+      this.$refs.input.checked = this.checked;
     }
   };
 </script>

--- a/packages/theme-default/src/switch.css
+++ b/packages/theme-default/src/switch.css
@@ -49,10 +49,6 @@
 
     @e input {
       display: none;
-      &:checked + .el-switch__core {
-        border-color: var(--switch-on-color);
-        background-color: var(--switch-on-color);
-      }
     }
 
     @e core {
@@ -77,6 +73,13 @@
       }
     }
 
+    @when checked {
+      .el-switch__core {
+        border-color: var(--switch-on-color);
+        background-color: var(--switch-on-color);
+      }
+    }
+
     @when disabled {
       .el-switch__core {
         border-color: var(--switch-disabled-color) !important;
@@ -89,11 +92,6 @@
         & ~ .el-switch__label * {
           color: var(--switch-disabled-text-color) !important;
         }
-      }
-
-      .el-switch__input:checked + .el-switch__core {
-        border-color: var(--switch-disabled-color);
-        background-color: var(--switch-disabled-color);
       }
     }
 

--- a/test/unit/specs/switch.spec.js
+++ b/test/unit/specs/switch.spec.js
@@ -148,4 +148,31 @@ describe('Switch', () => {
       }, 10);
     }, 10);
   });
+
+  it('value is the single source of truth', done => {
+    vm = createVue({
+      template: `
+        <div>
+          <el-switch :value="true"></el-switch>
+        </div>
+      `
+    }, true);
+
+    const component = vm.$children[0];
+    const input = vm.$el.querySelector('input');
+    const core = vm.$el.querySelector('.el-switch__core');
+    core.click();
+    setTimeout(() => {
+      expect(component.checked).to.equal(true);
+      expect(component.$el.classList.contains('is-checked')).to.equal(true);
+      expect(input.checked).to.equal(true);
+      core.click();
+      setTimeout(() => {
+        expect(component.checked).to.equal(true);
+        expect(component.$el.classList.contains('is-checked')).to.equal(true);
+        expect(input.checked).to.equal(true);
+        done();
+      }, 10);
+    }, 10);
+  });
 });


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

#### 做了什么
简化 Switch 的实现，消除不必要的属性，使展示状态仅和 value 有关。
测试代码已包含。
修复Issue：https://github.com/ElemeFE/element/issues/4824

#### 需求：
开关操作发Ajax请求到后端，这个请求可能不能满足，此时Switch的值不变（外观不变）

#### Demo：
修正前：http://jsfiddle.net/pj9quogd/
修正后：http://jsfiddle.net/pj9quogd/2/

怎么测试：点击Switch
期望行为：Switch绑定的值为true，点击Switch后：外观、value、input的checked属性依旧为true