### PR TITLE
Fix build locales, make sure only read `js` files from locale directory

### DIFF
--- a/build/bin/build-locale.js
+++ b/build/bin/build-locale.js
@@ -15,21 +15,25 @@ var transform = function(filename, name, cb) {
   }, cb);
 };
 
-fileList.forEach(function(file) {
-  var name = basename(file, '.js');
+fileList
+  .filter(function(file) {
+    return /\.js$/.test(file);
+  })
+  .forEach(function(file) {
+    var name = basename(file, '.js');
 
-  transform(file, name, function(err, result) {
-    if (err) {
-      console.error(err);
-    } else {
-      var code = result.code;
+    transform(file, name, function(err, result) {
+      if (err) {
+        console.error(err);
+      } else {
+        var code = result.code;
 
-      code = code
-        .replace('define(\'', 'define(\'element/locale/')
-        .replace('global.', 'global.ELEMENT.lang = global.ELEMENT.lang || {}; \n    global.ELEMENT.lang.');
-      save(resolve(__dirname, '../../lib/umd/locale', file)).write(code);
+        code = code
+          .replace('define(\'', 'define(\'element/locale/')
+          .replace('global.', 'global.ELEMENT.lang = global.ELEMENT.lang || {}; \n    global.ELEMENT.lang.');
+        save(resolve(__dirname, '../../lib/umd/locale', file)).write(code);
 
-      console.log(file);
-    }
+        console.log(file);
+      }
+    });
   });
-});


### PR DESCRIPTION
如果 lang 中存在非正常语言文件，会报错。目前在 Mac 上遇到了这种情况，具体问题如下：
`fs.readdirSync` 读取目录中的文件时，读到了系统自动生成的 .DS_Store，导致报错。

```
/Project/element-ui/src/locale/lang/.DS_Store: Unexpected character '' (1:0)
```
