### PR TITLE
Select: watch old value on select change

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -230,7 +230,7 @@
         this.cachedPlaceHolder = this.currentPlaceholder = val;
       },
 
-      value(val) {
+      value(val, oldVal) {
         if (this.multiple) {
           this.resetInputHeight();
           if (val.length > 0 || (this.$refs.input && this.query !== '')) {
@@ -243,7 +243,7 @@
         if (this.filterable && !this.multiple) {
           this.inputLength = 20;
         }
-        this.$emit('change', val);
+        this.$emit('change', val, oldVal);
         this.dispatch('ElFormItem', 'el.form.change', val);
       },
 


### PR DESCRIPTION
In some cases I need to get old value on select change. For example, If I have a group of select components which share the same option list (let's say ['a', 'b', 'c']). When I select 'a' in the first select component, I want to filter out 'a' in the option list and make the option list only ['b', 'c']. After that when I change the selection from 'a' to 'b', I want to filter out 'b' and put 'a' back to the list and the list will then be ['a', 'c'].

In this case, I need to know the old value I previously selected and put it back to the option list.



Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
