### PR TITLE
[table] Wrong with immutable when use fixed columns(fix immutable updateColumns)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [["es2015", { "loose": true }]],
-  "plugins": ["transform-vue-jsx"],
+  "plugins": ["transform-vue-jsx", "transform-object-rest-spread"],
   "env": {
     "utils": {
       "plugins": [

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "babel-plugin-module-resolver": "^2.2.0",
     "babel-plugin-syntax-jsx": "^6.8.0",
     "babel-plugin-transform-vue-jsx": "^3.3.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.14.0",
     "chai": "^3.5.0",
     "cheerio": "^0.18.0",

--- a/packages/table/src/table-store.js
+++ b/packages/table/src/table-store.js
@@ -352,6 +352,8 @@ TableStore.prototype.updateColumns = function() {
 
   states.columns = [].concat(fixedLeafColumns).concat(leafColumns).concat(rightFixedLeafColumns);
   states.isComplex = states.fixedColumns.length > 0 || states.rightFixedColumns.length > 0;
+
+  this.states = {...states};
 };
 
 TableStore.prototype.isSelected = function(row) {


### PR DESCRIPTION
<!-- generated by https://eleme-issue.surge.sh DO NOT REMOVE -->

### Element UI version
2.0.8

### OS/Browsers version
macos / chrome 63.0.3239.84

### Vue version
2.5.13

### Reproduction Link
[https://jsfiddle.net/8yLhv5cq/](https://jsfiddle.net/8yLhv5cq/)

### Steps to reproduce
- click button
- result: hide content column

### What is Expected?
Not hide content fixed column

### What is actually happening?
Hide content fixed column

<!-- generated by https://eleme-issue.surge.sh DO NOT REMOVE -->

https://github.com/ElemeFE/element/blob/0d952b79174520957e86dc5f4bf6cccd96a58ca0/packages/table/src/table-store.js#L332
When change all item in object then computed prop _leftFixedLeafCount_
https://github.com/ElemeFE/element/blob/0d952b79174520957e86dc5f4bf6cccd96a58ca0/packages/table/src/table-body.js#L186
don't recalculate because object _state_ not [change](https://vuejs.org/v2/guide/reactivity.html#Change-Detection-Caveats).

So need return new object. Or use get methods instead computed prop.

Thanks