### PR TITLE
update element use vue-i18n@6.x and other i18n docs

### DIFF
--- a/examples/docs/en-US/i18n.md
+++ b/examples/docs/en-US/i18n.md
@@ -102,7 +102,7 @@ const i18n = new VueI18n({
 })
 
 Vue.use(Element, {
-  i18n: key => i18n.t(key)
+  i18n: (key, value) => i18n.t(key. value)
 })
 
 new Vue({ i18n }).$mount('#app')
@@ -138,7 +138,7 @@ const i18n = new VueI18n({
   messages, // set locale messages
 })
 
-ElementLocale.i18n(key => i18n.t(key))
+ElementLocale.i18n((key, value) => i18n.t(key, value))
 ```
 
 ## Import via CDN

--- a/examples/docs/zh-CN/i18n.md
+++ b/examples/docs/zh-CN/i18n.md
@@ -114,7 +114,7 @@ const i18n = new VueI18n({
 })
 
 Vue.use(Element, {
-  i18n: key => i18n.vm._t(key)
+  i18n: (key, value) => i18n.vm._t(key, value)
 })
 
 new Vue({ i18n }).$mount('#app')
@@ -150,7 +150,7 @@ const i18n = new VueI18n({
   messages, // set locale messages
 })
 
-ElementLocale.i18n(key => i18n.t(key))
+ElementLocale.i18n((key, value) => i18n.t(key, value))
 ```
 
 ## 通过 CDN 的方式加载语言文件


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

在使用vue-i18n@6.x 时候，pagination total 的i18n使用的是 this.t(key,value)[代码处](https://github.com/ElemeFE/element/blob/dev/packages/pagination/src/pagination.js#L225)

所以如果只用
```
Vue.use(Element, {
  i18n: key => i18n.vm._t(key)
})

```
会丢失pagination total 的值。

