### PR TITLE
Upload: allow custom file icon

### DIFF
--- a/packages/upload/src/upload-list.vue
+++ b/packages/upload/src/upload-list.vue
@@ -24,7 +24,7 @@
         :src="file.url" alt=""
       >
       <a class="el-upload-list__item-name" @click="handleClick(file)">
-        <i class="el-icon-document"></i>{{file.name}}
+        <i :class="file.iconClass||'el-icon-document'"></i>{{file.name}}
       </a>
       <label class="el-upload-list__item-status-label">
         <i :class="{


### PR DESCRIPTION
Allow custom file icon class. Class can be updated on `change` or any other event.