### PR TITLE
[Select] [Option] convert string like number to convert to number

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -55,6 +55,10 @@
         return Object.prototype.toString.call(this.value).toLowerCase() === '[object object]';
       },
 
+      isNumberic() {
+        return !window.isNaN(window.parseFloat(this.value)) && window.isFinite(this.value);
+      },
+
       currentLabel() {
         return this.label || (this.isObject ? '' : this.value);
       },
@@ -94,6 +98,9 @@
     methods: {
       isEqual(a, b) {
         if (!this.isObject) {
+          if (this.isNumberic) {
+            return +a === +b;
+          }
           return a === b;
         } else {
           const valueKey = this.select.valueKey;

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -446,11 +446,19 @@
       getOption(value) {
         let option;
         const isObject = Object.prototype.toString.call(value).toLowerCase() === '[object object]';
+        const isNumberic = !window.isNaN(window.parseFloat(value)) && window.isFinite(value);
         for (let i = this.cachedOptions.length - 1; i >= 0; i--) {
           const cachedOption = this.cachedOptions[i];
-          const isEqual = isObject
-            ? getValueByPath(cachedOption.value, this.valueKey) === getValueByPath(value, this.valueKey)
-            : cachedOption.value === value;
+          let isEqual;
+          if (isObject) {
+            isEqual = getValueByPath(cachedOption.value, this.valueKey) === getValueByPath(value, this.valueKey)
+          } else {
+            if (isNumberic) {
+              isEqual = +cachedOption.value === +value;
+            } else {
+              isEqual = cachedOption.value === value;
+            }
+          }
           if (isEqual) {
             option = cachedOption;
             break;


### PR DESCRIPTION
Add a `isNumberic` function check to ensure if option's value is a string like number, then convert it to number, then compare to the select's value.

Because `PHP` always give us a string number, in this way, we can ignore the type of the value.


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
