### PR TITLE
fix #5813  component could not use Sogou input method in Chinese IE 11

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -111,7 +111,7 @@
       handleComposition(event) {
         if (event.type === 'compositionend') {
           this.isOnComposition = false;
-          this.handleChange(this.value);
+          this.handleChange(event.target.value);
         } else {
           this.isOnComposition = true;
         }


### PR DESCRIPTION
修复 autocomplete 组件 IE11 下使用搜狗输入法，无法输入中文的问题

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
