### PR TITLE
Update downloads badge to point to graph of downloads over time 📈 instead of duplicating link to npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/ElemeFE/element/badge.svg?branch=master)](https://coveralls.io/github/ElemeFE/element?branch=master)
 [![CDNJS](https://img.shields.io/cdnjs/v/element-ui.svg)](https://cdnjs.com/libraries/element-ui)
 [![npm package](https://img.shields.io/npm/v/element-ui.svg)](https://www.npmjs.org/package/element-ui)
-[![NPM downloads](http://img.shields.io/npm/dm/element-ui.svg)](https://npmjs.org/package/element-ui)
+[![NPM downloads](http://img.shields.io/npm/dm/element-ui.svg)](https://npmcharts.com/compare/element-ui?minimal=true)
 ![JS gzip size](http://img.badgesize.io/https://unpkg.com/element-ui/lib/index.js?compression=gzip&label=gzip%20size:%20JS)
 ![CSS gzip size](http://img.badgesize.io/https://unpkg.com/element-ui/lib/theme-chalk/index.css?compression=gzip&label=gzip%20size:%20CSS)
 [![Join the chat at https://gitter.im/ElemeFE/element](https://badges.gitter.im/ElemeFE/element.svg)](https://gitter.im/ElemeFE/element?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)(Chinese)


### PR DESCRIPTION
Hi! 我看到”npm“和"downloads"的勋章现在都同样链接到element-ui的Npm网页

是否会想要将“downloads”勋章链接到 [下载历史图表？](https://npmcharts.com/compare/element-ui?minimal=true)？

若不，请原谅打扰 😄
