### PR TITLE
[Loading]: .close() can be called earlier than visible=true

### DIFF
--- a/packages/loading/src/index.js
+++ b/packages/loading/src/index.js
@@ -19,21 +19,23 @@ LoadingConstructor.prototype.originalPosition = '';
 LoadingConstructor.prototype.originalOverflow = '';
 
 LoadingConstructor.prototype.close = function() {
-  if (this.fullscreen) {
-    fullscreenLoading = undefined;
-  }
-  this.$on('after-leave', _ => {
-    const target = this.fullscreen || this.body
-      ? document.body
-      : this.target;
-    removeClass(target, 'el-loading-parent--relative');
-    removeClass(target, 'el-loading-parent--hidden');
-    if (this.$el && this.$el.parentNode) {
-      this.$el.parentNode.removeChild(this.$el);
+  Vue.nextTick(() => {
+    if (this.fullscreen) {
+      fullscreenLoading = undefined;
     }
-    this.$destroy();
+    this.$on('after-leave', _ => {
+      const target = this.fullscreen || this.body
+        ? document.body
+        : this.target;
+      removeClass(target, 'el-loading-parent--relative');
+      removeClass(target, 'el-loading-parent--hidden');
+      if (this.$el && this.$el.parentNode) {
+        this.$el.parentNode.removeChild(this.$el);
+      }
+      this.$destroy();
+    });
+    this.visible = false;
   });
-  this.visible = false;
 };
 
 const addStyle = (options, parent, instance) => {


### PR DESCRIPTION
TL;DR: Sometimes the async sequence of operations can be: `this.visible = false; this.visible = true;` leaving the "Loading" opened forever.

In some scenarios the `.close()` can be called before
```
  Vue.nextTick(() => {
    instance.visible = true;
  });
```
Scenarios include some in-memory caching (Relay/Apollo GraphQL for example).

First time the "Loading" div shows fine. The second time (when a value is cached in memory) it shows and stays forever because `.close()` was called right after the `Loading` constructor call.

The proposed fix solves the bug. Not sure if that's the right way, or if I broke anything else. Probably need testing from core maintainers.

Happy to rework if needed.
