### PR TITLE
Select: fix default-first-option with async filter/remote

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -266,23 +266,7 @@
           this.broadcast('ElOptionGroup', 'queryChange');
         }
         if (this.defaultFirstOption && (this.filterable || this.remote) && this.filteredOptionsCount) {
-          this.hoverIndex = -1;
-          for (let i = 0; i !== this.options.length; ++i) {
-            const option = this.options[i];
-            if (val) {
-              // pick first options that passes the filter
-              if (!option.disabled && !option.groupDisabled && option.visible) {
-                this.hoverIndex = i;
-                break;
-              }
-            } else {
-              // pick currently selected option
-              if (option.itemSelected) {
-                this.hoverIndex = i;
-                break;
-              }
-            }
-          }
+          this.checkDefaultFirstOption();
         }
       },
 
@@ -345,6 +329,9 @@
         let inputs = this.$el.querySelectorAll('input');
         if ([].indexOf.call(inputs, document.activeElement) === -1) {
           this.setSelected();
+        }
+        if (this.defaultFirstOption && (this.filterable || this.remote) && this.filteredOptionsCount) {
+          this.checkDefaultFirstOption();
         }
       }
     },
@@ -651,6 +638,26 @@
       handleResize() {
         this.resetInputWidth();
         if (this.multiple) this.resetInputHeight();
+      },
+
+      checkDefaultFirstOption() {
+        this.hoverIndex = -1;
+        for (let i = 0; i !== this.options.length; ++i) {
+          const option = this.options[i];
+          if (this.query) {
+            // pick first options that passes the filter
+            if (!option.disabled && !option.groupDisabled && option.visible) {
+              this.hoverIndex = i;
+              break;
+            }
+          } else {
+            // pick currently selected option
+            if (option.itemSelected) {
+              this.hoverIndex = i;
+              break;
+            }
+          }
+        }
       }
     },
 

--- a/test/unit/specs/select.spec.js
+++ b/test/unit/specs/select.spec.js
@@ -426,6 +426,14 @@ describe('Select', () => {
           options: ['1', '2', '3', '4', '5'],
           value: ''
         };
+      },
+      methods: {
+        filterMethod(query) {
+          // simulate async filterMethod / remoteMethod
+          setTimeout(() => {
+            this.options.filter(option => option.label.indexOf(query) !== -1);
+          }, 5);
+        }
       }
     }, true);
 
@@ -443,7 +451,7 @@ describe('Select', () => {
           expect(select.value).to.equal('3');
           done();
         }, 10);
-      }, 10);
+      }, 10);  // wait for async filterMethod
     }, 10);
   });
 


### PR DESCRIPTION
fix https://github.com/ElemeFE/element/issues/5063

make default-first-option work with async filter/remote method
test is updated to reflect this change

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
