### PR TITLE
support custom filter-change

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -213,7 +213,12 @@
 
       defaultSort: Object,
 
-      tooltipEffect: String
+      tooltipEffect: String,
+
+      customFilter: {
+        type: Boolean,
+        default: false
+      }
     },
 
     components: {


### PR DESCRIPTION
`filter-change`事件是为了便于用户实现自己`filter`的，但是现在存在2个问题：
1. element-ui的filter逻辑总是会运行一次，需要类似`search="custom"`的选项。
2. `filter-change` emit出来的信息里没有`filterMethod`这个关键信息, 这使得element无法完全支持自定义排序。

这个PR为`el-table`添加了`customFilter`属性。`customFilter=true`的时候，`element-ui`的排序逻辑不再运行，同时的对外emit的事件带的信息为：
```
[{
  prop: column.columnKey,
  values,
  filterMethod: column.filterMethod
}]
```
这样一来，el-table外部，我们就有机会充分使用这个过滤功能了。

相关问题：https://github.com/njleonzhang/vue-data-tables/issues/56