### PR TITLE
[DatePicker] Added the possibilitie to pass custom prefix and suffix icons

### DIFF
--- a/examples/docs/en-US/date-picker.md
+++ b/examples/docs/en-US/date-picker.md
@@ -397,8 +397,8 @@ This feature is at alpha stage. Feedback welcome.
 | value-format | optional, format of binding value. If not specified, the binding value will be a Date object | string | year `yyyy`, month `MM`, day `dd`, hour `HH`, minute `mm`, second `ss`, AM/PM `A` | — |
 | name | same as `name` in native input | string | — | — |
 | unlink-panels | unlink two date-panels in range-picker | boolean | — | false |
-| prefix-icon | prefix icon class | string | — | — |
-| suffix-icon | suffix icon class | string | — | — |
+| prefix-icon | Custom prefix icon class | string | — | el-icon-date |
+| clear-icon | Custom clear icon class | string | — | el-icon-circle-close |
 
 ### Picker Options
 | Attribute      | Description          | Type      | Accepted Values       | Default  |

--- a/examples/docs/en-US/date-picker.md
+++ b/examples/docs/en-US/date-picker.md
@@ -397,6 +397,8 @@ This feature is at alpha stage. Feedback welcome.
 | value-format | optional, format of binding value. If not specified, the binding value will be a Date object | string | year `yyyy`, month `MM`, day `dd`, hour `HH`, minute `mm`, second `ss`, AM/PM `A` | — |
 | name | same as `name` in native input | string | — | — |
 | unlink-panels | unlink two date-panels in range-picker | boolean | — | false |
+| prefix-icon | prefix icon class | string | — | — |
+| suffix-icon | suffix icon class | string | — | — |
 
 ### Picker Options
 | Attribute      | Description          | Type      | Accepted Values       | Default  |

--- a/examples/docs/en-US/datetime-picker.md
+++ b/examples/docs/en-US/datetime-picker.md
@@ -256,6 +256,8 @@ DateTimePicker is derived from DatePicker and TimePicker. For a more detailed ex
 | value-format | optional, format of binding value. If not specified, the binding value will be a Date object | string | year `yyyy`, month `MM`, day `dd`, hour `HH`, minute `mm`, second `ss`, AM/PM `A` | — |
 | name | same as `name` in native input | string | — | — |
 | unlink-panels | unllink two date-panels in range-picker | boolean | — | false |
+| prefix-icon | Custom prefix icon class | string | — | el-icon-date |
+| clear-icon | Custom clear icon class | string | — | el-icon-circle-close |
 
 ### Picker Options
 | Attribute      | Description          | Type      | Accepted Values       | Default  |

--- a/examples/docs/en-US/time-picker.md
+++ b/examples/docs/en-US/time-picker.md
@@ -191,6 +191,8 @@ Can pick an arbitrary time range.
 | default-value | optional, default date of the calendar | Date for TimePicker, string for TimeSelect | anything accepted by `new Date()` for TimePicker, selectable value for TimeSelect | — |
 | value-format | optional, only for TimePicker, format of bounded value | string | hour `HH`, minute `mm`, second `ss`, AM/PM `A` | — |
 | name | same as `name` in native input | string | — | — |
+| prefix-icon | Custom prefix icon class | string | — | el-icon-time |
+| clear-icon | Custom clear icon class | string | — | el-icon-circle-close |
 
 ### Time Select Options
 | Attribute      | Description          | Type      | Accepted Values       | Default  |

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -23,7 +23,7 @@
     <i slot="suffix"
       class="el-input__icon"
       @click="handleClickIcon"
-      :class="[showClose ? '' + suffixIcon : '']"
+      :class="[showClose ? '' + clearIcon : '']"
       v-if="haveTrigger">
     </i>
   </el-input>
@@ -71,7 +71,7 @@
     <i
       @click="handleClickIcon"
       v-if="haveTrigger"
-      :class="[showClose ? '' + suffixIcon : '']"
+      :class="[showClose ? '' + clearIcon : '']"
       class="el-input__icon el-range__close-icon">
     </i>
   </div>
