### PR TITLE
docs:  increase page-component-up z-index

### DIFF
--- a/examples/pages/template/component.tpl
+++ b/examples/pages/template/component.tpl
@@ -112,6 +112,7 @@
       cursor: pointer;
       transition: .3s;
       box-shadow: 0 0 6px rgba(0,0,0, .12);
+      z-index: 5;
 
       i {
         color: #409EFF;


### PR DESCRIPTION
increase the 'z-index' of class 'page-component-up'
![image](https://note.youdao.com/yws/public/resource/42cf1ddfca3bc9dfdda5b5caf1a18dea/xmlnote/BA86E26766814ADAA6618988A776919B/1649)
![image](https://note.youdao.com/yws/public/resource/42cf1ddfca3bc9dfdda5b5caf1a18dea/xmlnote/83391A2169FD4709BE31AB77D952D4BB/1654)
the scroll to top component was coverted by the table element,
thus the z-index of this component should be more than 4