### PR TITLE
Table: 新增rowSpan 分组合并功能

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -15,10 +15,10 @@ export default {
       required: true
     },
     rowSpans: {
-        type: Array,
-        default: function() {
-          return [];
-        }
+      type: Array,
+      default: function() {
+        return [];
+      }
     },
     rowSpanKey: {
       type: String,
@@ -177,10 +177,10 @@ export default {
     getColumnStyle(row, index, column, cellIndex) {
       if (this.rowSpanKey) {
         for (var i = index - 1 ; i >= 0; i--) {
-            let lastSpan = this.getRowSpan(this.data[i], i, column, cellIndex);
-            if (index - i < lastSpan) {
-              return 'display:none';
-            }
+          let lastSpan = this.getRowSpan(this.data[i], i, column, cellIndex);
+          if (index - i < lastSpan) {
+            return 'display:none';
+          }
         }
       }
     },

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -27,6 +27,8 @@
       <table-body
         :context="context"
         :store="store"
+        :row-spans=rowSpans
+        :row-span-key=rowSpanKey
         :stripe="stripe"
         :layout="layout"
         :row-class-name="rowClassName"
@@ -71,6 +73,8 @@
         <table-body
           fixed="left"
           :store="store"
+          :row-spans=rowSpans
+          :row-span-key=rowSpanKey
           :stripe="stripe"
           :layout="layout"
           :highlight="highlightCurrentRow"
@@ -113,6 +117,8 @@
         <table-body
           fixed="right"
           :store="store"
+          :row-spans=rowSpans
+          :row-span-key=rowSpanKey
           :stripe="stripe"
           :layout="layout"
           :row-class-name="rowClassName"
@@ -167,6 +173,18 @@
         }
       },
 
+      rowSpans: {
+        type: Array,
+        default: function() {
+          return [];
+        }
+      },
+      rowSpanKey: {
+        type: String,
+        default: function() {
+          return '';
+        }
+      },
       width: [String, Number],
 
       height: [String, Number],


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

新增属性
rowSpans JSON数组, 用于确认合并项 数组格式 要有keyIndex用于标识数据
rowSpanKey String  keyIndex对应的key
如有数组data[{id:'1',name:'liu',date:'2017'},{id:'2',name:'xin',date:'2018']
rowSpanKey = id
rowSpans[{keyIndex:'2',name:2}]
表示 id为1的name列rowSpan为2

注意：因Vue 不能检测属性被添加的限制, 所以渲染后的修改注意使用$set
