### PR TITLE
doc: Add scheme part of URL in import via CDN examples

### DIFF
--- a/examples/docs/en-US/i18n.md
+++ b/examples/docs/en-US/i18n.md
@@ -144,9 +144,9 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 ## Import via CDN
 
 ```html
-<script src="//unpkg.com/vue"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/element-ui"></script>
+<script src="https://unpkg.com/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   ELEMENT.locale(ELEMENT.lang.en)
@@ -156,11 +156,11 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 Compatible with `vue-i18n`
 
 ```html
-<script src="//unpkg.com/vue"></script>
-<script src="//unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/zh-CN.js"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
+<script src="https://unpkg.com/element-ui"></script>
+<script src="https://unpkg.com/element-ui/lib/umd/locale/zh-CN.js"></script>
+<script src="https://unpkg.com/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   Vue.locale('en', ELEMENT.lang.en)

--- a/examples/docs/zh-CN/i18n.md
+++ b/examples/docs/zh-CN/i18n.md
@@ -156,9 +156,9 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 ## 通过 CDN 的方式加载语言文件
 
 ```html
-<script src="//unpkg.com/vue"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/element-ui"></script>
+<script src="https://unpkg.com/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   ELEMENT.locale(ELEMENT.lang.en)
@@ -168,11 +168,11 @@ ElementLocale.i18n((key, value) => i18n.t(key, value))
 搭配 `vue-i18n` 使用
 
 ```html
-<script src="//unpkg.com/vue"></script>
-<script src="//unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
-<script src="//unpkg.com/element-ui"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/zh-CN.js"></script>
-<script src="//unpkg.com/element-ui/lib/umd/locale/en.js"></script>
+<script src="https://unpkg.com/vue"></script>
+<script src="https://unpkg.com/vue-i18n/dist/vue-i18n.js"></script>
+<script src="https://unpkg.com/element-ui"></script>
+<script src="https://unpkg.com/element-ui/lib/umd/locale/zh-CN.js"></script>
+<script src="https://unpkg.com/element-ui/lib/umd/locale/en.js"></script>
 
 <script>
   Vue.locale('en', ELEMENT.lang.en)


### PR DESCRIPTION
When I tried locale setting with element-ui imported via CDN, sample code didn't work since scheme part of URL is missing.

Thanks,