### PR TITLE
Select: remove clickoutside, fix #4985

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="el-autocomplete" v-clickoutside="handleClickoutside">
+  <div class="el-autocomplete">
     <el-input
       ref="input"
       :value="value"
@@ -36,7 +36,6 @@
 </template>
 <script>
   import ElInput from 'element-ui/packages/input';
-  import Clickoutside from 'element-ui/src/utils/clickoutside';
   import ElAutocompleteSuggestions from './autocomplete-suggestions.vue';
   import Emitter from 'element-ui/src/mixins/emitter';
 
@@ -51,8 +50,6 @@
       ElInput,
       ElAutocompleteSuggestions
     },
-
-    directives: { Clickoutside },
 
     props: {
       popperClass: String,
@@ -136,9 +133,6 @@
         if (this.suggestionVisible && this.highlightedIndex >= 0 && this.highlightedIndex < this.suggestions.length) {
           this.select(this.suggestions[this.highlightedIndex]);
         }
-      },
-      handleClickoutside() {
-        this.isFocus = false;
       },
       select(item) {
         this.$emit('input', item.value);

--- a/test/unit/specs/autocomplete.spec.js
+++ b/test/unit/specs/autocomplete.spec.js
@@ -1,4 +1,4 @@
-import { createVue, triggerClick, destroyVM } from '../util';
+import { createVue, destroyVM } from '../util';
 
 describe('Autocomplete', () => {
   let vm;
@@ -59,11 +59,11 @@ describe('Autocomplete', () => {
       expect(suggestions.style.display).to.not.equal('none');
       expect(suggestions.querySelectorAll('.el-autocomplete-suggestion__list li').length).to.be.equal(4);
 
-      triggerClick(document);
+      inputElm.blur();
       setTimeout(_ => {
         expect(suggestions.style.display).to.be.equal('none');
         done();
-      }, 500);
+      }, 600);
     }, 500);
   });
   it('select', done => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

- when select text with mouse, if event `mouseup` was triggered outside the component, `this.isFocus` would become `false`. And `this.suggestionVisible` would also become `false`
- maybe `clickoutside` was duplicated with `blur`? if not, close this.

see #4985 