### PR TITLE
Input: autocomplete support suffixIcon & prefixIcon

### DIFF
--- a/examples/docs/en-US/input.md
+++ b/examples/docs/en-US/input.md
@@ -674,6 +674,8 @@ Attribute | Description | Type | Options | Default
 | name | same as `name` in native input | string | — | — |
 | select-when-unmatched | whether to emit a `select` event on enter when there is no autocomplete match | boolean | — | false |
 | label | label text | string | — | — |
+| prefix-icon | prefix icon class | string | — | — |
+| suffix-icon | suffix icon class | string | — | — |
 
 ### Autocomplete slots
 

--- a/examples/docs/zh-CN/input.md
+++ b/examples/docs/zh-CN/input.md
@@ -831,6 +831,8 @@ export default {
 | name | 原生属性 | string | — | — |
 | select-when-unmatched | 在输入没有任何匹配建议的情况下，按下回车是否触发 `select` 事件 | boolean | — | false |
 | label | 输入框关联的label文字 | string | — | — |
+| prefix-icon | 输入框头部图标 | string | — | — |
+| suffix-icon | 输入框尾部图标 | string | — | — |
 
 ### Autocomplete slots
 | name | 说明 |

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -103,6 +103,8 @@
         type: Boolean,
         default: false
       },
+      prefixIcon: String,
+      suffixIcon: String,
       label: String,
       debounce: {
         type: Number,


### PR DESCRIPTION
【需求】
```html
<el-autocomplete suffix-icon="el-icon-search"></el-autocomplete>
```

【当前情况】
 只允许使用 $slot 进行设置 autocomplete 组件的 `suffix-icon` 或者 `prefix-icon`
