### PR TITLE
ColorPicker: Fixed `Unknown custom element: <el-button>` error

### DIFF
--- a/packages/color-picker/src/components/picker-dropdown.vue
+++ b/packages/color-picker/src/components/picker-dropdown.vue
@@ -43,6 +43,7 @@
   import Popper from 'element-ui/src/utils/vue-popper';
   import Locale from 'element-ui/src/mixins/locale';
   import ElInput from 'element-ui/packages/input';
+  import ElButton from 'element-ui/packages/button';
 
   export default {
     name: 'el-color-picker-dropdown',
@@ -53,7 +54,8 @@
       SvPanel,
       HueSlider,
       AlphaSlider,
-      ElInput
+      ElInput,
+      ElButton
     },
 
     props: {


### PR DESCRIPTION
Added explicit ElButton reference as `el-button` is used in the template. Fixes error when ColorPicker is used on-demand.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [ ] Make sure you are merging your commits to `dev` branch. (think you mean `carbon` in this case)
* [x] Add some descriptions and refer relative issues for you PR.
