### PR TITLE
[bugfix] remove outline for collapse & upload

### DIFF
--- a/examples/docs/en-US/upload.md
+++ b/examples/docs/en-US/upload.md
@@ -18,7 +18,7 @@
         position: relative;
         overflow: hidden;
 
-        &:hover {
+        &:hover, &:focus {
           border-color: #409EFF;
         }
       }

--- a/examples/docs/zh-CN/upload.md
+++ b/examples/docs/zh-CN/upload.md
@@ -18,7 +18,7 @@
         position: relative;
         overflow: hidden;
 
-        &:hover {
+        &:hover, &:focus{
           border-color: #409EFF;
         }
       }

--- a/packages/theme-chalk/src/collapse.scss
+++ b/packages/theme-chalk/src/collapse.scss
@@ -16,10 +16,7 @@
     font-size: $--collapse-header-size;
     font-weight: 500;
     transition: border-bottom-color .3s;
-    &:focus:not(.focusing), &:active {
-      outline-width: 0;
-    }
-
+    outline: none;
     @include e(arrow) {
       margin-right: 8px;
       transition: transform .3s;
@@ -27,6 +24,14 @@
       line-height: 48px;
       font-weight: 300;
     }
+    &.focusing:focus:not(:hover){
+      color: $--color-primary;
+    }
+
+    //&:focus{
+    //  color: $--color-primary;
+    //}
+
   }
 
   @include e(wrap) {

--- a/packages/theme-chalk/src/upload.scss
+++ b/packages/theme-chalk/src/upload.scss
@@ -6,7 +6,7 @@
   display: inline-block;
   text-align: center;
   cursor: pointer;
-
+  outline: none;
   @include e(input) {
     display: none;
   }
@@ -46,6 +46,14 @@
     &:hover {
       border-color: $--color-primary;
       color: $--color-primary;
+    }
+  }
+  &:focus {
+    border-color: $--color-primary;
+    color: $--color-primary;
+
+    .el-upload-dragger {
+      border-color: $--color-primary;
     }
   }
 }
@@ -160,11 +168,11 @@
       display: none;
       position: absolute;
       top: 5px;
-      right: 0;
+      right: 5px;
+      font-size: 12px;
       cursor: pointer;
       opacity: 1;
       color: $--color-primary;
-      transform: translate(15%,0);
     }
     
     &:hover {
@@ -189,20 +197,20 @@
         cursor: pointer;
       }
 
-      &:focus {
+      &:focus:not(:hover) {  /* 键盘focus */
         .el-icon-close-tip {
           display: inline-block;
         }
       }
 
-      &:focus:not(.focusing), &:active {
+      &:not(.focusing):focus, &:active { /* click时 */
         outline-width: 0;
         .el-icon-close-tip {
           display: none;
         }
       }
 
-      &:hover, &:focus {  /*键盘焦点时 显示提示文字 focus*/
+      &:hover, &:focus {
         .el-upload-list__item-status-label {
           display: none;
         }


### PR DESCRIPTION
1、修复collapse点击时闪现 outline的bug

2、修改upload组件的 upload框框点击时outline的bug，新增:focus样式(同:hover样式一致)，因为浏览器原生的input=file组件在上传文件完成后，焦点会保留在input上，因此upload框框在上传文件后，依然会保持聚焦行为，和浏览器原生行为保持一致；
