### PR TITLE
Dialog: fix nested popover cannot gain focus

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="dialog-fade">
-    <div class="el-dialog__wrapper" tabindex="-1" v-show="visible" @click.self="handleWrapperClick">
+    <div class="el-dialog__wrapper" v-show="visible" @click.self="handleWrapperClick">
       <div
         class="el-dialog"
         :class="[sizeClass, customClass]"

--- a/src/utils/popup/popup-manager.js
+++ b/src/utils/popup/popup-manager.js
@@ -174,16 +174,6 @@ if (!Vue.prototype.$isServer) {
       }
     }
   });
-
-  // keep focusing inside the popup by `tab` key
-  document.addEventListener('focusin', function(event) {
-    const topPopup = getTopPopup();
-
-    if (topPopup && !topPopup.$el.contains(event.target)) {
-      event.stopPropagation();
-      topPopup.$el.focus();
-    }
-  });
 }
 
 export default PopupManager;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

#5322
原因是 #4786 的改动造成在 Dialog 打开时，非 Dialog 子元素的元素无法获取焦点。造成问题的代码是为了
> When the popup is shown, with key tab pressed, the focus jump outside the popup, and move around the total page.

现在撤回这部分代码。
