### PR TITLE
Dialog:  componentize it to provide common methods like MessageBox

### DIFF
--- a/build/bin/new.js
+++ b/build/bin/new.js
@@ -119,7 +119,7 @@ Files.forEach(file => {
 const navConfigFile = require('../../examples/nav.config.json');
 
 Object.keys(navConfigFile).forEach(lang => {
-  let groups = navConfigFile[lang][2].groups;
+  let groups = navConfigFile[lang][3].groups;
   groups[groups.length - 1].list.push({
     path: `/${componentname}`,
     title: lang === 'zh-CN' && componentname !== chineseName

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="el-autocomplete" v-clickoutside="handleClickoutside">
+  <div class="el-autocomplete">
     <el-input
       ref="input"
       :value="value"
@@ -36,7 +36,6 @@
 </template>
 <script>
   import ElInput from 'element-ui/packages/input';
-  import Clickoutside from 'element-ui/src/utils/clickoutside';
   import ElAutocompleteSuggestions from './autocomplete-suggestions.vue';
   import Emitter from 'element-ui/src/mixins/emitter';
 
@@ -51,8 +50,6 @@
       ElInput,
       ElAutocompleteSuggestions
     },
-
-    directives: { Clickoutside },
 
     props: {
       popperClass: String,
@@ -136,9 +133,6 @@
         if (this.suggestionVisible && this.highlightedIndex >= 0 && this.highlightedIndex < this.suggestions.length) {
           this.select(this.suggestions[this.highlightedIndex]);
         }
-      },
-      handleClickoutside() {
-        this.isFocus = false;
       },
       select(item) {
         this.$emit('input', item.value);

--- a/packages/carousel/src/main.vue
+++ b/packages/carousel/src/main.vue
@@ -109,6 +109,10 @@ export default {
     activeIndex(val, oldVal) {
       this.resetItemPosition();
       this.$emit('change', val, oldVal);
+    },
+
+    autoplay(val) {
+      val ? this.startTimer() : this.pauseTimer();
     }
   },
 

--- a/packages/theme-default/src/button.css
+++ b/packages/theme-default/src/button.css
@@ -10,6 +10,7 @@
     cursor: pointer;
     background: var(--button-default-fill);
     border: var(--border-base);
+    border-color: var(--button-default-border);
     color: var(--button-default-color);
     -webkit-appearance: none;
     text-align: center;

--- a/src/locale/lang/pt-br.js
+++ b/src/locale/lang/pt-br.js
@@ -67,7 +67,7 @@ export default {
     },
     pagination: {
       goto: 'Ir para',
-      pagesize: '/pagina',
+      pagesize: '/página',
       total: 'Total {total}',
       pageClassifier: ''
     },
@@ -87,7 +87,7 @@ export default {
       confirmFilter: 'Confirmar',
       resetFilter: 'Limpar',
       clearFilter: 'Todos',
-      sumText: 'Sum' // to be translated
+      sumText: 'Total'
     },
     tree: {
       emptyText: 'Sem dados'
@@ -95,10 +95,10 @@ export default {
     transfer: {
       noMatch: 'Sem resultados',
       noData: 'Sem dados',
-      titles: ['List 1', 'List 2'], // to be translated
-      filterPlaceholder: 'Enter keyword', // to be translated
-      noCheckedFormat: '{total} items', // to be translated
-      hasCheckedFormat: '{checked}/{total} checked' // to be translated
+      titles: ['Lista 1', 'Lista 2'],
+      filterPlaceholder: 'Digite uma palavra-chave',
+      noCheckedFormat: '{total} itens',
+      hasCheckedFormat: '{checked}/{total} selecionados'
     }
   }
 };

--- a/src/locale/lang/ta.js
+++ b/src/locale/lang/ta.js
@@ -1,0 +1,103 @@
+export default {
+  el: {
+    colorpicker: {
+      confirm: 'உறுதி செய்',
+      clear: 'தெளிவாக்கு'
+    },
+    datepicker: {
+      now: 'தற்போது',
+      today: 'இன்று',
+      cancel: 'ரத்து செய்',
+      clear: 'சரி',
+      confirm: 'உறுதி செய்',
+      selectDate: 'தேதியை தேர்வு செய்',
+      selectTime: 'நேரத்தை தேர்வு செய்',
+      startDate: 'தொடங்கும் நாள்',
+      startTime: 'தொடங்கும் நேரம்',
+      endDate: 'முடியும் தேதி',
+      endTime: 'முடியும் நேரம்',
+      year: 'வருடம்',
+      month1: 'ஜனவரி',
+      month2: 'பிப்ரவரி',
+      month3: 'மார்ச்',
+      month4: 'ஏப்ரல்',
+      month5: 'மே',
+      month6: 'ஜூன்',
+      month7: 'ஜூலை',
+      month8: 'ஆகஸ்ட்',
+      month9: 'செப்டம்பர்',
+      month10: 'அக்டோபர்',
+      month11: 'நவம்பர்',
+      month12: 'டிசம்பர்',
+      weeks: {
+        sun: 'ஞாயிறு',
+        mon: 'திங்கள்',
+        tue: 'செவ்வாய்',
+        wed: 'புதன்',
+        thu: 'வியாழன்',
+        fri: 'வெள்ளி',
+        sat: 'சனி'
+      },
+      months: {
+        jan: 'ஜனவரி',
+        feb: 'பிப்ரவரி',
+        mar: 'மார்ச்',
+        apr: 'ஏப்ரல்',
+        may: 'மே',
+        jun: 'ஜூன்',
+        jul: 'ஜூலை',
+        aug: 'ஆகஸ்ட்',
+        sep: 'செப்டம்பர்',
+        oct: 'அக்டோபர்',
+        nov: 'நவம்பர்',
+        dec: 'டிசம்பர்'
+      }
+    },
+    select: {
+      loading: 'தயாராகிக்கொண்டிருக்கிறது',
+      noMatch: 'பொருத்தமான தரவு கிடைக்கவில்லை',
+      noData: 'தரவு இல்லை',
+      placeholder: 'தேர்வு செய்'
+    },
+    cascader: {
+      noMatch: 'பொருத்தமான தரவு கிடைக்கவில்லை',
+      loading: 'தயாராகிக்கொண்டிருக்கிறது',
+      placeholder: 'தேர்வு செய்'
+    },
+    pagination: {
+      goto: 'தேவையான் பகுதிக்கு செல்',
+      pagesize: '/page',
+      total: 'மொத்தம் {total}',
+      pageClassifier: ''
+    },
+    messagebox: {
+      title: 'செய்தி',
+      confirm: 'உறுதி செய்',
+      cancel: 'ரத்து செய்',
+      error: 'பொருத்தாமில்லாத உள்ளீடு'
+    },
+    upload: {
+      delete: 'நீக்கு',
+      preview: 'முன்னோட்டம் பார்',
+      continue: 'தொடரு'
+    },
+    table: {
+      emptyText: 'தரவு இல்லை',
+      confirmFilter: 'உறுதி செய்',
+      resetFilter: 'புதுமாற்றம் செய்',
+      clearFilter: 'அனைத்தும்',
+      sumText: 'கூட்டு'
+    },
+    tree: {
+      emptyText: 'தரவு இல்லை'
+    },
+    transfer: {
+      noMatch: 'பொருத்தமான தரவு கிடைக்கவில்லை',
+      noData: 'தரவு இல்லை',
+      titles: ['பட்டியல் 1', 'பட்டியல் 2'],
+      filterPlaceholder: 'சொல்லை உள்ளீடு செய்',
+      noCheckedFormat: '{மொத்தம்} items',
+      hasCheckedFormat: '{தேர்வு செய்யப்பட்டவைகள்}/{மொத்தம்} தேர்வு செய்யப்பட்டவைகள்'
+    }
+  }
+};

--- a/test/unit/specs/autocomplete.spec.js
+++ b/test/unit/specs/autocomplete.spec.js
@@ -1,4 +1,4 @@
-import { createVue, triggerClick, destroyVM } from '../util';
+import { createVue, destroyVM } from '../util';
 
 describe('Autocomplete', () => {
   let vm;
@@ -59,11 +59,11 @@ describe('Autocomplete', () => {
       expect(suggestions.style.display).to.not.equal('none');
       expect(suggestions.querySelectorAll('.el-autocomplete-suggestion__list li').length).to.be.equal(4);
 
-      triggerClick(document);
+      inputElm.blur();
       setTimeout(_ => {
         expect(suggestions.style.display).to.be.equal('none');
         done();
-      }, 500);
+      }, 600);
     }, 500);
   });
   it('select', done => {


### PR DESCRIPTION
We need to dynamically make an instance of Dialog, but we don't want to bind the dialog with a tag in the template. So we need a dialog component like Messagebox, a dialog that can be open by $dialog/$modal like $msgbox, especially when a new dialog is generated by click some elements in an opened dialog. There can be a queue of dialogs. 

Although Messagebox to some extend meets this requirement, but its footer buttons (Confirm and Cancel) can not be removed like the slotted footer in the Dialog.  We need customized buttons, buttons more than confirm and cancel. 
