### PR TITLE
Tree: Add `getNode` method

### DIFF
--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -203,6 +203,9 @@
         if (!this.nodeKey) throw new Error('[Tree] nodeKey is required in updateKeyChild');
         this.store.updateChildren(key, data);
       },
+      getNode(nodeData) {
+        return this.store.getNode(nodeData)
+      },
       initTabindex() {
         this.treeItems = this.$el.querySelectorAll('.is-focusable[role=treeitem]');
         this.checkboxItems = this.$el.querySelectorAll('input[type=checkbox]');


### PR DESCRIPTION
Add `getNode` method to `Tree` component. 

There are so many methods on Tree component, such as `getCheckedNodes`, `getCheckedKeys`, etc. But all `get` methods are based on `checked` or `current` nodes, so I think it is very useful for adding a `getNode` method to help users get specified tree node easier.

```js
const parentNodeData = {
  key: 'foo'
}

const parentNode = this.$refs.tree.getNode(parentNodeData)
```

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
