### PR TITLE
Fix line height of cascader label

### DIFF
--- a/packages/theme-default/src/cascader.css
+++ b/packages/theme-default/src/cascader.css
@@ -34,7 +34,7 @@
       left: 0;
       top: 0;
       height: 100%;
-      line-height: 34px;
+      line-height: 36px;
       padding: 0 25px 0 10px;
       color: var(--input-color);
       width: 100%;


### PR DESCRIPTION
Cascader label isn't aligned in its parent element.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x ] Make sure you are merging your commits to `dev` branch.
* [x ] Add some descriptions and refer relative issues for you PR.
