### PR TITLE
Popover: fix: delayed popover appears after mouse left

### DIFF
--- a/packages/popover/src/main.vue
+++ b/packages/popover/src/main.vue
@@ -109,16 +109,17 @@ export default {
       this.showPopper = false;
     },
     handleMouseEnter() {
+      clearTimeout(this._timer);
       if (this.openDelay) {
-        setTimeout(() => {
+        this._timer = setTimeout(() => {
           this.showPopper = true;
         }, this.openDelay);
       } else {
         this.showPopper = true;
       }
-      clearTimeout(this._timer);
     },
     handleMouseLeave() {
+      clearTimeout(this._timer);
       this._timer = setTimeout(() => {
         this.showPopper = false;
       }, 200);


### PR DESCRIPTION
Fix a popover bug:

If cursor leave the trigger element earlier than `open-delay`, the popover will still show up, which is not expected.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
