### PR TITLE
clickoutside: fix memory leak

### DIFF
--- a/src/utils/clickoutside.js
+++ b/src/utils/clickoutside.js
@@ -12,6 +12,29 @@ let seed = 0;
 !Vue.prototype.$isServer && on(document, 'mouseup', e => {
   nodeList.forEach(node => node[ctx].documentHandler(e, startClick));
 });
+
+function createDocumentHandler (el, binding, vnode) {
+  return function(mouseup = {}, mousedown = {}) {
+    if (!vnode.context ||
+      !mouseup.target ||
+      !mousedown.target ||
+      el.contains(mouseup.target) ||
+      el.contains(mousedown.target) ||
+      el === mouseup.target ||
+      (vnode.context.popperElm &&
+      (vnode.context.popperElm.contains(mouseup.target) ||
+      vnode.context.popperElm.contains(mousedown.target)))) return;
+
+    if (binding.expression &&
+      el[ctx].methodName &&
+      vnode.context[el[ctx].methodName]) {
+      vnode.context[el[ctx].methodName]();
+    } else {
+      el[ctx].bindingFn && el[ctx].bindingFn();
+    }
+  };
+}
+
 /**
  * v-clickoutside
  * @desc 点击元素外面才会触发的事件
@@ -24,34 +47,16 @@ export default {
   bind(el, binding, vnode) {
     nodeList.push(el);
     const id = seed++;
-    const documentHandler = function(mouseup = {}, mousedown = {}) {
-      if (!vnode.context ||
-        !mouseup.target ||
-        !mousedown.target ||
-        el.contains(mouseup.target) ||
-        el.contains(mousedown.target) ||
-        el === mouseup.target ||
-        (vnode.context.popperElm &&
-        (vnode.context.popperElm.contains(mouseup.target) ||
-        vnode.context.popperElm.contains(mousedown.target)))) return;
-
-      if (binding.expression &&
-        el[ctx].methodName &&
-        vnode.context[el[ctx].methodName]) {
-        vnode.context[el[ctx].methodName]();
-      } else {
-        el[ctx].bindingFn && el[ctx].bindingFn();
-      }
-    };
     el[ctx] = {
       id,
-      documentHandler,
+      documentHandler: createDocumentHandler(el, binding, vnode),
       methodName: binding.expression,
       bindingFn: binding.value
     };
   },
 
-  update(el, binding) {
+  update(el, binding, vnode) {
+    el[ctx].documentHandler = createDocumentHandler(el, binding, vnode);
     el[ctx].methodName = binding.expression;
     el[ctx].bindingFn = binding.value;
   },


### PR DESCRIPTION
Relative issue: [#7465](https://github.com/ElemeFE/element/issues/7465)

`documentHandler` use an old vnode in closure, which caused unexpected memory leak.