### PR TITLE
Popper: Fix memory leak on route change (#7715)

### DIFF
--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -240,7 +240,6 @@
         if (typeof this.state.updateCallback === 'function') {
             this.state.updateCallback(data);
         }
-
     };
 
     /**
@@ -438,7 +437,6 @@
         popperOffsets.width   = popperRect.width;
         popperOffsets.height  = popperRect.height;
 
-
         return {
             popper: popperOffsets,
             reference: referenceOffsets
@@ -464,6 +462,7 @@
                 target = root;
             }
             target.addEventListener('scroll', this.state.updateBound);
+            this.state.scrollTarget = target;
         }
     };
 
@@ -476,13 +475,9 @@
     Popper.prototype._removeEventListeners = function() {
         // NOTE: 1 DOM access here
         root.removeEventListener('resize', this.state.updateBound);
-        if (this._options.boundariesElement !== 'window') {
-            var target = getScrollParent(this._reference);
-            // here it could be both `body` or `documentElement` thanks to Firefox, we then check both
-            if (target === root.document.body || target === root.document.documentElement) {
-                target = root;
-            }
-            target.removeEventListener('scroll', this.state.updateBound);
+        if (this._options.boundariesElement !== 'window' && this.state.scrollTarget) {
+            this.state.scrollTarget.removeEventListener('scroll', this.state.updateBound);
+            this.state.scrollTarget = null;
         }
         this.state.updateBound = null;
     };
@@ -519,13 +514,13 @@
             var scrollParent = getScrollParent(this._popper);
             var offsetParentRect = getOffsetRect(offsetParent);
 
-			// Thanks the fucking native API, `document.body.scrollTop` & `document.documentElement.scrollTop`
-			var getScrollTopValue = function (element) {
-				return element == document.body ? Math.max(document.documentElement.scrollTop, document.body.scrollTop) : element.scrollTop;
-			}
-			var getScrollLeftValue = function (element) {
-				return element == document.body ? Math.max(document.documentElement.scrollLeft, document.body.scrollLeft) : element.scrollLeft;
-			}
+            // Thanks the fucking native API, `document.body.scrollTop` & `document.documentElement.scrollTop`
+            var getScrollTopValue = function (element) {
+                return element == document.body ? Math.max(document.documentElement.scrollTop, document.body.scrollTop) : element.scrollTop;
+            }
+            var getScrollLeftValue = function (element) {
+                return element == document.body ? Math.max(document.documentElement.scrollLeft, document.body.scrollLeft) : element.scrollLeft;
+            }
 
             // if the popper is fixed we don't have to substract scrolling from the boundaries
             var scrollTop = data.offsets.popper.position === 'fixed' ? 0 : getScrollTopValue(scrollParent);

--- a/src/utils/vue-popper.js
+++ b/src/utils/vue-popper.js
@@ -129,9 +129,9 @@ export default {
       }
     },
 
-    doDestroy() {
+    doDestroy(forceDestroy) {
       /* istanbul ignore if */
-      if (this.showPopper || !this.popperJS) return;
+      if (!this.popperJS || (this.showPopper && !forceDestroy)) return;
       this.popperJS.destroy();
       this.popperJS = null;
     },
@@ -184,7 +184,7 @@ export default {
   },
 
   beforeDestroy() {
-    this.doDestroy();
+    this.doDestroy(true);
     if (this.popperElm && this.popperElm.parentNode === document.body) {
       this.popperElm.removeEventListener('click', stop);
       document.body.removeChild(this.popperElm);


### PR DESCRIPTION
#### Fixes #7715 by addressing the two following issues:
- When the route changed on click, the `doDestroy` method of vue-popper was returning right away without actually destroying the popper due to `showPopper` being true. `forceDestroy` parameter is added to handle this case. An alternative fix could be to set `showPopper` to `false` in `beforeDestroy` before calling `doDestroy`, but the parameter approach was chosen as it can be reused.
- After the above fix, the `destroy` method of popper.js was being successfully called, which in turn called `_removeEventListeners`. The `target` that this method was removing the `scroll` event listener from was not the same element to which the listener was added (this is due to `getScrollParent` not being able to find the correct element as some of the top level nodes had already been destroyed). This caused the event listener (bound to `this`) to leak, and consequently the whole associated DOM and VDOM tree. The fix is to replace the logic to find the target in `_removeEventListeners` and use the stored target to remove the listener from.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
