### PR TITLE
fix show loading, leak memory

### DIFF
--- a/packages/loading/src/directive.js
+++ b/packages/loading/src/directive.js
@@ -44,10 +44,8 @@ exports.install = Vue => {
             : el;
           removeClass(target, 'el-loading-parent--relative');
           removeClass(target, 'el-loading-parent--hidden');
-          
           el.instance.hiding = false;
         });
-
         el.instance.visible = false;
         el.instance.hiding = true;
       }

--- a/packages/loading/src/directive.js
+++ b/packages/loading/src/directive.js
@@ -44,7 +44,7 @@ exports.install = Vue => {
             : el;
           removeClass(target, 'el-loading-parent--relative');
           removeClass(target, 'el-loading-parent--hidden');
-
+          
           el.instance.hiding = false;
         });
 

--- a/packages/loading/src/directive.js
+++ b/packages/loading/src/directive.js
@@ -37,15 +37,21 @@ exports.install = Vue => {
       });
     } else {
       if (el.domVisible) {
-        el.instance.$on('after-leave', _ => {
+        const onAfterLeave = _ => {
           el.domVisible = false;
           const target = binding.modifiers.fullscreen || binding.modifiers.body
             ? document.body
             : el;
           removeClass(target, 'el-loading-parent--relative');
           removeClass(target, 'el-loading-parent--hidden');
-        });
+
+          el.instance.hiding = false;
+          el.instance.$off('after-leave', onAfterLeave);
+        };
+
+        el.instance.$on('after-leave', onAfterLeave);
         el.instance.visible = false;
+        el.instance.hiding = true;
       }
     }
   };
@@ -65,7 +71,11 @@ exports.install = Vue => {
 
       parent.appendChild(el.mask);
       Vue.nextTick(() => {
-        el.instance.visible = true;
+        if (el.instance.hiding) {
+          el.instance.$emit('after-leave');
+        } else {
+          el.instance.visible = true;
+        };
       });
       el.domInserted = true;
     }

--- a/packages/loading/src/directive.js
+++ b/packages/loading/src/directive.js
@@ -37,7 +37,7 @@ exports.install = Vue => {
       });
     } else {
       if (el.domVisible) {
-        const onAfterLeave = _ => {
+        el.instance.$once('after-leave', _ => {
           el.domVisible = false;
           const target = binding.modifiers.fullscreen || binding.modifiers.body
             ? document.body
@@ -46,10 +46,8 @@ exports.install = Vue => {
           removeClass(target, 'el-loading-parent--hidden');
 
           el.instance.hiding = false;
-          el.instance.$off('after-leave', onAfterLeave);
-        };
+        });
 
-        el.instance.$on('after-leave', onAfterLeave);
         el.instance.visible = false;
         el.instance.hiding = true;
       }


### PR DESCRIPTION
There is situations, when flag loading fast change from _true_ to _false_ overlay of loading show.
It happens when this line runed(flag already false):
https://github.com/ElemeFE/element/blob/837354df3b24463457817a8c701b7327f6d82378/packages/loading/src/directive.js#L40
then run line:
https://github.com/ElemeFE/element/blob/837354df3b24463457817a8c701b7327f6d82378/packages/loading/src/directive.js#L68

and event _after-leave_ don't call.

I use flag instance.hiding for fix it.

Also there is leak memory in 
https://github.com/ElemeFE/element/blob/837354df3b24463457817a8c701b7327f6d82378/packages/loading/src/directive.js#L40
because _$on_ add listener many times. So use $once instead $on.