### PR TITLE
Col: fix <el-col :span="0"> cant't get the 'el-col-0' class name

### DIFF
--- a/packages/col/src/col.js
+++ b/packages/col/src/col.js
@@ -38,7 +38,7 @@ export default {
     }
 
     ['span', 'offset', 'pull', 'push'].forEach(prop => {
-      if (this[prop]) {
+      if (this[prop] !== undefined) {
         classList.push(
           prop !== 'span'
           ? `el-col-${prop}-${this[prop]}`


### PR DESCRIPTION
Fixed https://github.com/ElemeFE/element/issues/6440

`<el-col :span="0"></el-col>` expect to get `<div class="el-col el-col-0">` but only get the `<div class="el-col">`