### PR TITLE
Fix inconsistency of the TypeScript definitions - Solution 1

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -283,4 +283,4 @@ declare namespace ElementUI {
   export class Upload extends ElUpload {}
 }
 
-export default ElementUI
+export = ElementUI


### PR DESCRIPTION
@vtroop asked a question about importing element-ui in TypeScript in #3910 today. And I notice that there is a critical inconsistency in index.d.ts:

```typescript
declare namespace ElementUI { ... }
export default ElementUI
```

When importing element-ui, TypeScript will do conversions like this:

```typescript
import ElementUI from 'element-ui'
import * as ElementUI from 'element-ui'
```

```javascript
var ElementUI = require('element-ui').default
var ElementUI = require('element-ui')
```

But Babel and webpack will try to find default export for compatibility like this:

```javascript
import ElementUI from 'element-ui'
// -->
var ElementUI = require('element-ui').default || require('element-ui')
```

In the source file, components and functions are exported via `module.exports`. There is no `default` entry in the exports.

The first solution is the same as this PR does: to change the definition file and tell users to import element-ui like this:

```typescript
import * as ElementUI from 'element-ui'
```

See #7940 for solution 2.