### PR TITLE
ColorPicker: add show-clear & support form validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 npm-debug.log
 lerna-debug.log
+yarn-error.log
 npm-debug.log.*
 lerna-debug.log.*
 lib

--- a/examples/docs/en-US/color-picker.md
+++ b/examples/docs/en-US/color-picker.md
@@ -4,7 +4,8 @@
       return {
         color1: '#20a0ff',
         color2: null,
-        color3: 'rgba(19, 206, 102, 0.8)'
+        color3: 'rgba(19, 206, 102, 0.8)',
+        color4: '#f0f'
       };
     },
     mounted() {
@@ -84,9 +85,28 @@ ColorPicker is a color selector supporting multiple color formats.
 ```
 :::
 
+### Clear button
+
+:::demo Set `show-clear` to `false` to hide clear button.
+```html
+<el-color-picker v-model="color4" :show-clear="false"></el-color-picker>
+
+<script>
+  export default {
+    data() {
+      return {
+        color4: '#f0f'
+      }
+    }
+  };
+</script>
+```
+:::
+
 ### Attributes
 | Attribute | Description | Type | Accepted Values | Default |
 |---------- |-------- |---------- |-------------  |-------- |
+| show-clear | whether to show clear button | boolean | — | true |
 | show-alpha | whether to display the alpha slider | boolean | — | false |
 | color-format | color format of v-model | string | hsl / hsv / hex / rgb | hex (when show-alpha is false)/ rgb (when show-alpha is true) |
 

--- a/examples/docs/en-US/form.md
+++ b/examples/docs/en-US/form.md
@@ -59,6 +59,7 @@
         },
         ruleForm: {
           name: '',
+          color: '#f0f',
           region: '',
           date1: '',
           date2: '',
@@ -79,6 +80,9 @@
           name: [
             { required: true, message: 'Please input Activity name', trigger: 'blur' },
             { min: 3, max: 5, message: 'Length should be 3 to 5', trigger: 'blur' }
+          ],
+          color: [
+            { required: true, message: 'Please pick a color', trigger: 'change' }
           ],
           region: [
             { required: true, message: 'Please select Activity zone', trigger: 'change' }
@@ -406,6 +410,9 @@ Form component allows you to verify your data, helping you find and correct erro
   <el-form-item label="Activity name" prop="name">
     <el-input v-model="ruleForm.name"></el-input>
   </el-form-item>
+  <el-form-item label="Background color" prop="color">
+    <el-color-picker v-model="ruleForm.color"></el-color-picker>
+  </el-form-item>
   <el-form-item label="Activity zone" prop="region">
     <el-select v-model="ruleForm.region" placeholder="Activity zone">
       <el-option label="Zone one" value="shanghai"></el-option>
@@ -456,6 +463,7 @@ Form component allows you to verify your data, helping you find and correct erro
       return {
         ruleForm: {
           name: '',
+          color: '#f0f',
           region: '',
           date1: '',
           date2: '',
@@ -468,6 +476,9 @@ Form component allows you to verify your data, helping you find and correct erro
           name: [
             { required: true, message: 'Please input Activity name', trigger: 'blur' },
             { min: 3, max: 5, message: 'Length should be 3 to 5', trigger: 'blur' }
+          ],
+          color: [
+            { required: true, message: 'Please pick a color', trigger: 'change' }
           ],
           region: [
             { required: true, message: 'Please select Activity zone', trigger: 'change' }

--- a/examples/docs/zh-CN/color-picker.md
+++ b/examples/docs/zh-CN/color-picker.md
@@ -4,7 +4,8 @@
       return {
         color1: '#20a0ff',
         color2: null,
-        color3: 'rgba(19, 206, 102, 0.8)'
+        color3: 'rgba(19, 206, 102, 0.8)',
+        color4: '#f0f'
       };
     },
     mounted() {
@@ -84,9 +85,28 @@
 ```
 :::
 
+### 隐藏清空按钮
+
+:::demo 将`show-clear`属性设置为`false`即可隐藏清空按钮。
+```html
+<el-color-picker v-model="color4" :show-clear="false"></el-color-picker>
+
+<script>
+  export default {
+    data() {
+      return {
+        color4: '#f0f'
+      }
+    }
+  };
+</script>
+```
+:::
+
 ### Attributes
 | 参数      | 说明    | 类型      | 可选值       | 默认值   |
 |---------- |-------- |---------- |-------------  |-------- |
+| show-clear | 是否显示清空按钮 | boolean | — | true |
 | show-alpha | 是否支持透明度选择 | boolean | — | false |
 | color-format | 写入 v-model 的颜色的格式 | string | hsl / hsv / hex / rgb | hex（show-alpha 为 false）/ rgb（show-alpha 为 true） |
 

--- a/examples/docs/zh-CN/form.md
+++ b/examples/docs/zh-CN/form.md
@@ -59,6 +59,7 @@
         },
         ruleForm: {
           name: '',
+          color: '#f0f',
           region: '',
           date1: '',
           date2: '',
@@ -77,6 +78,9 @@
           name: [
             { required: true, message: '请输入活动名称', trigger: 'blur' },
             { min: 3, max: 5, message: '长度在 3 到 5 个字符', trigger: 'blur' }
+          ],
+          color: [
+            { required: true, message: '请选择背景颜色', trigger: 'change' }
           ],
           region: [
             { required: true, message: '请选择活动区域', trigger: 'change' }
@@ -397,6 +401,9 @@
   <el-form-item label="活动名称" prop="name">
     <el-input v-model="ruleForm.name"></el-input>
   </el-form-item>
+  <el-form-item label="背景颜色" prop="color">
+    <el-color-picker v-model="ruleForm.color"></el-color-picker>
+  </el-form-item>
   <el-form-item label="活动区域" prop="region">
     <el-select v-model="ruleForm.region" placeholder="请选择活动区域">
       <el-option label="区域一" value="shanghai"></el-option>
@@ -447,6 +454,7 @@
       return {
         ruleForm: {
           name: '',
+          color: '#f0f',
           region: '',
           date1: '',
           date2: '',
@@ -459,6 +467,9 @@
           name: [
             { required: true, message: '请输入活动名称', trigger: 'blur' },
             { min: 3, max: 5, message: '长度在 3 到 5 个字符', trigger: 'blur' }
+          ],
+          color: [
+            { required: true, message: '请选择背景颜色', trigger: 'change' }
           ],
           region: [
             { required: true, message: '请选择活动区域', trigger: 'change' }

--- a/packages/color-picker/src/components/picker-dropdown.vue
+++ b/packages/color-picker/src/components/picker-dropdown.vue
@@ -10,7 +10,7 @@
       <alpha-slider v-if="showAlpha" ref="alpha" :color="color"></alpha-slider>
       <div class="el-color-dropdown__btns">
         <span class="el-color-dropdown__value">{{ currentColor }}</span>
-        <a href="JavaScript:" class="el-color-dropdown__link-btn" @click="$emit('clear')">{{ t('el.colorpicker.clear') }}</a>
+        <a v-if="showClear" href="JavaScript:" class="el-color-dropdown__link-btn" @click="$emit('clear')">{{ t('el.colorpicker.clear') }}</a>
         <button class="el-color-dropdown__btn" @click="confirmValue">{{ t('el.colorpicker.confirm') }}</button>
       </div>
     </div>
@@ -39,6 +39,7 @@
       color: {
         required: true
       },
+      showClear: Boolean,
       showAlpha: Boolean
     },
 

--- a/packages/color-picker/src/main.vue
+++ b/packages/color-picker/src/main.vue
@@ -17,6 +17,7 @@
        @pick="confirmValue"
        @clear="clearValue"
        :color="color"
+       :show-clear="showClear"
        :show-alpha="showAlpha">
     </picker-dropdown>
   </div>
@@ -26,13 +27,20 @@
   import Color from './color';
   import PickerDropdown from './components/picker-dropdown.vue';
   import Clickoutside from 'element-ui/src/utils/clickoutside';
+  import Emitter from 'element-ui/src/mixins/emitter';
 
   export default {
     name: 'ElColorPicker',
 
+    mixins: [ Emitter ],
+
     props: {
       value: {
         type: String
+      },
+      showClear: {
+        type: Boolean,
+        default: true
       },
       showAlpha: {
         type: Boolean
@@ -80,11 +88,13 @@
       confirmValue(value) {
         this.$emit('input', this.color.value);
         this.$emit('change', this.color.value);
+        this.dispatch('ElFormItem', 'el.form.change', [this.color.value]);
         this.showPicker = false;
       },
       clearValue() {
         this.$emit('input', null);
         this.$emit('change', null);
+        this.dispatch('ElFormItem', 'el.form.change', [null]);
         this.showPanelColor = false;
         this.showPicker = false;
         this.resetColor();


### PR DESCRIPTION
有时，我们想要用户必须选择一个颜色，那么设置 `show-clear` 为 `false` 即可。

同时，现在，我们可以把颜色选择器放在表单里，并对其验证。