### PR TITLE
Tree:fix checkbox functionality when checkStrictly

### DIFF
--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -302,7 +302,7 @@ export default class Node {
     this.checked = value === true;
     let { all, allWithoutDisable } = getChildState(this.childNodes);
 
-    if (this.childNodes.length && (!all && allWithoutDisable)) {
+    if (deep && this.childNodes.length && (!all && allWithoutDisable)) {
       this.checked = false;
       value = false;
     }


### PR DESCRIPTION
a check-able node who has descendants should can be checked even though all of its descendants disabled, when check strictly is set up.
see issue https://github.com/ElemeFE/element/issues/6118

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
