### PR TITLE
Notification: fix unnecessary required type definitions

### DIFF
--- a/types/notification.d.ts
+++ b/types/notification.d.ts
@@ -15,31 +15,31 @@ export interface ElNotificationOptions {
   message: string | VNode
 
   /** Notification type */
-  type: MessageType
+  type?: MessageType
 
   /** Custom icon's class. It will be overridden by type */
-  iconClass: string
+  iconClass?: string
 
   /** Custom class name for Notification */
-  customClass: string
+  customClass?: string
 
   /** Duration before close. It will not automatically close if set 0 */
-  duration: number
+  duration?: number
 
   /** Whether to show a close button */
-  showClose: boolean
+  showClose?: boolean
 
   /** Whether message is treated as HTML string */
   dangerouslyUseHTMLString?: boolean
 
   /** Callback function when closed */
-  onClose: () => void
+  onClose?: () => void
 
   /** Callback function when notification clicked */
-  onClick: () => void
+  onClick?: () => void
 
   /** Offset from the top edge of the screen. Every Notification instance of the same moment should have the same offset */
-  offset: number
+  offset?: number
 }
 
 export interface ElNotification {


### PR DESCRIPTION
According to [notification components docs](http://element.eleme.io/#/en-US/component/notification#basic-usage), all needed properties of notification options is only `title` and `message`. But now, all properties are defined as required in type difinitions. 
So I fixed the other properties to be optional.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
