### PR TITLE
「DateTimePicker 日期时间选择器」中的截止时间应默认23:59:59比较好

### DIFF
--- a/packages/date-picker/src/basic/date-table.vue
+++ b/packages/date-picker/src/basic/date-table.vue
@@ -409,7 +409,7 @@
             this.markRange(this.minDate);
           } else if (this.minDate && !this.maxDate) {
             if (newDate >= this.minDate) {
-              const maxDate = new Date(newDate.getTime());
+              const maxDate = new Date(newDate.getTime() + 1000 * 60 * 60 * 24 - 1);
               this.rangeState.selecting = false;
 
               this.$emit('pick', {


### PR DESCRIPTION
用户点击了同一天，意图是选择今天的时间范围，而这个控件默认却选择了：
2017-07-24 00:00:00 - 2017-07-24 00:00:00
应该默认选择：
2017-07-24 00:00:00 - 2017-07-24 23:59:59

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
