### PR TITLE
Fix:ELMain doesn`t work as The Other Browsers

### DIFF
--- a/packages/theme-chalk/src/main.scss
+++ b/packages/theme-chalk/src/main.scss
@@ -4,6 +4,7 @@
 @include b(main) {
   flex: 1;
   overflow: auto;
+  display: block;
   box-sizing: border-box;
   padding: $--main-padding;
 }


### PR DESCRIPTION
Fix:ELMain doesn`t work as The Other Browsers

Because there haven`t  a  default display value on  the 'main' element of IE9,IE10,IE11 .The other browsers have a 'display:block' on main in user agent style.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
