### PR TITLE
lazy rendering for popover (#9814)

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -80,7 +80,7 @@
     display: inline-block;
     font-size: inherit;
     height: $--input-height;
-    line-height: 1;
+    line-height: $--input-height;
     outline: none;
     padding: 0 15px;
     transition: $--border-transition-base;
@@ -186,6 +186,7 @@
 
     @include e(inner) {
       height: $--input-medium-height;
+      line-height: $--input-medium-height;
     }
 
     .el-input__icon {
@@ -197,6 +198,7 @@
 
     @include e(inner) {
       height: $--input-small-height;
+      line-height: $--input-small-height;
     }
 
     .el-input__icon {
@@ -208,6 +210,7 @@
 
     @include e(inner) {
       height: $--input-mini-height;
+      line-height: $--input-mini-height;
     }
 
     .el-input__icon {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

#9814 
Current implementation of `Popover` component renders contents before it is activated.
I added `lazy` prop to enable lazy rendering of contents. When no `lazy` prop, it worked as before.
It'll allow us to use popover components with heavy contents and rare display(I'm using it for popovers inside `Table` now).
And I think there are some components that can be improved with this design, e.g. `MessageBox`.
