### PR TITLE
Remove implicit any in type definition

### DIFF
--- a/types/carousel.d.ts
+++ b/types/carousel.d.ts
@@ -36,18 +36,18 @@ export declare class ElCarousel extends ElementUIComponent {
    *
    * @param index Index of the slide to be switched to (starting from 0)
    */
-  setActiveItem (index: number)
+  setActiveItem (index: number): void
 
   /**
    * Manually switch slide by carousel item's name
    *
    * @param name The name of the corresponding `el-carousel-item`
    */
-  setActiveItem (name: string)
+  setActiveItem (name: string): void
 
   /** Switch to the previous slide */
-  prev ()
+  prev (): void
 
   /** Switch to the next slide */
-  next ()
+  next (): void
 }

--- a/types/component.d.ts
+++ b/types/component.d.ts
@@ -3,7 +3,7 @@ import Vue from 'vue'
 /** ElementUI component common definition */
 export declare class ElementUIComponent extends Vue {
   /** Install component into Vue */
-  static install (vue: typeof Vue)
+  static install (vue: typeof Vue): void
 }
 
 /** Component size definition for button, input, etc */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,7 +77,7 @@ declare namespace ElementUI {
    * Please do not invoke this method directly.
    * Call `Vue.use(ElementUI)` to install.
    */
-  export function install (vue: typeof Vue, options: ElementUI.InstallationOptions)
+  export function install (vue: typeof Vue, options: ElementUI.InstallationOptions): void
 
   /** ElementUI component common definition */
   export type Component = ElementUIComponent

--- a/types/loading.d.ts
+++ b/types/loading.d.ts
@@ -30,7 +30,7 @@ export interface LoadingServiceOptions {
 /** Loading Component */
 export declare class ElLoadingComponent extends Vue {
   /** Close the Loading instance */
-  close ()
+  close (): void
 }
 
 /** Loading directive definition */
@@ -46,7 +46,7 @@ export interface ElLoadingDirective extends VNodeDirective {
 /** Show animation while loading data */
 export interface ElLoading {
   /** Install Loading directive into Vue */
-  install (vue: typeof Vue)
+  install (vue: typeof Vue): void
 
   /** If you do not have a specific DOM node to attach the Loading directive, or if you simply prefer not to use Loading as a directive, you can call this service with some configs to open a Loading instance. */
   service (options: LoadingServiceOptions): ElLoadingComponent

--- a/types/message-box.d.ts
+++ b/types/message-box.d.ts
@@ -139,10 +139,10 @@ export interface ElMessageBox {
   prompt: ElMessageBoxShortcutMethod
 
   /** Set default options of message boxes */
-  setDefaults (defaults: ElMessageBoxOptions)
+  setDefaults (defaults: ElMessageBoxOptions): void
 
   /** Close current message box */
-  close ()
+  close (): void
 }
 
 declare module 'vue/types/vue' {

--- a/types/message.d.ts
+++ b/types/message.d.ts
@@ -5,7 +5,7 @@ export type MessageType = 'success' | 'warning' | 'info' | 'error'
 /** Message Component */
 export declare class ElMessageComponent extends Vue {
   /** Close the Loading instance */
-  close ()
+  close (): void
 }
 
 export interface CloseEventHandler {

--- a/types/notification.d.ts
+++ b/types/notification.d.ts
@@ -4,7 +4,7 @@ import { MessageType } from './message'
 /** Notification Component */
 export declare class ElNotificationComponent extends Vue {
   /** Close the Notification instance */
-  close ()
+  close (): void
 }
 
 export interface ElNotificationOptions {

--- a/types/tree.d.ts
+++ b/types/tree.d.ts
@@ -46,7 +46,7 @@ export declare class ElTree extends ElementUIComponent {
   props: object
 
   /** Method for loading subtree data */
-  load: (node: TreeNode, resolve) => void
+  load: (node: TreeNode, resolve: Function) => void
 
   /** Render function for tree node */
   renderContent: RenderContent
@@ -128,7 +128,7 @@ export declare class ElTree extends ElementUIComponent {
    * @param checked Indicating the node checked or not
    * @param deep Indicating whether to checked state deeply or not
    */
-  setChecked (data: TreeNode | any, checked: boolean, deep: boolean)
+  setChecked (data: TreeNode | any, checked: boolean, deep: boolean): void
 
   /**
    * Return the highlight node's key (null if no node is highlighted)

--- a/types/tree.d.ts
+++ b/types/tree.d.ts
@@ -1,6 +1,5 @@
 import { CreateElement, VNode } from 'vue'
 import { ElementUIComponent } from './component'
-import {Tree} from "./index";
 
 /** The node of the tree */
 export interface TreeNode {


### PR DESCRIPTION
Make the definitions compliant with the option `--noImplicitAny` of [typescript's compiler](https://www.typescriptlang.org/docs/handbook/compiler-options.html).