@@ -312,7 +312,7 @@ export default {
     startPlaceholder: String,
     endPlaceholder: String,
     prefixIcon: String,
-    suffixIcon: {
+    clearIcon: {
       type: String,
       default: 'el-icon-circle-close'
     },

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -53,7 +53,6 @@
       @input="handleStartInput"
       @change="handleStartChange"
       @focus="handleFocus"
-      :prefix-icon="triggerClass"
       class="el-range-input">
     <span class="el-range-separator">{{ rangeSeparator }}</span>
     <input
@@ -66,7 +65,6 @@
       @input="handleEndInput"
       @change="handleEndChange"
       @focus="handleFocus"
-      :prefix-icon="triggerClass"
       class="el-range-input">
     <i
       @click="handleClickIcon"

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -23,7 +23,7 @@
     <i slot="suffix"
       class="el-input__icon"
       @click="handleClickIcon"
-      :class="{ 'el-icon-circle-close': showClose }"
+      :class="{ suffixIconClass: showClose }"
       v-if="haveTrigger">
     </i>
   </el-input>
@@ -309,6 +309,8 @@ export default {
     placeholder: String,
     startPlaceholder: String,
     endPlaceholder: String,
+    prefixIcon: String,
+    suffixIcon: String,
     name: {
       default: '',
       validator
@@ -407,6 +409,10 @@ export default {
       return [];
     },
 
+    suffixIconClass() {
+      return this.suffixIcon || 'el-icon-circle-close';
+    },
+
     valueIsEmpty() {
       const val = this.value;
       if (Array.isArray(val)) {
@@ -424,7 +430,7 @@ export default {
     },
 
     triggerClass() {
-      return this.type.indexOf('time') !== -1 ? 'el-icon-time' : 'el-icon-date';
+      return this.prefixIcon || (this.type.indexOf('time') !== -1 ? 'el-icon-time' : 'el-icon-date');
     },
 
     selectionMode() {

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -23,7 +23,7 @@
     <i slot="suffix"
       class="el-input__icon"
       @click="handleClickIcon"
-      :class="{ suffixIconClass: showClose }"
+      :class="[showClose ? '' + suffixIcon : '']"
       v-if="haveTrigger">
     </i>
   </el-input>
@@ -53,6 +53,7 @@
       @input="handleStartInput"
       @change="handleStartChange"
       @focus="handleFocus"
+      :prefix-icon="triggerClass"
       class="el-range-input">
     <span class="el-range-separator">{{ rangeSeparator }}</span>
     <input
@@ -65,11 +66,12 @@
       @input="handleEndInput"
       @change="handleEndChange"
       @focus="handleFocus"
+      :prefix-icon="triggerClass"
       class="el-range-input">
     <i
       @click="handleClickIcon"
       v-if="haveTrigger"
-      :class="{ 'el-icon-circle-close': showClose }"
+      :class="[showClose ? '' + suffixIcon : '']"
       class="el-input__icon el-range__close-icon">
     </i>
   </div>
@@ -310,7 +312,10 @@ export default {
     startPlaceholder: String,
     endPlaceholder: String,
     prefixIcon: String,
-    suffixIcon: String,
+    suffixIcon: {
+      type: String,
+      default: 'el-icon-circle-close'
+    },
     name: {
       default: '',
       validator
@@ -409,10 +414,6 @@ export default {
       return [];
     },
 
-    suffixIconClass() {
-      return this.suffixIcon || 'el-icon-circle-close';
-    },
-
     valueIsEmpty() {
       const val = this.value;
       if (Array.isArray(val)) {
@@ -430,7 +431,7 @@ export default {
     },
 
     triggerClass() {
-      return this.prefixIcon || (this.type.indexOf('time') !== -1 ? 'el-icon-time' : 'el-icon-date');
+      return this.prefixIcon || (this.type.indexOf('time') !== -1 ? 'el-icon-time' : 'el-icon-date');
     },
 
     selectionMode() {


### PR DESCRIPTION
Added the possibilitie to pass custom prefix and suffix icon class with same props as usual (prefix-icon and suffix-icon)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
