### PR TITLE
Autocomplete: emit blur and focus events from el-input

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -8,6 +8,7 @@
       @compositionend.native="handleComposition"
       @change="handleChange"
       @focus="handleFocus"
+      @blur="handleBlur"
       @keydown.up.native.prevent="highlight(highlightedIndex - 1)"
       @keydown.down.native.prevent="highlight(highlightedIndex + 1)"
       @keydown.enter.native="handleKeyEnter"
@@ -124,11 +125,15 @@
         }
         this.getData(value);
       },
-      handleFocus() {
+      handleFocus(event) {
+        this.$emit('focus', event);
         this.activated = true;
         if (this.triggerOnFocus) {
           this.getData(this.value);
         }
+      },
+      handleBlur(event) {
+        this.$emit('blur', event);
       },
       close(e) {
         this.activated = false;


### PR DESCRIPTION
In some cases there is a need to handle autocomplete el-input focus and blur events, so let's proxy them? 

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

I think this relevant to https://github.com/ElemeFE/element/issues/2544