### PR TITLE
[Table]: Add information under table header about how many rows were selected as well as provide options for bulk actions

### DIFF
--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -1271,7 +1271,7 @@ You can also select multiple rows.
 
 You can also show actions to perform on the selection.
 
-:::demo Activating multiple selection is easy: simply add an `el-table-column` with its `type` set to `selection`. Apart from multiple selection, this example also uses `show-overflow-tooltip`: by default, if the content is too long, it will break into multiple lines. If you want to keep it in one line, use attribute `show-overflow-tooltip`, which accepts a `Boolean` value. When set `true`, the extra content will show in tooltip when hover on the cell.
+:::demo Activating actions for multiple selection is easy: simply pass an object to `el-table` as `multiple-select`. The object should have a message and an array of actions which holds the information for each action as an object. Take a look at the code to see how it should be structured. Apart from multiple selection, this example also uses `show-overflow-tooltip`: by default, if the content is too long, it will break into multiple lines. If you want to keep it in one line, use attribute `show-overflow-tooltip`, which accepts a `Boolean` value. When set `true`, the extra content will show in tooltip when hover on the cell.
 ```html
 <template>
   <el-table
@@ -1286,7 +1286,7 @@ You can also show actions to perform on the selection.
           class: 'edit-button',
           type: '',
           size: 'mini',
-          action(selectedRows) {
+          action(selection) {
             // action goes here
           }
         },
@@ -1295,7 +1295,7 @@ You can also show actions to perform on the selection.
           class: 'print-button',
           type: 'primary',
           size: 'mini',
-          action(selectedRows) {
+          action(selection) {
             // action goes here
           }
         }
@@ -1365,9 +1365,6 @@ You can also show actions to perform on the selection.
       }
     },
     methods: {
-      action(command) {
-        console.log(`This is what I should be doing: ${command}`)
-      },
       toggleSelection(rows) {
         if (rows) {
           rows.forEach(row => {

--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -1267,6 +1267,125 @@ You can also select multiple rows.
 ```
 :::
 
+### Multiple select with actions
+
+You can also show actions to perform on the selection.
+
+:::demo Activating multiple selection is easy: simply add an `el-table-column` with its `type` set to `selection`. Apart from multiple selection, this example also uses `show-overflow-tooltip`: by default, if the content is too long, it will break into multiple lines. If you want to keep it in one line, use attribute `show-overflow-tooltip`, which accepts a `Boolean` value. When set `true`, the extra content will show in tooltip when hover on the cell.
+```html
+<template>
+  <el-table
+    ref="multipleTable"
+    :data="tableData3"
+    style="width: 100%"
+    :multiple-select="{
+      message: ' row(s) have been selected.',
+      actions: [
+        {
+          label: 'edit',
+          class: 'edit-button',
+          type: '',
+          size: 'mini',
+          action(selectedRows) {
+            // action goes here
+          }
+        },
+        {
+          label: 'print',
+          class: 'print-button',
+          type: 'primary',
+          size: 'mini',
+          action(selectedRows) {
+            // action goes here
+          }
+        }
+      ]
+    }"
+    @selection-change="handleSelectionChange">
+    <el-table-column
+      type="selection"
+      width="55">
+    </el-table-column>
+    <el-table-column
+      label="Date"
+      width="120">
+      <template slot-scope="scope">{{ scope.row.date }}</template>
+    </el-table-column>
+    <el-table-column
+      property="name"
+      label="Name"
+      width="120">
+    </el-table-column>
+    <el-table-column
+      property="address"
+      label="Address"
+      show-overflow-tooltip>
+    </el-table-column>
+  </el-table>
+  <div style="margin-top: 20px">
+    <el-button @click="toggleSelection([tableData3[1], tableData3[2]])">Toggle selection status of second and third rows</el-button>
+    <el-button @click="toggleSelection()">Clear selection</el-button>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        tableData3: [{
+          date: '2016-05-03',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-02',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-04',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-01',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-08',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-06',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-07',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }],
+        multipleSelection: []
+      }
+    },
+    methods: {
+      action(command) {
+        console.log(`This is what I should be doing: ${command}`)
+      },
+      toggleSelection(rows) {
+        if (rows) {
+          rows.forEach(row => {
+            this.$refs.multipleTable.toggleRowSelection(row);
+          });
+        } else {
+          this.$refs.multipleTable.clearSelection();
+        }
+      },
+      handleSelectionChange(val) {
+        this.multipleSelection = val;
+      }
+    }
+  }
+</script>
+```
+:::
+
 ### Sorting
 
 Sort the data to find or compare data quickly.

