### PR TITLE
Upload: fix default status of fileList

### DIFF
--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -109,7 +109,7 @@ export default {
       handler(fileList) {
         this.uploadFiles = fileList.map(item => {
           item.uid = item.uid || (Date.now() + this.tempIndex++);
-          item.status = 'success';
+          item.status = item.status || 'success';
           return item;
         });
       }


### PR DESCRIPTION
fix: #6080 

if file in fileList (props) exist 'status', uploadFiles use its default 'status'
