### PR TITLE
Date Picker: make prefix icon on the input clickable on no range pickers (#9687)

### DIFF
--- a/examples/docs/en-US/input.md
+++ b/examples/docs/en-US/input.md
@@ -696,7 +696,6 @@ Attribute | Description | Type | Options | Default
 |fetch-suggestions | a method to fetch input suggestions. When suggestions are ready, invoke `callback(data:[])` to return them to Autocomplete | Function(queryString, callback) | — | — |
 | popper-class | custom class name for autocomplete's dropdown | string | — | — |
 | trigger-on-focus | whether show suggestions when input focus | boolean | — | true |
-| on-icon-click | hook function when clicking on the input icon | function | — | — |
 | name | same as `name` in native input | string | — | — |
 | select-when-unmatched | whether to emit a `select` event on enter when there is no autocomplete match | boolean | — | false |
 | label | label text | string | — | — |

--- a/examples/docs/es/input.md
+++ b/examples/docs/es/input.md
@@ -675,7 +675,6 @@ Atributo | Descripción | Tipo | Opciones | Por defecto
 |fetch-suggestions | un método para obtener las sugerencias del input. Cuando las sugerencias estén listas, invocar `callback(data:[])` para devolverlas a Autocomplete | Function(queryString, callback) | — | — |
 | popper-class | nombre personalizado de clase para el dropdown de autocomplete | string | — | — |
 | trigger-on-focus | si se deben mostrar sugerencias cuando el input obtiene el foco | boolean | — | true |
-| on-icon-click | funcion que se invoca cuando se hace click en el icono | function | — | — |
 | name | igual que `name` en el input nativo | string | — | — |
 | select-when-unmatched | si se emite un evento `select` al pulsar enter cuando no hay coincidencia de Autocomplete | boolean | — | false |
 | label | texto de la etiqueta | string | — | — |

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -18,8 +18,12 @@
     @mouseenter.native="handleMouseEnter"
     @mouseleave.native="showClose = false"
     :validateEvent="false"
-    :prefix-icon="triggerClass"
     ref="reference">
+    <i slot="prefix"
+      class="el-input__icon"
+      :class="triggerClass"
+      @click="handleFocus">
+    </i>
     <i slot="suffix"
       class="el-input__icon"
       @click="handleClickIcon"

--- a/types/autocomplete.d.ts
+++ b/types/autocomplete.d.ts
@@ -1,5 +1,4 @@
 import { ElementUIComponent } from './component'
-import { IconClickEventHandler } from './input'
 
 export interface FetchSuggestionsCallback {
   /**

--- a/types/input.d.ts
+++ b/types/input.d.ts
@@ -13,11 +13,6 @@ export interface AutoSize {
   maxRows: number
 }
 
-export interface IconClickEventHandler {
-  /** The handler function of on-icon-click property */
-  (this: Window, ev: MouseEvent): any
-}
-
 /** Input Component */
 export declare class ElInput extends ElementUIComponent {
   /** Type of input */
@@ -79,7 +74,4 @@ export declare class ElInput extends ElementUIComponent {
 
   /** Same as form in native input */
   form: string
-
-  /** Hook function when clicking on the input icon */
-  onIconClick: IconClickEventHandler
 }


### PR DESCRIPTION
- Prefix icon on the date/time input is now clickable on no range pickers
- In english and spanish documentation, remove `on-icon-click` hook function in `el-input` component
- Remove `onIconClick` type definition in `input.d.ts`


**Fixed** [#9687](https://github.com/ElemeFE/element/issues/9687)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
