### PR TITLE
#feature

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -1,5 +1,6 @@
 <template>
   <el-input
+    v-if="hiddeInput"
     class="el-date-editor"
     :class="'el-date-editor--' + type"
     :readonly="!editable || readonly"
@@ -223,7 +224,15 @@ export default {
     rangeSeparator: {
       default: ' - '
     },
-    pickerOptions: {}
+    pickerOptions: {},
+    show:{
+      type: Boolean,
+      default: false
+    },
+    hiddeInput:{
+      type: Boolean,
+      default: false
+    },
   },
 
   components: { ElInput },
@@ -355,6 +364,7 @@ export default {
       gpuAcceleration: false
     };
     this.placement = PLACEMENT_MAP[this.align] || PLACEMENT_MAP.left;
+    this.showClose = this.show || this.hiddeInput;
   },
 
   methods: {


### PR DESCRIPTION
If you can show directly your datepicker, you can add show props.
If you just view datepicker without input, you can add props justView.

#code

Add show props for show the datepicker without click on input.
Add justView props for show your datepicker without input, if hideInput is true i show datepicker

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
