### PR TITLE
Select: check popper exist before invoke scrollIntoView

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -355,8 +355,10 @@
       },
 
       scrollToOption(className = 'selected') {
-        const menu = this.$refs.popper.$el.querySelector('.el-select-dropdown__wrap');
-        scrollIntoView(menu, menu.getElementsByClassName(className)[0]);
+        if (this.$refs.popper) {
+          const menu = this.$refs.popper.$el.querySelector('.el-select-dropdown__wrap');
+          scrollIntoView(menu, menu.getElementsByClassName(className)[0]);
+        }
       },
 
       handleMenuEnter() {


### PR DESCRIPTION
  handleOptionSelect() use $nextTick() to invoke scrollToOption(), but component could be destroyed after select(e.g. routed to another page), "$refs.popper" would be undefined.