### PR TITLE
Breadcrumb: use provide/inject instead of this.$parent

### DIFF
--- a/packages/breadcrumb/src/breadcrumb-item.vue
+++ b/packages/breadcrumb/src/breadcrumb-item.vue
@@ -20,9 +20,12 @@
         separatorClass: ''
       };
     },
+
+    inject: ['elBreadcrumb'],
+
     mounted() {
-      this.separator = this.$parent.separator;
-      this.separatorClass = this.$parent.separatorClass;
+      this.separator = this.elBreadcrumb.separator;
+      this.separatorClass = this.elBreadcrumb.separatorClass;
       let self = this;
       if (this.to) {
         let link = this.$refs.link;

--- a/packages/breadcrumb/src/breadcrumb.vue
+++ b/packages/breadcrumb/src/breadcrumb.vue
@@ -17,6 +17,13 @@
         default: ''
       }
     },
+
+    provide() {
+      return {
+        elBreadcrumb: this
+      };
+    },
+
     mounted() {
       const items = this.$el.querySelectorAll('.el-breadcrumb__item');
       items[items.length - 1].setAttribute('aria-current', 'page');


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x ] Make sure you are merging your commits to `dev` branch.
* [x ] Add some descriptions and refer relative issues for you PR.


if l want  add some animation to breadcrumb ,like
```
<el-breadcrumb separator="/">
  <transition-group  name="slide">
    <el-breadcrumb-item key='1' :to="{ path: '/' }">首页</el-breadcrumb-item>
    <el-breadcrumb-item key='2'>活动管理</el-breadcrumb-item>
    <el-breadcrumb-item key='3'>活动列表</el-breadcrumb-item>
    <el-breadcrumb-item key='4'>活动详情</el-breadcrumb-item>
  </transition-group>
</el-breadcrumb>
```
because of the code `this.separator = this.$parent.separator;` , so l could not set `separator`.
so i think use `provide/inject` is better