### PR TITLE
Update fr.js

### DIFF
--- a/src/locale/lang/fr.js
+++ b/src/locale/lang/fr.js
@@ -20,7 +20,7 @@ export default {
       nextYear: 'Année suivante',
       prevMonth: 'Mois précédent',
       nextMonth: 'Mois suivant',
-      year: 'Année',
+      year: '',
       month1: 'Janvier',
       month2: 'Février',
       month3: 'Mars',


### PR DESCRIPTION
In french, like in english, we don't say "Année" after the year number.
