### PR TITLE
Table: fix hover-row bgcolor of table with fixed column

### DIFF
--- a/packages/theme-default/src/table.css
+++ b/packages/theme-default/src/table.css
@@ -400,8 +400,14 @@
     }
 
     @e body {
-      tr.hover-row > td {
-        background-color: var(--color-extra-light-gray);
+      tr.hover-row {
+        &, &.el-table__row--striped {
+          &, &.current-row {
+            > td {
+              background-color: var(--color-extra-light-gray);
+            }
+          }
+        }
       }
 
       tr.current-row > td {


### PR DESCRIPTION
Fix: The background color of highlighted hover-row or hover-row of table with fixed column do not change when hovering.