### PR TITLE
DatePicker: support default-value for date-range

### DIFF
--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -153,6 +153,14 @@
   import DateTable from '../basic/date-table';
   import ElInput from 'element-ui/packages/input';
 
+  const calcDefaultValue = defaultValue => {
+    if (Array.isArray(defaultValue)) {
+      return new Date(defaultValue[0]);
+    } else {
+      return new Date(defaultValue);
+    }
+  };
+
   export default {
     mixins: [Locale],
 
@@ -221,7 +229,7 @@
         popperClass: '',
         minPickerWidth: 0,
         maxPickerWidth: 0,
-        date: new Date(),
+        date: this.$options.defaultValue ? calcDefaultValue(this.$options.defaultValue) : new Date(),
         minDate: '',
         maxDate: '',
         rangeState: {
@@ -297,6 +305,7 @@
       handleClear() {
         this.minDate = null;
         this.maxDate = null;
+        this.date = this.$options.defaultValue ? calcDefaultValue(this.$options.defaultValue) : new Date();
         this.handleConfirm(false);
       },
 

--- a/test/unit/specs/date-picker.spec.js
+++ b/test/unit/specs/date-picker.spec.js
@@ -319,23 +319,11 @@ describe('DatePicker', () => {
   });
 
   it('default value', done => {
-    const toDateStr = date => {
-      let d = new Date(date);
-      return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
-    };
-    let today = new Date();
-    let nextMonth = new Date(today);
-    nextMonth.setDate(1);
-    if (nextMonth.getMonth() === 12) {
-      nextMonth.setFullYear(today.getFullYear + 1);
-      nextMonth.setMonth(1);
-    } else {
-      nextMonth.setMonth(today.getMonth() + 1);
-    }
-    let nextMonthStr = toDateStr(nextMonth);
+    let defaultValue = '2000-01-01';
+    let expectValue = new Date(2000, 0, 1);
 
     vm = createVue({
-      template: `<el-date-picker v-model="value" ref="compo" default-value="${nextMonthStr}" />`,
+      template: `<el-date-picker v-model="value" ref="compo" default-value="${defaultValue}" />`,
       data() {
         return {
           value: ''
@@ -350,10 +338,10 @@ describe('DatePicker', () => {
       const $el = vm.$refs.compo.picker.$el;
       $el.querySelector('td.current').click();
       setTimeout(_ => {
-        expect(vm.value).to.equal(nextMonthStr);
-      });
-      done();
-    });
+        expect(+vm.value).to.equal(+expectValue);
+        done();
+      }, 10);
+    }, 10);
   });
 
   describe('keydown', () => {


### PR DESCRIPTION
date-range 模式下支持 default-value 选项，控制面板默认显示的日期。

实现与 date 模式下相同。

DEMO: https://jsfiddle.net/u2opvyxa/