### PR TITLE
Add spaces between Chinese, English and numbers.

### DIFF
--- a/src/locale/lang/zh-CN.js
+++ b/src/locale/lang/zh-CN.js
@@ -82,7 +82,7 @@ export default {
       error: '输入的数据不合法!'
     },
     upload: {
-      deleteTip: '按delete键可删除',
+      deleteTip: '按 delete 键可删除',
       delete: '删除',
       preview: '查看图片',
       continue: '继续上传'

--- a/src/locale/lang/zh-TW.js
+++ b/src/locale/lang/zh-TW.js
@@ -82,7 +82,7 @@ export default {
       error: '輸入的資料不符規定!'
     },
     upload: {
-      deleteTip: '按delete鍵可刪除',
+      deleteTip: '按 delete 鍵可刪除',
       delete: '刪除',
       preview: '查看圖片',
       continue: '繼續上傳'


### PR DESCRIPTION
这几项中英文或数字之间都有空格：
1. `noCheckedFormat: '共 {total} 项'` 
2. `titles: ['列表 1', '列表 2']`
3. `total: '共 {total} 条'`

唯独它「`deleteTip: '按delete键可删除'`」是没有空格的。