### PR TITLE
Pagination: fix Jumper value reassign problem

### DIFF
--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -189,16 +189,25 @@ export default {
         handleFocus(event) {
           this.oldValue = event.target.value;
         },
+        handleBlur({ target }) {
+          this.reassignMaxValue(target);
+        },
         handleKeyUp(event) {
           const key = event.key || '';
           const keyCode = event.keyCode || '';
           if ((key && key === 'Enter') || (keyCode && keyCode === 13)) {
+            this.reassignMaxValue(event.target);
             this.handleChange({ target: event.target });
           }
         },
         handleChange({ target }) {
           this.$parent.internalCurrentPage = this.$parent.getValidCurrentPage(target.value);
           this.oldValue = null;
+        },
+        reassignMaxValue(target) {
+          if (+target.value > this.$parent.internalPageCount) {
+            target.value = this.$parent.internalPageCount;
+          }
         }
       },
 
@@ -210,11 +219,12 @@ export default {
               class="el-pagination__editor"
               type="number"
               min={ 1 }
-              max={ this.internalPageCount }
+              max={ this.$parent.internalPageCount }
               value={ this.$parent.internalCurrentPage }
               domProps-value={ this.$parent.internalCurrentPage }
               on-change={ this.handleChange }
               on-focus={ this.handleFocus }
+              on-blur={ this.handleBlur }
               on-keyup={ this.handleKeyUp }
               number/>
             { this.t('el.pagination.pageClassifier') }

--- a/test/unit/specs/pagination.spec.js
+++ b/test/unit/specs/pagination.spec.js
@@ -219,6 +219,7 @@ describe('Pagination', () => {
       triggerEvent(input, 'change');
       setTimeout(() => {
         expect(vm.page).to.equal(10);
+        expect(input.value).to.equal('10');
 
         input.value = '我好帅';
         triggerEvent(input, 'change');


### PR DESCRIPTION
Jumper value should reassign when internalCurrentPage greater than internalPageCount.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
