### PR TITLE
Input-Number: fixed multi-size component border overflow, tested on c…

### DIFF
--- a/packages/theme-default/src/input-number.css
+++ b/packages/theme-default/src/input-number.css
@@ -63,7 +63,7 @@
       width: 200px;
 
       & .el-input-number__increase, .el-input-number__decrease {
-        line-height: var(--input-large-height);
+        line-height: calc(var(--input-large-height) - 2);
         width: var(--input-large-height);
         font-size: var(--input-large-font-size);
       }
@@ -78,7 +78,7 @@
       width: 130px;
 
       & .el-input-number__increase, .el-input-number__decrease {
-        line-height: var(--input-small-height);
+        line-height: calc(var(--input-small-height) - 2);
         width: var(--input-small-height);
         font-size: var(--input-small-font-size);
       }


### PR DESCRIPTION
Input-Number: fixed multi-size component border overflow, tested on chrome 60, canary, chromium, safari, firefox
--



### bug screenshot
![image](https://user-images.githubusercontent.com/15975785/28975416-79fcad62-796c-11e7-96dd-bb82f1091111.png)
### Chrome version
![image](https://user-images.githubusercontent.com/15975785/28975453-a0e24dba-796c-11e7-8618-92d03aa24f26.png)
### OS 
![image](https://user-images.githubusercontent.com/15975785/28975502-d2f293fa-796c-11e7-9f27-19a470d37cd3.png)
# after fixed
### Testing on Chrome  ver: 60.0.3112.78
![image](https://user-images.githubusercontent.com/15975785/28975430-90f5f6e0-796c-11e7-8307-6cee9a8dedd6.png)
### Testing on Safari ver: 10.0.3 (12602.4.8)
![image](https://user-images.githubusercontent.com/15975785/28975549-056f2e6a-796d-11e7-80e8-2ab0c86c946a.png)
### Testing on Canary ver: 62.0.3173.0（正式版本）canary （64 位）
![image](https://user-images.githubusercontent.com/15975785/28975609-3db64506-796d-11e7-86af-dce51702db7a.png)
### Testing on Chromium ver:  60.0.3091.0（开发者内部版本）（64 位）
![image](https://user-images.githubusercontent.com/15975785/28975653-64c5f9b6-796d-11e7-87e3-015d327c437f.png)


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
