### PR TITLE
Add form submit event and fix browser reload upon form submission.

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -1,10 +1,10 @@
 <template>
-  <form class="el-form" :class="[
+    <form @submit="handleSubmit" class="el-form" :class="[
     labelPosition ? 'el-form--label-' + labelPosition : '',
     { 'el-form--inline': inline }
   ]">
-    <slot></slot>
-  </form>
+        <slot></slot>
+    </form>
 </template>
 <script>
   export default {
@@ -51,6 +51,10 @@
       });
     },
     methods: {
+      handleSubmit(evt) {
+        evt.preventDefault();
+        this.$emit('submit', evt);
+      },
       resetFields() {
         if (!this.model) {
           process.env.NODE_ENV !== 'production' &&


### PR DESCRIPTION
This fixes two bad behaviors:

1. When you hit enter in a form, it may not submit at all.

2. If it does, it will cause the browser to reload the page and you'll lose state.

By adding a submit event for el-form, the consuming component can run relevant code when the form submits.
