### PR TITLE
Menu: routeToItem 错误处理

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -244,8 +244,9 @@
         }
 
         if (this.router) {
-          this.routeToItem(item, () => {
+          this.routeToItem(item, (error) => {
             this.activeIndex = oldActiveIndex;
+            if (error) console.error(error);
           });
         }
       },


### PR DESCRIPTION
看了一下 vue-router对router.push 源码的处理，在onAbort的处理上有两种方式，一种是有错误回调 另一种是无错误回调所以我个人认为不能单纯的忽略掉onAbort的回调参数。应该加一个判断

![image](https://user-images.githubusercontent.com/9914235/36624498-0f2c4900-194b-11e8-8a51-99f5776f66a5.png)

