### PR TITLE
modify set collapse-tags just show text

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -9,9 +9,8 @@
       @click.stop="toggleMenu"
       ref="tags"
       :style="{ 'max-width': inputWidth - 32 + 'px' }">
-      <transition-group  v-if="collapseTags && selected.length">
+      <div v-if="collapseTags && selected.length">
         <el-tag
-          :key="getValueKey(selected[0])"
           :closable="!disabled"
           size="small"
           :hit="selected[0].hitState"
@@ -21,15 +20,14 @@
           <span class="el-select__tags-text">{{ selected[0].currentLabel }}</span>
         </el-tag>
         <el-tag
-          v-show="selected.length > 1"
-          key="el__select__collapse"
+          v-if="selected.length > 1"
           :closable="false"
           size="small"
           type="info"
-        >
+          disable-transitions>
           <span class="el-select__tags-text">+ {{ selected.length - 1 }}</span>
         </el-tag>
-      </transition-group>
+      </div>
       <transition-group @after-leave="resetInputHeight" v-if="!collapseTags">
         <el-tag
           v-for="item in selected"

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -9,12 +9,27 @@
       @click.stop="toggleMenu"
       ref="tags"
       :style="{ 'max-width': inputWidth - 32 + 'px' }">
-      <span
-        class="el-select__multiple-text"
-        v-show="multipleText"
-        v-if="collapseTags">
-        {{ multipleText }}
-      </span>
+      <transition-group  v-if="collapseTags && selected.length">
+        <el-tag
+          :key="getValueKey(selected[0])"
+          :closable="!disabled"
+          size="small"
+          :hit="selected[0].hitState"
+          type="info"
+          @close="deleteTag($event, selected[0])"
+          disable-transitions>
+          <span class="el-select__tags-text">{{ selected[0].currentLabel }}</span>
+        </el-tag>
+        <el-tag
+          v-show="selected.length > 1"
+          key="el__select__collapse"
+          :closable="false"
+          size="small"
+          type="info"
+        >
+          <span class="el-select__tags-text">+ {{ selected.length - 1 }}</span>
+        </el-tag>
+      </transition-group>
       <transition-group @after-leave="resetInputHeight" v-if="!collapseTags">
         <el-tag
           v-for="item in selected"
@@ -191,14 +206,6 @@
 
       selectSize() {
         return this.size || this._elFormItemSize || (this.$ELEMENT || {}).size;
-      },
-
-      multipleText() {
-        const selected = this.selected;
-        if (!selected || !selected.length) return '';
-        const length = selected.length;
-        const countText = length > 1 ? `(+${ selected.length - 1 })` : '';
-        return `${ selected[0].currentLabel } ${ countText }`;
       }
     },
 

--- a/packages/theme-chalk/src/select.scss
+++ b/packages/theme-chalk/src/select.scss
@@ -89,14 +89,6 @@
     }
   }
 
-  @include e(multiple-text) {
-    margin-left: 15px;
-    color: $--input-color;
-    font-size: $--font-size-base;
-    display: inline;
-    @include utils-ellipsis;
-  }
-
   @include e(close) {
     cursor: pointer;
     position: absolute;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ √] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ √] Make sure you are merging your commits to `dev` branch.
* [ √] Add some descriptions and refer relative issues for you PR.

目前设置 collapse-tags 为 true 时只显示文字。与设置为false 的显示风格不统一。比较建议更好点的显示方式，以及更好的可操作性。

![image](https://user-images.githubusercontent.com/7720722/33408770-19dee708-d5b3-11e7-9adf-f0473d4a0689.png)

