### PR TITLE
Message: fix Message.close() bug

### DIFF
--- a/packages/message/src/main.js
+++ b/packages/message/src/main.js
@@ -52,6 +52,7 @@ Message.close = function(id, userOnClose) {
       if (typeof userOnClose === 'function') {
         userOnClose(instances[i]);
       }
+      instances[i].close();
       instances.splice(i, 1);
       break;
     }


### PR DESCRIPTION
直接将 instance 从 instances 中移除并不能正确关闭显示着的 Message。
需要在 instances.splice(i, 1); 前调用 instances[i].close();。