### PR TITLE
DateTimePicker: fix invalid month value bug for Firefox 37

### DIFF
--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -301,7 +301,9 @@
       enableMonthArrow() {
         const nextMonth = (this.leftMonth + 1) % 12;
         const yearOffset = this.leftMonth + 1 >= 12 ? 1 : 0;
-        return this.unlinkPanels && new Date(`${this.leftYear + yearOffset}-${nextMonth + 1}`) < new Date(`${this.rightYear}-${this.rightMonth + 1}`);
+        const leftMonth = nextMonth + 1 >= 10 ? nextMonth + 1 : '0' + (nextMonth + 1);
+        const rightMonth = this.rightMonth + 1 >= 10 ? this.rightMonth + 1 : '0' + (this.rightMonth + 1);
+        return this.unlinkPanels && new Date(`${this.leftYear + yearOffset}-${leftMonth}`) < new Date(`${this.rightYear}-${rightMonth}`);
       },
 
       enableYearArrow() {

--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -301,9 +301,7 @@
       enableMonthArrow() {
         const nextMonth = (this.leftMonth + 1) % 12;
         const yearOffset = this.leftMonth + 1 >= 12 ? 1 : 0;
-        const leftMonth = nextMonth + 1 >= 10 ? nextMonth + 1 : '0' + (nextMonth + 1);
-        const rightMonth = this.rightMonth + 1 >= 10 ? this.rightMonth + 1 : '0' + (this.rightMonth + 1);
-        return this.unlinkPanels && new Date(`${this.leftYear + yearOffset}-${leftMonth}`) < new Date(`${this.rightYear}-${rightMonth}`);
+        return this.unlinkPanels && new Date(this.leftYear + yearOffset, nextMonth) < new Date(this.rightYear, this.rightMonth);
       },
 
       enableYearArrow() {


### PR DESCRIPTION
NeoKylin OS default browser is Firefox 37 and the Date function required two-digit month value.
