### PR TITLE
Dropdown: Click open uses `show-timeout` attribute

### DIFF
--- a/packages/dropdown/src/dropdown.vue
+++ b/packages/dropdown/src/dropdown.vue
@@ -128,7 +128,11 @@
       },
       handleClick() {
         if (this.triggerElm.disabled) return;
-        this.visible = !this.visible;
+        if (this.visible) {
+          this.hide();
+        } else {
+          this.show();
+        }
       },
       handleTriggerKeyDown(ev) {
         const keyCode = ev.keyCode;

--- a/test/unit/specs/dropdown.spec.js
+++ b/test/unit/specs/dropdown.spec.js
@@ -81,7 +81,7 @@ describe('Dropdown', () => {
   it('trigger', done => {
     vm = createVue({
       template: `
-        <el-dropdown trigger="click" ref="dropdown">
+        <el-dropdown trigger="click" ref="dropdown" >
           <span class="el-dropdown-link">
             下拉菜单trigger click<i class="el-icon-caret-bottom el-icon-right"></i>
           </span>
@@ -100,14 +100,13 @@ describe('Dropdown', () => {
     let triggerElm = dropdownElm.children[0];
 
     triggerEvent(triggerElm, 'mouseenter');
-    dropdown.$nextTick(_ => {
+    setTimeout(_ => {
       expect(dropdown.visible).to.not.true;
-
       triggerElm.click();
-      dropdown.$nextTick(_ => {
+      setTimeout(_ => {
         expect(dropdown.visible).to.be.true;
         done();
-      });
+      }, 300);
     });
   });
   it('split button', done => {

--- a/test/unit/specs/dropdown.spec.js
+++ b/test/unit/specs/dropdown.spec.js
@@ -81,7 +81,7 @@ describe('Dropdown', () => {
   it('trigger', done => {
     vm = createVue({
       template: `
-        <el-dropdown trigger="click" ref="dropdown" >
+        <el-dropdown trigger="click" ref="dropdown">
           <span class="el-dropdown-link">
             下拉菜单trigger click<i class="el-icon-caret-bottom el-icon-right"></i>
           </span>
@@ -100,7 +100,7 @@ describe('Dropdown', () => {
     let triggerElm = dropdownElm.children[0];
 
     triggerEvent(triggerElm, 'mouseenter');
-    setTimeout(_ => {
+    dropdown.$nextTick(_ => {
       expect(dropdown.visible).to.not.true;
       triggerElm.click();
       setTimeout(_ => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x ] Make sure you are merging your commits to `dev` branch.
* [x ] Add some descriptions and refer relative issues for you PR.

Click to open dropdown ignored the `show-timeout` attribute.
Rewrote the click handler to use `open/close` methods instead of manipulating `visible` directly.

If possible, please release a new patch version with this fix as soon as possible. 

Thanks