### PR TITLE
Menu: fixed error handling

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -270,7 +270,7 @@
         try {
           this.$router.push(route, () => {}, onError);
         } catch (e) {
-          console.error(e);
+          if (e) console.error(e);
         }
       },
       open(index) {


### PR DESCRIPTION
as `vue-router` will throw undefined when we push the same route twice.to reproduce you can set `el-menu :router=true` and click it twice then you can see `undefined` error in console

在 `el-menu :router=true` 的情况下如果点击两次相同的菜单按钮会报一个undefined的错误.`vue-router`的push函数应该是做了重复验证然后回调onAbort()所以回调参数是undefined