--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -1267,41 +1267,25 @@ You can also select multiple rows.
 ```
 :::
 
-### Multiple select with actions
+### Multiple select with bulk actions
 
-You can also show actions to perform on the selection.
+You can also show bulk actions to perform on the selection.
 
-:::demo Activating actions for multiple selection is easy: simply pass an object to `el-table` as `multiple-select`. The object should have a message and an array of actions which holds the information for each action as an object. Take a look at the code to see how it should be structured. Apart from multiple selection, this example also uses `show-overflow-tooltip`: by default, if the content is too long, it will break into multiple lines. If you want to keep it in one line, use attribute `show-overflow-tooltip`, which accepts a `Boolean` value. When set `true`, the extra content will show in tooltip when hover on the cell.
+:::demo Activating bulk actions for multiple selection is easy: simply add a `bulk` slot right under the opening `el-table` tag. Take a look at the code below to see how it should be structured. Apart from multiple selection, this example also uses `show-overflow-tooltip`: by default, if the content is too long, it will break into multiple lines. If you want to keep it in one line, use attribute `show-overflow-tooltip`, which accepts a `Boolean` value. When set `true`, the extra content will show in tooltip when hover on the cell.
 ```html
 <template>
   <el-table
     ref="multipleTable"
     :data="tableData3"
     style="width: 100%"
-    :multiple-select="{
-      message: ' row(s) have been selected.',
-      actions: [
-        {
-          label: 'edit',
-          class: 'edit-button',
-          type: '',
-          size: 'mini',
-          action(selection) {
-            // action goes here
-          }
-        },
-        {
-          label: 'print',
-          class: 'print-button',
-          type: 'primary',
-          size: 'mini',
-          action(selection) {
-            // action goes here
-          }
-        }
-      ]
-    }"
     @selection-change="handleSelectionChange">
+    <div class="actions" slot="bulk" slot-scope="scope">
+      <span class="message">A total of {{ scope.selection.length }} row(s) have been selected</span>
+      <div class="actions-container">
+        <el-button @click="actionOne(scope.selection)" size="mini">Action 1</el-button>
+        <el-button @click="actionTwo(scope.selection)" type="primary" size="mini">Action 2</el-button>
+      </div>
+    </div>
     <el-table-column
       type="selection"
       width="55">
@@ -1376,6 +1360,12 @@ You can also show actions to perform on the selection.
       },
       handleSelectionChange(val) {
         this.multipleSelection = val;
+      },
+      actionOne(selection) {
+        // do something
+      },
+      actionTwo(selection) {
+        // do something
       }
     }
   }

