### PR TITLE
messagebox support customize buttons

### DIFF
--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -48,6 +48,18 @@
         </div>
         <div class="el-message-box__btns">
           <el-button
+            v-for="button in buttons"
+            :key="button.text"
+            :loading="button.loading"
+            :class="[ button.class ]"
+            :round="button.roundButton"
+            size="small"
+            @click.native="handleCustomAction(button)"
+            @keydown.enter="handleCustomAction(button)"
+          >
+            {{ button.text }}
+          </el-button>
+          <el-button
             :loading="cancelButtonLoading"
             :class="[ cancelButtonClasses ]"
             v-show="showCancelButton"
@@ -123,7 +135,8 @@
       roundButton: {
         default: false,
         type: Boolean
-      }
+      },
+      buttons: []
     },
 
     components: {
@@ -145,6 +158,9 @@
     },
 
     methods: {
+      isPromise(obj) {
+        return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+      },
       handleComposition(event) {
         if (event.type === 'compositionend') {
           setTimeout(() => {
@@ -208,6 +224,20 @@
           this.beforeClose(action, this, this.close);
         } else {
           this.doClose();
+        }
+      },
+
+      handleCustomAction(button) {
+        if (button.needValidate && this.$type === 'prompt' && !this.validate()) {
+          return;
+        }
+        let result = button.action && button.action(button);
+        if (this.isPromise(result)) {
+          result.then(() => {
+            this.handleAction('customize');
+          });
+        } else {
+          this.handleAction('customize');
         }
       },
 

--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -51,6 +51,7 @@
             v-for="button in buttons"
             :key="button.text"
             :loading="button.loading"
+            :type="button.type"
             :class="[ button.class ]"
             :round="button.roundButton"
             size="small"


### PR DESCRIPTION
make messagebox support customize buttons

sample: 

```
<template>
  <div style="margin: 20px;">
    <el-button @click="showBox">show box</el-button>
  </div>
</template>
<script>

  export default {
    data() {
      return {
      }
    },
    methods: {
      showBox() {
        this.$msgbox({
          showCancelButton: false,
          showConfirmButton: false,
          buttons: [
            {
              text: '取消'
            },
            {
              text: '去修改状态',
              loading: false,
              action: button => {
                return new Promise(resolve => {
                  button.loading = true
                  setTimeout(() => {
                    console.log('去修改状态')
                    button.loading = false
                    resolve()
                  }, 2000);
                })
              }
            },
            {
              text: '确定',
              action: button => {
                console.log('确定')
              }
            }
          ]
        })
      }
    }
  };
</script>
```

result:
![test](https://user-images.githubusercontent.com/13174059/35035025-fd6c89b8-fbaa-11e7-9ca3-4314245652b4.gif)
