### PR TITLE
FAQ: fix attribute scope typo

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -22,7 +22,7 @@
 使用 [Scoped slot](https://vuejs.org/v2/guide/components.html#Scoped-Slots) 即可：
 ```html
 <el-table-column label="操作">
-  <template scoped="props">
+  <template scope="props">
     <el-button @click.native="showDetail(props.row)">查看详情</el-button>
   </template>
 </el-table-column>
@@ -115,7 +115,7 @@ For other components, the `.native` modifier is still mandatory.
 Just use [Scoped slot](https://vuejs.org/v2/guide/components.html#Scoped-Slots):
 ```html
 <el-table-column label="Operations">
-  <template scoped="props">
+  <template scope="props">
     <el-button @click.native="showDetail(props.row)">Details</el-button>
   </template>
 </el-table-column>


### PR DESCRIPTION
FAQ DOC: fix typo `scoped`=>`scope` in 'How do I add buttons in each row of Table to operate data of that row?'

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
