### PR TITLE
Fix inconsistency of the TypeScript definitions - Solution 2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,3 +248,5 @@ module.exports = {
   Main,
   Footer
 };
+
+module.exports.default = module.exports;


### PR DESCRIPTION
See descriptions in #7939

The second Solution is to add a `default` entry in the exports. So you can keep the original typings and users can import element-ui like this:


```typescript
import ElementUI from 'element-ui'
```

Then TypeScript will resolve the module correctly.
 