### PR TITLE
Upload: add default option for headers

### DIFF
--- a/packages/upload/src/ajax.js
+++ b/packages/upload/src/ajax.js
@@ -75,6 +75,10 @@ export default function upload(option) {
 
   const headers = option.headers || {};
 
+  if (typeof headers['X-Requested-With'] === 'undefined') {
+    headers['X-Requested-With'] = 'XMLHttpRequest';
+  }
+
   for (let item in headers) {
     if (headers.hasOwnProperty(item) && headers[item] !== null) {
       xhr.setRequestHeader(item, headers[item]);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

添加了一个关于 headers 的判断，因为在很多后端框架里，会通过 【X-Requested-With】 header 头信息来判断是否是一个有效的 ajax 请求，我觉得有必要将它设为默认值