### PR TITLE
[Form]: added validateOnRuleChange

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -34,11 +34,17 @@
         type: Boolean,
         default: true
       },
-      size: String
+      size: String,
+      validateOnRuleChange: {
+        type: Boolean,
+        default: true
+      }
     },
     watch: {
       rules() {
-        this.validate();
+        if (this.validateOnRuleChange) {
+          this.validate(() => {});
+        }
       }
     },
     data() {


### PR DESCRIPTION
In my use case, the rules provided to form change dynamically. The form validating itself every time is not welcome.

I would add this validateOnRuleChange boolean value, that can be changed to false to prevent this behavior.

Also the watcher didn't provide a callback to the validate() so the rejected promise escaped to console and was shown as error.
