### PR TITLE
Tooltip: positioning in dynamic lists after has been list changed.

### DIFF
--- a/packages/tooltip/src/main.js
+++ b/packages/tooltip/src/main.js
@@ -114,11 +114,7 @@ export default {
   },
 
   mounted() {
-    this.referenceElm = this.$el;
-    if (this.$el.nodeType === 1) {
-      this.$el.setAttribute('aria-describedby', this.tooltipId);
-      this.$el.setAttribute('tabindex', 0);
-    }
+    this.makeReferenceLink();
   },
   watch: {
     focusing(val) {
@@ -130,7 +126,15 @@ export default {
     }
   },
   methods: {
+    makeReferenceLink() {
+      this.referenceElm = this.$el;
+      if (this.$el.nodeType === 1) {
+        this.$el.setAttribute('aria-describedby', this.tooltipId);
+        this.$el.setAttribute('tabindex', 0);
+      }
+    },
     show() {
+      this.makeReferenceLink();
       this.setExpectedState(true);
       this.handleShowPopper();
     },


### PR DESCRIPTION
Fix bug with positioning tooltip in dynamic list of elements after it has been changed.
I tried recreated bug in JSfiddle but without success.

In production project this change fixed issue.

Code looks like this
```
          <div class="dtable-body">
            <div class="dtable-row" v-for="(ind, i) in Indicators" :key="ind.Name">
              <div>{{ ind.Name }}</div>
              <template v-for="city in citiesVisible">
                <el-tooltip effect="dark" :content="getTooltipContent(ind, city)" placement="right" :popper-options="{ gpuAcceleration: false }">
                  <div :data-label="city" :key="city+i">
                    {{ getCellContent(ind, city) }}
                  </div>
                </el-tooltip>
              </template>
              <div v-if="citiesHidden.length">...</div>
            </div>
          </div>
```
