### PR TITLE
To prevent the default submit event of <el-form>

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -2,7 +2,7 @@
   <form class="el-form" :class="[
     labelPosition ? 'el-form--label-' + labelPosition : '',
     { 'el-form--inline': inline }
-  ]">
+  ]" @submit.prevent="">
     <slot></slot>
   </form>
 </template>


### PR DESCRIPTION
To prevent the default submit event, when the `<form>` contains only a `<input type="text">`, keydown `enter` will automatically trigger submit and refresh my website. ([example](https://jsfiddle.net/zngxduab/))

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
