### PR TITLE
Removed Dutch "Jaar" suffix from DatePicker

### DIFF
--- a/src/locale/lang/nl.js
+++ b/src/locale/lang/nl.js
@@ -16,7 +16,7 @@ export default {
       startTime: 'Starttijd',
       endDate: 'Einddatum',
       endTime: 'Eindtijd',
-      year: 'Jaar',
+      year: '',
       month1: 'januari',
       month2: 'februari',
       month3: 'maart',


### PR DESCRIPTION
Removed the suffix "Jaar" from DatePicker. Since this is unnecessary. 
Fixes the same issue as described in #5825 but for the Dutch language.