### PR TITLE
cascader: Add a 2nd parameter for change event

### DIFF
--- a/packages/cascader/src/main.vue
+++ b/packages/cascader/src/main.vue
@@ -243,7 +243,7 @@ export default {
     handlePick(value, close = true) {
       this.currentValue = value;
       this.$emit('input', value);
-      this.$emit('change', value);
+      this.$emit('change', value, this.menu.options[0].__IS__FLAT__OPTIONS);
 
       if (close) {
         this.menuVisible = false;

--- a/packages/cascader/src/main.vue
+++ b/packages/cascader/src/main.vue
@@ -243,7 +243,7 @@ export default {
     handlePick(value, close = true) {
       this.currentValue = value;
       this.$emit('input', value);
-      this.$emit('change', value, this.menu.options[0].__IS__FLAT__OPTIONS);
+      this.$emit('change', value, !!this.menu.options[0].__IS__FLAT__OPTIONS);
 
       if (close) {
         this.menuVisible = false;

--- a/test/unit/specs/cascader.spec.js
+++ b/test/unit/specs/cascader.spec.js
@@ -465,6 +465,7 @@ describe('Cascader', () => {
           :options="options"
           change-on-select
           v-model="selectedOptions"
+          @change="handleChange"
         ></el-cascader>
       `,
       data() {
@@ -499,8 +500,14 @@ describe('Cascader', () => {
               }]
             }]
           }],
-          selectedOptions: []
+          selectedOptions: [],
+          selectedFromFilterList: false
         };
+      },
+      methods: {
+        handleChange(val, fromFilterList) {
+          this.selectedFromFilterList = fromFilterList;
+        }
       }
     }, true);
     expect(vm.$el).to.be.exist;
@@ -534,6 +541,7 @@ describe('Cascader', () => {
             expect(vm.selectedOptions[0]).to.be.equal('zhejiang');
             expect(vm.selectedOptions[1]).to.be.equal('hangzhou');
             expect(vm.selectedOptions[2]).to.be.equal('xihu');
+            expect(vm.selectedFromFilterList).to.not.be.true;
             done();
           }, 500);
         });
@@ -617,7 +625,7 @@ describe('Cascader', () => {
           expect(vm.selectedOptions[0]).to.be.equal('zhejiang');
           expect(vm.selectedOptions[1]).to.be.equal('hangzhou');
           expect(vm.selectedOptions[2]).to.be.equal('xihu');
-          expect(vm.selectedFromFilterList).to.be.equal(true);
+          expect(vm.selectedFromFilterList).to.be.true;
           done();
         }, 500);
       }, 300);

--- a/test/unit/specs/cascader.spec.js
+++ b/test/unit/specs/cascader.spec.js
@@ -550,6 +550,7 @@ describe('Cascader', () => {
           filterable
           :debounce="0"
           v-model="selectedOptions"
+          @change="handleChange"
         ></el-cascader>
       `,
       data() {
@@ -584,8 +585,14 @@ describe('Cascader', () => {
               }]
             }]
           }],
-          selectedOptions: []
+          selectedOptions: [],
+          selectedFromFilterList: false
         };
+      },
+      methods: {
+        handleChange(val, fromFilterList) {
+          this.selectedFromFilterList = fromFilterList;
+        }
       }
     }, true);
     expect(vm.$el).to.be.exist;
@@ -610,6 +617,7 @@ describe('Cascader', () => {
           expect(vm.selectedOptions[0]).to.be.equal('zhejiang');
           expect(vm.selectedOptions[1]).to.be.equal('hangzhou');
           expect(vm.selectedOptions[2]).to.be.equal('xihu');
+          expect(vm.selectedFromFilterList).to.be.equal(true);
           done();
         }, 500);
       }, 300);

--- a/test/unit/specs/cascader.spec.js
+++ b/test/unit/specs/cascader.spec.js
@@ -541,7 +541,7 @@ describe('Cascader', () => {
             expect(vm.selectedOptions[0]).to.be.equal('zhejiang');
             expect(vm.selectedOptions[1]).to.be.equal('hangzhou');
             expect(vm.selectedOptions[2]).to.be.equal('xihu');
-            expect(vm.selectedFromFilterList).to.not.be.true;
+            expect(vm.selectedFromFilterList).to.be.false;
             done();
           }, 500);
         });


### PR DESCRIPTION
Add a 2nd parameter for change event to distinguish filtered-list-based change from cascaded-poppers-based change.

This is a new feature to satisfy the requirements 1 and 2 from a post of SegmentFault.com.

![SegmentFault Post](https://user-images.githubusercontent.com/3956876/29425660-a6ecc358-83b6-11e7-8650-35fb3c5623b9.png)

Currently the 2nd requirement can't be satisfied.

My reply to the post:

![My Reply](https://user-images.githubusercontent.com/3956876/29425818-30c40334-83b7-11e7-9e9a-238362ff5465.png)

Please make sure these boxes are checked before submitting your PR, thank you!

[*] Make sure you follow Element's contributing guide (中文 | English).
[*] Make sure you are merging your commits to dev branch.
[*] Add some descriptions and refer relative issues for you PR.
