### PR TITLE
Pagination: fix event 'current-change'

### DIFF
--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -38,7 +38,8 @@ export default {
   data() {
     return {
       internalCurrentPage: 1,
-      internalPageSize: 0
+      internalPageSize: 0,
+      shouldTriggerCurrenChange: true
     };
   },
 
@@ -304,6 +305,10 @@ export default {
     currentPage: {
       immediate: true,
       handler(val) {
+        /* only execute when component is mounted */
+        if (this._isMounted) {
+          this.shouldTriggerCurrenChange = (val === this.internalCurrentPage);
+        }
         this.internalCurrentPage = val;
       }
     },
@@ -328,10 +333,11 @@ export default {
       if (newVal !== undefined) {
         this.$nextTick(() => {
           this.internalCurrentPage = newVal;
-          if (oldVal !== newVal) {
+          if (this.shouldTriggerCurrenChange && (oldVal !== newVal)) {
             this.$emit('update:currentPage', newVal);
             this.$emit('current-change', this.internalCurrentPage);
           }
+          this.shouldTriggerCurrenChange = true;
         });
       } else {
         this.$emit('update:currentPage', newVal);


### PR DESCRIPTION
when 'current-page' is modifed manually outside \<el-pagination\/\>, 'current-change' shouldn't be triggered

connected to #3339 

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
