### PR TITLE
Table: fix fixed's box-shadow without a horizontal scroll bar

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -49,7 +49,12 @@
         :style="{ width: layout.bodyWidth ? layout.bodyWidth + 'px' : '' }">
       </table-footer>
     </div>
-    <div class="el-table__fixed" ref="fixedWrapper"
+    <div
+      :class="[
+        'el-table__fixed',
+        { 'el-table__fixed-without-h-scroll-bar': !this.layout.scrollX }
+      ]"
+      ref="fixedWrapper"
       v-if="fixedColumns.length > 0"
       :style="[
         { width: layout.fixedWidth ? layout.fixedWidth + 'px' : '' },
@@ -90,7 +95,12 @@
           :style="{ width: layout.fixedWidth ? layout.fixedWidth + 'px' : '' }"></table-footer>
       </div>
     </div>
-    <div class="el-table__fixed-right" ref="rightFixedWrapper"
+    <div
+      :class="[
+        'el-table__fixed-right',
+        { 'el-table__fixed-without-h-scroll-bar': !this.layout.scrollX }
+      ]"
+      ref="rightFixedWrapper"
       v-if="rightFixedColumns.length > 0"
       :style="[
         { width: layout.rightFixedWidth ? layout.rightFixedWidth + 'px' : '' },

--- a/packages/theme-default/src/table.css
+++ b/packages/theme-default/src/table.css
@@ -216,6 +216,10 @@
       }
     }
 
+    @e fixed-without-h-scroll-bar {
+      box-shadow: none;
+    }
+
     @e fixed-header-wrapper {
       position: absolute;
       left: 0;


### PR DESCRIPTION
when a table's horizontal scroll bar disappears, fixed columns' box-shadow should also be invisible

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
