### PR TITLE
Select: Fix size el-tag in multiple select

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -14,7 +14,7 @@
           v-for="item in selected"
           :key="getValueKey(item)"
           :closable="!disabled"
-          size="small"
+          :size="selectSize"
           :hit="item.hitState"
           type="info"
           @close="deleteTag($event, item)"


### PR DESCRIPTION
Size el-tag in multiple select is always small.
This change fix size el-tags as selectSize.
