### PR TITLE
Fixed reactivity of colors prop for rate component

### DIFF
--- a/packages/rate/src/main.vue
+++ b/packages/rate/src/main.vue
@@ -32,7 +32,6 @@
     data() {
       return {
         classMap: {},
-        colorMap: {},
         pointerAtLeftHalf: true,
         currentValue: this.value,
         hoverIndex: -1
@@ -153,6 +152,16 @@
         return this.getValueFromMap(this.currentValue, this.classMap);
       },
 
+      colorMap() {
+        return {
+          lowColor: this.colors[0],
+          mediumColor: this.colors[1],
+          highColor: this.colors[2],
+          voidColor: this.voidColor,
+          disabledVoidColor: this.disabledVoidColor
+        };
+      },
+
       activeColor() {
         return this.getValueFromMap(this.currentValue, this.colorMap);
       },
@@ -266,13 +275,6 @@
         highClass: this.iconClasses[2],
         voidClass: this.voidIconClass,
         disabledVoidClass: this.disabledVoidIconClass
-      };
-      this.colorMap = {
-        lowColor: this.colors[0],
-        mediumColor: this.colors[1],
-        highColor: this.colors[2],
-        voidColor: this.voidColor,
-        disabledVoidColor: this.disabledVoidColor
       };
     }
   };

--- a/test/unit/specs/rate.spec.js
+++ b/test/unit/specs/rate.spec.js
@@ -106,9 +106,9 @@ describe('Rate', () => {
       computed: {
         colors() {
           if (this.muted) {
-            return ['#999', '#999', '#999']
+            return ['#999', '#999', '#999'];
           } else {
-            return ['#99A9BF', '#F7BA2A', '#FF9900']
+            return ['#99A9BF', '#F7BA2A', '#FF9900'];
           }
         }
       },

--- a/test/unit/specs/rate.spec.js
+++ b/test/unit/specs/rate.spec.js
@@ -123,8 +123,7 @@ describe('Rate', () => {
       vm.muted = true;
       vm.$nextTick(() => {
         const thirdIcon = vm.$el.querySelectorAll('.el-rate__item')[2].querySelector('.el-rate__icon');
-        //expect(thirdIcon.style.color).to.equal('rgb(153, 153, 153)');
-        expect(thirdIcon.style.color).to.equal('rgb(0, 0, 0)');
+        expect(thirdIcon.style.color).to.equal('rgb(153, 153, 153)');
         done();
       });
     }, 10);

--- a/test/unit/specs/rate.spec.js
+++ b/test/unit/specs/rate.spec.js
@@ -95,6 +95,41 @@ describe('Rate', () => {
     expect(thirdIcon.style.color).to.equal('rgb(255, 153, 0)');
   });
 
+  it('colors are updated after prop is changed', done => {
+    vm = createVue({
+      template: `
+        <div>
+          <el-rate v-model="value" :colors="colors"></el-rate>
+        </div>
+      `,
+
+      computed: {
+        colors() {
+          if (this.muted) {
+            return ['#999', '#999', '#999']
+          } else {
+            return ['#99A9BF', '#F7BA2A', '#FF9900']
+          }
+        }
+      },
+      data() {
+        return {
+          value: 4,
+          muted: false
+        };
+      }
+    }, true);
+    setTimeout(() => {
+      vm.muted = true;
+      vm.$nextTick(() => {
+        const thirdIcon = vm.$el.querySelectorAll('.el-rate__item')[2].querySelector('.el-rate__icon');
+        //expect(thirdIcon.style.color).to.equal('rgb(153, 153, 153)');
+        expect(thirdIcon.style.color).to.equal('rgb(0, 0, 0)');
+        done();
+      });
+    }, 10);
+  });
+
   it('threshold', () => {
     vm = createVue({
       template: `


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

-----

What I wanted to allow user to rate some items and also see other users's average rating. Until user rates the item herself that average rating should be "muted" (dimmed colors), so I wanted to pass `colors` prop. However, I then noticed that changing that `colors` array at parent component have not impact of the colors at rate component. Looking at the code I can see that `colorMap` is prepared once at the `created` hook. This makes `colors` prop non-reactive which is odd.

I've made `colorMap` a computed value that should be based on `colors` prop.