### PR TITLE
make pagination responsible to the URL param

### DIFF
--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -40,7 +40,9 @@ export default {
 
     prevText: String,
 
-    nextText: String
+    nextText: String,
+
+    token: String
   },
 
   data() {
@@ -303,7 +305,13 @@ export default {
       } else if (resetValue === 0) {
         resetValue = 1;
       }
-
+      if (this.token) {
+        let url = new URL(window.location.href);
+        url.searchParams.set(this.token, resetValue === undefined ? value : resetValue);
+        this.$nextTick(_=>{
+          window.history.pushState(null, document.title, url.toString());
+        });
+      }
       return resetValue === undefined ? value : resetValue;
     }
   },
@@ -367,5 +375,15 @@ export default {
         this.internalCurrentPage = newVal === 0 ? 1 : newVal;
       }
     }
+  },
+  mounted() {
+    if (this.token) {
+      let url = new URL(window.location.href);
+      let page = url.searchParams.get(this.token);
+      if (page) {
+        this.internalCurrentPage = +page;
+      }
+    }
   }
 };
+


### PR DESCRIPTION
1. if the current page of the pagination changes, the corresponding param will change automatically
2. when mounted, if there is a param in URL, it will be the default value of current page
3. all the above functionality only are available when `token` is set in the `el-pagination` tag

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you are merging your commits to `dev` branch.
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md)).
* [x] Add some descriptions and refer relative issues for you PR.
