### PR TITLE
Upload: fix 当在onChange中修改了fileList对象时，报Cannot set property 'status' of null的错误bug

### DIFF
--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -136,7 +136,7 @@ export default {
       }
 
       this.uploadFiles.push(file);
-      this.onChange(file, this.uploadFiles);
+      return this.onChange(file, this.uploadFiles);
     },
     handleProgress(ev, rawFile) {
       var file = this.getFile(rawFile);

--- a/packages/upload/src/upload.vue
+++ b/packages/upload/src/upload.vue
@@ -70,7 +70,7 @@ export default {
       if (postFiles.length === 0) { return; }
 
       postFiles.forEach(rawFile => {
-        this.onStart(rawFile);
+        if (this.onStart(rawFile) === false) return;
         if (this.autoUpload) this.upload(rawFile);
       });
     },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

场景：在onchange里想限制上传的文件数量，所以修改了fileList对象

当在onChange中修改了fileList对象时，upload会继续执行，并报错
```
Uncaught TypeError: Cannot set property 'status' of null
    at VueComponent.handleProgress (vendor.js:43280)
    at VueComponent.boundFn (vendor.js:396)
    at Object.onProgress (vendor.js:43798)
    at XMLHttpRequestUpload.progress (vendor.js:43919)
```
源码
```
            handleProgress: function handleProgress(ev, rawFile) {
	      var file = this.getFile(rawFile);
	      this.onProgress(ev, file, this.uploadFiles);
	      file.status = 'uploading';  // 错误产生在这行
	      file.percentage = ev.percent || 0;
	    }
```
解决：
当onChange返回“false”，则跳过上传该文件
