### PR TITLE
select: fix el.form.change emission

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -268,7 +268,6 @@
         if (this.filterable && !this.multiple) {
           this.inputLength = 20;
         }
-        this.dispatch('ElFormItem', 'el.form.change', val);
       },
 
       visible(val) {
@@ -394,6 +393,7 @@
       emitChange(val) {
         if (!valueEquals(this.value, val)) {
           this.$emit('change', val);
+          this.dispatch('ElFormItem', 'el.form.change', val);
         }
       },
 

--- a/test/unit/specs/form.spec.js
+++ b/test/unit/specs/form.spec.js
@@ -320,7 +320,7 @@ describe('Form', () => {
             <el-form-item label="记住密码" prop="region" ref="field">
               <el-select v-model="form.region" placeholder="请选择活动区域">
                 <el-option label="区域一" value="shanghai"></el-option>
-                <el-option label="区域二" value="beijing"></el-option>
+                <el-option label="区域二" ref="opt" value="beijing"></el-option>
               </el-select>
             </el-form-item>
           </el-form>
@@ -328,7 +328,7 @@ describe('Form', () => {
         data() {
           return {
             form: {
-              region: 'shanghai'
+              region: ''
             },
             rules: {
               region: [
@@ -336,24 +336,23 @@ describe('Form', () => {
               ]
             }
           };
-        },
-        methods: {
-          setValue(value) {
-            this.form.region = value;
-          }
         }
       }, true);
       vm.$refs.form.validate(valid => {
         let field = vm.$refs.field;
-        expect(valid).to.true;
-        vm.setValue('');
+        expect(valid).to.false;
         setTimeout(_ => {
           expect(field.validateMessage).to.equal('请选择活动区域');
-          vm.setValue('shanghai');
-
+          // programatic modification of bound value does not triggers change validation
+          vm.form.region = 'shanghai';
           setTimeout(_ => {
-            expect(field.validateMessage).to.equal('');
-            done();
+            expect(field.validateMessage).to.equal('请选择活动区域');
+            // user modification of bound value triggers change validation
+            vm.$refs.opt.$el.click();
+            setTimeout(_ => {
+              expect(field.validateMessage).to.equal('');
+              done();
+            }, 100);
           }, 100);
         }, 100);
       });


### PR DESCRIPTION
https://github.com/ElemeFE/element/issues/6011

本应该和 https://github.com/ElemeFE/element/pull/5360 在一起。

修正后，仅在用户修改时会触发校验 -> 通过程序修改时不会触发。

** 感觉 FormItem 应该新增一个清空验证状态的方法。 **

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