--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -73,7 +73,10 @@ export default {
     const columnRows = convertToRows(originColumns, this.columns);
     // 是否拥有多级表头
     const isGroup = columnRows.length > 1;
+    const hasSelection = this.store.states.selection.length > 0;
+    const selectedRows = this.store.states.selection.length;
     if (isGroup) this.$parent.isGroup = true;
+    if (hasSelection) this.$parent.hasSelection = true;
     return (
       <table
         class="el-table__header"
@@ -88,7 +91,7 @@ export default {
             this.hasGutter ? <col name="gutter" /> : ''
           }
         </colgroup>
-        <thead class={ [{ 'is-group': isGroup, 'has-gutter': this.hasGutter }] }>
+        <thead class={ [{ 'is-group': isGroup, 'has-selection': hasSelection, 'has-gutter': this.hasGutter }] }>
           {
             this._l(columnRows, (columns, rowIndex) =>
               <tr
@@ -131,6 +134,28 @@ export default {
                       </div>
                     </th>
                   )
+                }
+                {
+                  this.hasGutter ? <th class="gutter"></th> : ''
+                }
+              </tr>
+            )
+          }
+          {
+            this._l(columnRows, (columns, rowIndex) =>
+              <tr
+                style={ this.getHeaderRowStyle(rowIndex) }
+                class={ this.getHeaderRowClass(rowIndex) }
+              >
+                {
+                  hasSelection
+                    ? <th
+                      colspan={ columns.length }
+                      style={ this.getHeaderCellStyle(rowIndex, 0, columns, 0) }
+                      class={ this.getHeaderCellClass(rowIndex, 0, columns, 0) }>
+                      총 { selectedRows }개의 검사기록이 선택되었습니다.
+                    </th>
+                    : ''
                 }
                 {
                   this.hasGutter ? <th class="gutter"></th> : ''

--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -73,10 +73,9 @@ export default {
     const columnRows = convertToRows(originColumns, this.columns);
     // 是否拥有多级表头
     const isGroup = columnRows.length > 1;
-    const hasSelection = this.store.states.selection.length > 0;
-    const selectedRows = this.store.states.selection.length;
     if (isGroup) this.$parent.isGroup = true;
-    if (hasSelection) this.$parent.hasSelection = true;
+    const hasSelection = this.store.states.selection.length > 0;
+    hasSelection ? this.$parent.hasSelection = true : this.$parent.hasSelection = false;
     return (
       <table
         class="el-table__header"
@@ -141,29 +140,6 @@ export default {
               </tr>
             )
           }
-          {
-            this._l(columnRows, (columns, rowIndex) =>
-              <tr
-                style={ this.getHeaderRowStyle(rowIndex) }
-                class={ this.getHeaderRowClass(rowIndex) }
-              >
-                {
-                  hasSelection && this.multipleSelect
-                    ? <th
-                      colspan={ columns.length }
-                      style={ this.getHeaderCellStyle(rowIndex, 0, columns, 0) }
-                      class="actions">
-                      <span class="message">{ selectedRows }{ this.multipleSelect.message }</span>
-                      <div class="actions-container">{ this._l(this.multipleSelect.actions, action => <el-button on-click={ ($event) => this.handleActionClick($event, action.action, this.store.states.selection) } class={ action.class } type={ action.type } size={ action.size }>{ action.label }</el-button>) }</div>
-                    </th>
-                    : ''
-                }
-                {
-                  this.hasGutter ? <th class="gutter"></th> : ''
-                }
-              </tr>
-            )
-          }
         </thead>
       </table>
     );
@@ -182,12 +158,6 @@ export default {
           prop: '',
           order: ''
         };
-      }
-    },
-    multipleSelect: {
-      type: Object,
-      default() {
-        return null;
       }
     }
   },

--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -75,7 +75,7 @@ export default {
     const isGroup = columnRows.length > 1;
     if (isGroup) this.$parent.isGroup = true;
     const hasSelection = this.store.states.selection.length > 0;
-    hasSelection ? this.$parent.hasSelection = true : this.$parent.hasSelection = false;
+    this.$parent.hasSelection = hasSelection;
     return (
       <table
         class="el-table__header"
@@ -474,10 +474,6 @@ export default {
     handleMouseOut() {
       if (this.$isServer) return;
       document.body.style.cursor = '';
-    },
-
-    handleActionClick(event, action, selection) {
-      action(selection);
     },
 
     toggleOrder(order) {

--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -148,12 +148,13 @@ export default {
                 class={ this.getHeaderRowClass(rowIndex) }
               >
                 {
-                  hasSelection
+                  hasSelection && this.multipleSelect
                     ? <th
                       colspan={ columns.length }
                       style={ this.getHeaderCellStyle(rowIndex, 0, columns, 0) }
-                      class={ this.getHeaderCellClass(rowIndex, 0, columns, 0) }>
-                      총 { selectedRows }개의 검사기록이 선택되었습니다.
+                      class="actions">
+                      <span class="message">{ selectedRows }{ this.multipleSelect.message }</span>
+                      <div class="actions-container">{ this._l(this.multipleSelect.actions, action => <el-button on-click={ action.action(selectedRows) } class={ action.class } type={ action.type } size={ action.size }>{ action.label }</el-button>) }</div>
                     </th>
                     : ''
                 }
@@ -181,6 +182,12 @@ export default {
           prop: '',
           order: ''
         };
+      }
+    },
+    multipleSelect: {
+      type: Object,
+      default() {
+        return null;
       }
     }
   },

--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -154,7 +154,7 @@ export default {
                       style={ this.getHeaderCellStyle(rowIndex, 0, columns, 0) }
                       class="actions">
                       <span class="message">{ selectedRows }{ this.multipleSelect.message }</span>
-                      <div class="actions-container">{ this._l(this.multipleSelect.actions, action => <el-button on-click={ action.action(selectedRows) } class={ action.class } type={ action.type } size={ action.size }>{ action.label }</el-button>) }</div>
+                      <div class="actions-container">{ this._l(this.multipleSelect.actions, action => <el-button on-click={ ($event) => this.handleActionClick($event, action.action, this.store.states.selection) } class={ action.class } type={ action.type } size={ action.size }>{ action.label }</el-button>) }</div>
                     </th>
                     : ''
                 }
@@ -504,6 +504,10 @@ export default {
     handleMouseOut() {
       if (this.$isServer) return;
       document.body.style.cursor = '';
+    },
+
+    handleActionClick(event, action, selection) {
+      action(selection);
     },
 
     toggleOrder(order) {

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -24,6 +24,7 @@
         :store="store"
         :border="border"
         :default-sort="defaultSort"
+        :multiple-select="multipleSelect"
         :style="{
           width: layout.bodyWidth ? layout.bodyWidth + 'px' : ''
         }">
@@ -303,6 +304,8 @@
       defaultExpandAll: Boolean,
 
       defaultSort: Object,
+
+      multipleSelect: Object,
 
       tooltipEffect: String,
 

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -30,12 +30,7 @@
         }">
       </table-header>
     </div>
-    <div
-      v-if="hasSelection"
-      class="el-table__bulk-wrapper"
-      ref="bulkWrapper">
-      <slot name="bulk" :selection="store.states.selection"></slot>
-    </div>
+    <slot name="bulk" :selection="store.states.selection" v-if="hasSelection"></slot>
     <div
       class="el-table__body-wrapper"
       ref="bodyWrapper"
@@ -109,12 +104,7 @@
             width: layout.fixedWidth ? layout.fixedWidth + 'px' : ''
           }"></table-header>
       </div>
-      <div
-        v-if="hasSelection"
-        class="el-table__bulk-wrapper"
-        ref="bulkWrapper">
-        <slot name="bulk" :selection="store.states.selection"></slot>
-      </div>
+      <slot name="bulk" :selection="store.states.selection" v-if="hasSelection"></slot>
       <div
         class="el-table__fixed-body-wrapper"
         ref="fixedBodyWrapper"
@@ -316,8 +306,6 @@
       defaultExpandAll: Boolean,
 
       defaultSort: Object,
-
-      multipleSelect: Object,
 
       tooltipEffect: String,
 

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -24,7 +24,6 @@
         :store="store"
         :border="border"
         :default-sort="defaultSort"
-        :multiple-select="multipleSelect"
         :style="{
           width: layout.bodyWidth ? layout.bodyWidth + 'px' : ''
         }">

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -31,6 +31,12 @@
       </table-header>
     </div>
     <div
+      v-if="hasSelection"
+      class="el-table__bulk-wrapper"
+      ref="bulkWrapper">
+      <slot name="bulk" :selection="store.states.selection"></slot>
+    </div>
+    <div
       class="el-table__body-wrapper"
       ref="bodyWrapper"
       :class="[layout.scrollX ? `is-scrolling-${scrollPosition}` : 'is-scrolling-none']"
@@ -102,6 +108,12 @@
           :style="{
             width: layout.fixedWidth ? layout.fixedWidth + 'px' : ''
           }"></table-header>
