### PR TITLE
[el-menu-item] fix disabled

### DIFF
--- a/packages/menu/src/menu-item.vue
+++ b/packages/menu/src/menu-item.vue
@@ -100,8 +100,10 @@
         this.$el.style.backgroundColor = this.backgroundColor;
       },
       handleClick() {
-        this.dispatch('ElMenu', 'item-click', this);
-        this.$emit('click', this);
+        if (!this.disabled) {
+          this.dispatch('ElMenu', 'item-click', this);
+          this.$emit('click', this);
+        };
       }
     },
     created() {


### PR DESCRIPTION
I did to don't bubbling event click when item of menu is disabled. Because use prop _disabled_ don't implemented.

Thanks