### PR TITLE
MessageBox : fix unclosed overlay after called close()

### DIFF
--- a/packages/message-box/src/main.js
+++ b/packages/message-box/src/main.js
@@ -204,6 +204,7 @@ MessageBox.prompt = (message, title, options) => {
 };
 
 MessageBox.close = () => {
+  instance.doClose();
   instance.visible = false;
   msgQueue = [];
   currentMsg = null;


### PR DESCRIPTION
Fixed issue [#5667](https://github.com/ElemeFE/element/issues/5667) and [#7672](https://github.com/ElemeFE/element/issues/7672). 

---

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