+      </div>
+      <div
+        v-if="hasSelection"
+        class="el-table__bulk-wrapper"
+        ref="bulkWrapper">
+        <slot name="bulk" :selection="store.states.selection"></slot>
       </div>
       <div
         class="el-table__fixed-body-wrapper"
@@ -640,6 +652,7 @@
         },
         // 是否拥有多级表头
         isGroup: false,
+        hasSelection: false,
         scrollPosition: 'left'
       };
     }

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -246,24 +246,6 @@
     }
   }
 
-  .actions {
-    display: flex;
-    justify-content: space-between;
-    padding: 0 0 0 14px;
-    font-weight: 500;
-    vertical-align: middle;
-    background: #ebeef5;
-
-    .message {
-      line-height: 38px;
-    }
-
-    .actions-container {
-      margin: -1px 14px 0 0;
-      line-height: 36px;
-    }
-  }
-
   // 拥有多级表头
   @include m((group, border)) {
     border: $--table-border;

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -104,24 +104,6 @@
         background: $--background-color-base;
       }
     }
-    
-    &.has-selection {
-      .actions {
-        padding: 0 0 0 14px;
-        font-weight: 500;
-        vertical-align: middle;
-        background: #ebeef5;
-
-        .message {
-          line-height: 40px;
-        }
-
-        .actions-container {
-          float: right;
-          margin-top: -1px;
-        }
-      }
-    }
   }
 
   th, td {
@@ -261,6 +243,24 @@
     &.el-tooltip {
       white-space: nowrap;
       min-width: 50px;
+    }
+  }
+
+  .actions {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 0 0 14px;
+    font-weight: 500;
+    vertical-align: middle;
+    background: #ebeef5;
+
+    .message {
+      line-height: 38px;
+    }
+
+    .actions-container {
+      margin: -1px 14px 0 0;
+      line-height: 36px;
     }
   }
 

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -104,6 +104,13 @@
         background: $--background-color-base;
       }
     }
+    
+    &.has-selection {
+      th:last-child {
+        padding: 5px 14px;
+        font-weight: 500;
+      }
+    }
   }
 
   th, td {

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -106,9 +106,20 @@
     }
     
     &.has-selection {
-      th:last-child {
-        padding: 5px 14px;
+      .actions {
+        padding: 0 0 0 14px;
         font-weight: 500;
+        vertical-align: middle;
+        background: #ebeef5;
+
+        .message {
+          line-height: 40px;
+        }
+
+        .actions-container {
+          float: right;
+          margin-top: -1px;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #9864 

You can now add a slot to show how many rows have been selected as well as if you have any bulk actions available! 🐑 