### PR TITLE
Table:fix table support for IE9

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -1,5 +1,5 @@
 import { getCell, getColumnByCell, getRowIdentity } from './util';
-import { hasClass } from 'element-ui/src/utils/dom';
+import { hasClass, addClass, removeClass } from 'element-ui/src/utils/dom';
 import ElCheckbox from 'element-ui/packages/checkbox';
 import ElTooltip from 'element-ui/packages/tooltip';
 import debounce from 'throttle-debounce/debounce';
@@ -98,10 +98,10 @@ export default {
       const oldRow = rows[oldVal];
       const newRow = rows[newVal];
       if (oldRow) {
-        oldRow.classList.remove('hover-row');
+        removeClass(oldRow, 'hover-row');
       }
       if (newRow) {
-        newRow.classList.add('hover-row');
+        addClass(newRow, 'hover-row');
       }
     },
     'store.states.currentRow'(newVal, oldVal) {
@@ -113,12 +113,12 @@ export default {
       const oldRow = rows[data.indexOf(oldVal)];
       const newRow = rows[data.indexOf(newVal)];
       if (oldRow) {
-        oldRow.classList.remove('current-row');
+        removeClass(oldRow, 'current-row');
       } else if (rows) {
-        [].forEach.call(rows, row => row.classList.remove('current-row'));
+        [].forEach.call(rows, row => removeClass(row, 'current-row'));
       }
       if (newRow) {
-        newRow.classList.add('current-row');
+        addClass(newRow, 'current-row');
       }
     }
   },

--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -1,3 +1,4 @@
+import { hasClass, addClass, removeClass } from 'element-ui/src/utils/dom';
 import ElCheckbox from 'element-ui/packages/checkbox';
 import ElTag from 'element-ui/packages/tag';
 import Vue from 'vue';
@@ -295,7 +296,7 @@ export default {
         const columnRect = columnEl.getBoundingClientRect();
         const minLeft = columnRect.left - tableLeft + 30;
 
-        columnEl.classList.add('noclick');
+        addClass(columnEl, 'noclick');
 
         this.dragState = {
           startMouseLeft: event.clientX,
@@ -344,7 +345,7 @@ export default {
           document.ondragstart = null;
 
           setTimeout(function() {
-            columnEl.classList.remove('noclick');
+            removeClass(columnEl, 'noclick');
           }, 0);
         };
 
@@ -395,8 +396,8 @@ export default {
       }
 
       if (target && target.tagName === 'TH') {
-        if (target.classList.contains('noclick')) {
-          target.classList.remove('noclick');
+        if (hasClass(target, 'noclick')) {
+          removeClass(target, 'noclick');
           return;
         }
       }


### PR DESCRIPTION
问题：IE9下点击表格头部无反应，报错‘找不到contains方法’，定位到是classList不支持缘故

解决：查看以往Issues #315，你们已有解决方案，所以照搬处理。