### PR TITLE
Cascader: Add `activeOptions` as `handleItemChange`'s second argument to make dynamic loading more friendly

### DIFF
--- a/examples/docs/en-US/cascader.md
+++ b/examples/docs/en-US/cascader.md
@@ -1413,16 +1413,16 @@ Load child options when their parent option is clicked or hovered over.
     },
 
     methods: {
-      handleItemChange(val) {
+      handleItemChange(val, options) {
         console.log('active item:', val);
+        console.log('active options:', options);
         setTimeout(_ => {
-          if (val.indexOf('California') > -1 && !this.options2[0].cities.length) {
-            this.options2[0].cities = [{
-              label: 'Los Angeles'
-            }];
-          } else if (val.indexOf('Florida') > -1 && !this.options2[1].cities.length) {
-            this.options2[1].cities = [{
-              label: 'Orlando'
+          const currentOption = options[options.length - 2];
+          if (!currentOption.cities.length) {
+            currentOption.cities = [{
+              label: 'City 1'
+            }, {
+              label: 'City 2'
             }];
           }
         }, 300);

--- a/examples/docs/zh-CN/cascader.md
+++ b/examples/docs/zh-CN/cascader.md
@@ -1413,16 +1413,16 @@
     },
 
     methods: {
-      handleItemChange(val) {
+      handleItemChange(val, options) {
         console.log('active item:', val);
+        console.log('active options:', options);
         setTimeout(_ => {
-          if (val.indexOf('江苏') > -1 && !this.options2[0].cities.length) {
-            this.options2[0].cities = [{
-              label: '南京'
-            }];
-          } else if (val.indexOf('浙江') > -1 && !this.options2[1].cities.length) {
-            this.options2[1].cities = [{
-              label: '杭州'
+          const currentOption = options[options.length - 2];
+          if (!currentOption.cities.length) {
+            currentOption.cities = [{
+              label: '城市1'
+            }, {
+              label: '城市2'
             }];
           }
         }, 300);

--- a/packages/cascader/src/menu.vue
+++ b/packages/cascader/src/menu.vue
@@ -90,7 +90,7 @@
         if (this.changeOnSelect) {
           this.$emit('pick', this.activeValue, false);
         } else {
-          this.$emit('activeItemChange', this.activeValue);
+          this.$emit('activeItemChange', this.activeValue, this.activeOptions);
         }
       }
     },


### PR DESCRIPTION
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

When dynamically loading child options in `Cascader` component, since all options is not an object but an array, we have to traverse all options to find current option we want, and then assign data to `cities` key, in this case.

http://element.eleme.io/#/en-US/component/cascader#dynamically-load-child-options

This PR adds `activeOptions` as second argument to `handleItemChange` callback in `Cascader` component, to make dynamic loading more friendly.