### PR TITLE
DatePicker: fix bug for wrong year number when week cross the year

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -162,8 +162,14 @@ const TYPE_VALUE_RESOLVER_MAP = {
   },
   week: {
     formatter(value, format) {
-      let date = formatDate(value, format);
-      const week = getWeekNumber(value);
+      let week = getWeekNumber(value);
+      let month = value.getMonth();
+      const trueDate = new Date(value);
+      if (week === 1 && month === 11) {
+        trueDate.setHours(0, 0, 0, 0);
+        trueDate.setDate(trueDate.getDate() + 3 - (trueDate.getDay() + 6) % 7);
+      }
+      let date = formatDate(trueDate, format);
 
       date = /WW/.test(date)
             ? date.replace(/WW/, week < 10 ? '0' + week : week)


### PR DESCRIPTION
…ke 2014/12/29

我发现了一个bug并且尝试修复。我在使用DatePicker选择周的时候，发现：如果周在跨年的状态下，会出现年份错误。

例如: 当我查看2014年12月29日的周数的时候，得到的是2014年1月。

所以我查看了源码发现没有更新年份，因此我尝试解决。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
