### PR TITLE
Menu: use <router-link> in router mode

### DIFF
--- a/packages/menu/src/menu-item.vue
+++ b/packages/menu/src/menu-item.vue
@@ -1,33 +1,3 @@
-<template>
-  <li class="el-menu-item"
-    :style="[paddingStyle, itemStyle, { backgroundColor }]"
-    @click="handleClick"
-    @mouseenter="onMouseEnter"
-    @focus="onMouseEnter"
-    @blur="onMouseLeave"
-    @mouseleave="onMouseLeave"
-    :class="{
-      'is-active': active,
-      'is-disabled': disabled
-    }"
-    role="menuitem"
-    tabindex="-1"
-  >
-    <el-tooltip
-      v-if="$parent === rootMenu && rootMenu.collapse"
-      effect="dark"
-      placement="right">
-      <div slot="content"><slot name="title"></slot></div>
-      <div style="position: absolute;left: 0;top: 0;height: 100%;width: 100%;display: inline-block;box-sizing: border-box;padding: 0 20px;">
-        <slot></slot>
-      </div>
-    </el-tooltip>
-    <template v-else>
-      <slot></slot>
-      <slot name="title"></slot>
-    </template>
-  </li>
-</template>
 <script>
   import Menu from './menu-mixin';
   import ElTooltip from 'element-ui/packages/tooltip';
@@ -93,11 +63,11 @@
     methods: {
       onMouseEnter() {
         if (this.mode === 'horizontal' && !this.rootMenu.backgroundColor) return;
-        this.$el.style.backgroundColor = this.hoverBackground;
+        this.$refs.item.style.backgroundColor = this.hoverBackground;
       },
       onMouseLeave() {
         if (this.mode === 'horizontal' && !this.rootMenu.backgroundColor) return;
-        this.$el.style.backgroundColor = this.backgroundColor;
+        this.$refs.item.style.backgroundColor = this.backgroundColor;
       },
       handleClick() {
         this.dispatch('ElMenu', 'item-click', this);
@@ -111,6 +81,45 @@
     beforeDestroy() {
       this.parentMenu.removeItem(this);
       this.rootMenu.removeItem(this);
+    },
+
+    render(h) {
+      const item = (
+        <li ref="item"
+          style={[this.paddingStyle, this.itemStyle, { backgroundColor: this.backgroundColor }]}
+          onClick={this.handleClick}
+          onMouseenter={this.onMouseEnter}
+          onFocus={this.onMouseEnter}
+          onBlur={this.onMouseLeave}
+          onMouseleave={this.onMouseLeave}
+          class={{
+            'el-menu-item': true,
+            'is-active': this.active,
+            'is-disabled': this.disabled
+          }}
+          role="menuitem"
+          tabindex="-1"
+        >
+          {
+            this.$parent === this.rootMenu && this.rootMenu.collapse
+              ? (
+                <el-tooltip
+                  effect="dark"
+                  placement="right">
+                  <div slot="content">{this.$slots.title}</div>
+                  <div style="position: absolute;left: 0;top: 0;height: 100%;width: 100%;display: inline-block;box-sizing: border-box;padding: 0 20px;">
+                    {this.$slots.default}
+                  </div>
+                </el-tooltip>
+              )
+              : [this.$slots.default, this.$slots.title]
+          }
+        </li>
+      );
+
+      return this.rootMenu.router
+        ? <router-link to={this.route || this.index}>{item}</router-link>
+        : item;
     }
   };
 </script>

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -241,10 +241,6 @@
         if (this.mode === 'horizontal' || this.collapse) {
           this.openedMenus = [];
         }
-
-        if (this.router) {
-          this.routeToItem(item);
-        }
       },
       // 初始化展开菜单
       // initialize opened menu
@@ -261,14 +257,6 @@
           let submenu = this.submenus[index];
           submenu && this.openMenu(index, submenu.indexPath);
         });
-      },
-      routeToItem(item) {
-        let route = item.route || item.index;
-        try {
-          this.$router.push(route);
-        } catch (e) {
-          console.error(e);
-        }
       },
       open(index) {
         const { indexPath } = this.submenus[index.toString()];


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

---

Using `<router-link>` instead of programmatically calling `vm.$router.push` bring theses benefits:

1. Links are rendered to real `<a>` tags and are capable of what normal links can do. E.g. open in new tab, copy link, add to bookmarks...
2. Fix #1915: MenuItem will have `<router-link>`'s active class.