### PR TITLE
Select filterable collapse tags

### DIFF
--- a/examples/docs/en-US/select.md
+++ b/examples/docs/en-US/select.md
@@ -102,6 +102,7 @@
         value9: [],
         value10: [],
         value11: [],
+        value12: [],
         loading: false,
         states: ["Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado", "Connecticut", "Delaware", "Florida", "Georgia", "Hawaii", "Idaho", "Illinois", "Indiana", "Iowa", "Kansas", "Kentucky", "Louisiana", "Maine", "Maryland", "Massachusetts", "Michigan", "Minnesota", "Mississippi", "Missouri", "Montana", "Nebraska", "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York", "North Carolina", "North Dakota", "Ohio", "Oklahoma", "Oregon", "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas", "Utah", "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming"]
       };
@@ -338,6 +339,21 @@ Multiple select uses tags to display selected options.
     multiple
     collapse-tags
     style="margin-left: 20px;"
+    placeholder="Select">
+    <el-option
+      v-for="item in options"
+      :key="item.value"
+      :label="item.label"
+      :value="item.value">
+    </el-option>
+  </el-select>
+  
+  <el-select
+    v-model="value12"
+    multiple
+    filterable
+    collapse-tags
+    style="margin-left: 20px; width: 200px"
     placeholder="Select">
     <el-option
       v-for="item in options"

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -558,7 +558,7 @@
       },
 
       resetInputHeight() {
-        if (this.collapseTags) return;
+        if (this.collapseTags && !this.filterable) return;
         this.$nextTick(() => {
           if (!this.$refs.reference) return;
           let inputChildNodes = this.$refs.reference.$el.childNodes;

--- a/test/unit/specs/select.spec.js
+++ b/test/unit/specs/select.spec.js
@@ -713,4 +713,42 @@ describe('Select', () => {
       }, 10);
     }, 10);
   });
+
+  describe.only('resetInputHeight', () => {
+    it('should reset height if collapse-tags option is disabled', () => {
+      vm = createVue({
+        template: `
+          <el-select ref="select"></el-select>
+        `
+      });
+      const select = vm.$refs.select;
+      sinon.stub(select, '$nextTick');
+      select.resetInputHeight();
+      expect(select.$nextTick.callCount).to.equal(1);
+    });
+
+    it('should not reset height if collapse-tags option is enabled', () => {
+      vm = createVue({
+        template: `
+          <el-select ref="select" collapse-tags></el-select>
+        `
+      });
+      const select = vm.$refs.select;
+      sinon.stub(select, '$nextTick');
+      select.resetInputHeight();
+      expect(select.$nextTick.callCount).to.equal(0);
+    });
+
+    it('should reset height if both collapse-tags and filterable are enabled', () => {
+      vm = createVue({
+        template: `
+          <el-select ref="select" collapse-tags filterable></el-select>
+        `
+      });
+      const select = vm.$refs.select;
+      sinon.stub(select, '$nextTick');
+      select.resetInputHeight();
+      expect(select.$nextTick.callCount).to.equal(1);
+    });
+  });
 });

--- a/test/unit/specs/select.spec.js
+++ b/test/unit/specs/select.spec.js
@@ -3,7 +3,7 @@ import Select from 'packages/select';
 
 describe('Select', () => {
   const getSelectVm = (configs = {}, options) => {
-    ['multiple', 'clearable', 'filterable', 'allowCreate', 'remote'].forEach(config => {
+    ['multiple', 'clearable', 'filterable', 'allowCreate', 'remote', 'collapseTags'].forEach(config => {
       configs[config] = configs[config] || false;
     });
     configs.multipleLimit = configs.multipleLimit || 0;
@@ -34,12 +34,14 @@ describe('Select', () => {
       template: `
         <div>
           <el-select
+            ref="select"
             v-model="value"
             :multiple="multiple"
             :multiple-limit="multipleLimit"
             :popper-class="popperClass"
             :clearable="clearable"
             :filterable="filterable"
+            :collapse-tags="collapseTags"
             :allow-create="allowCreate"
             :filterMethod="filterMethod"
             :remote="remote"
@@ -63,6 +65,7 @@ describe('Select', () => {
           multipleLimit: configs.multipleLimit,
           clearable: configs.clearable,
           filterable: configs.filterable,
+          collapseTags: configs.collapseTags,
           allowCreate: configs.allowCreate,
           popperClass: configs.popperClass,
           loading: false,
@@ -714,38 +717,28 @@ describe('Select', () => {
     }, 10);
   });
 
-  describe.only('resetInputHeight', () => {
+  describe('resetInputHeight', () => {
+    const getSelectComponentVm = (configs) => {
+      vm = getSelectVm(configs || {});
+      return vm.$refs.select;
+    };
+
     it('should reset height if collapse-tags option is disabled', () => {
-      vm = createVue({
-        template: `
-          <el-select ref="select"></el-select>
-        `
-      });
-      const select = vm.$refs.select;
+      const select = getSelectComponentVm();
       sinon.stub(select, '$nextTick');
       select.resetInputHeight();
       expect(select.$nextTick.callCount).to.equal(1);
     });
 
     it('should not reset height if collapse-tags option is enabled', () => {
-      vm = createVue({
-        template: `
-          <el-select ref="select" collapse-tags></el-select>
-        `
-      });
-      const select = vm.$refs.select;
+      const select = getSelectComponentVm({ collapseTags: true });
       sinon.stub(select, '$nextTick');
       select.resetInputHeight();
       expect(select.$nextTick.callCount).to.equal(0);
     });
 
     it('should reset height if both collapse-tags and filterable are enabled', () => {
-      vm = createVue({
-        template: `
-          <el-select ref="select" collapse-tags filterable></el-select>
-        `
-      });
-      const select = vm.$refs.select;
+      const select = getSelectComponentVm({ collapseTags: true, filterable: true });
       sinon.stub(select, '$nextTick');
       select.resetInputHeight();
       expect(select.$nextTick.callCount).to.equal(1);


### PR DESCRIPTION
## Issue description

If one sets both `collapse-tags` and `filtering` for select component, if it is not wide enough, tags + input take 2 lines while select has still same height. Please see the screenshot:

![element-select-1](https://user-images.githubusercontent.com/190381/34318080-960387b8-e7be-11e7-9b9c-cb9eeba7ed84.png)

## Possible solution:

Basically select component should expand itself even if collapse tags are enabled as long as filtering is enabled too:

![element-select-fixed](https://user-images.githubusercontent.com/190381/34318084-bd18324a-e7be-11e7-808a-9b75545f9d98.png)


-----

Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
