### PR TITLE
Message-box: fix multiple messagebox with duplicate title

### DIFF
--- a/packages/message-box/src/main.js
+++ b/packages/message-box/src/main.js
@@ -1,5 +1,5 @@
 const defaults = {
-  title: undefined,
+  title: null,
   message: '',
   type: '',
   showInput: false,

--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -10,7 +10,7 @@
       :aria-label="title || 'dialog'"
     >
       <div class="el-message-box" :class="[customClass, center && 'el-message-box--center']">
-        <div class="el-message-box__header" v-if="title !== undefined">
+        <div class="el-message-box__header" v-if="title !== null">
           <div class="el-message-box__title">
             <div class="el-message-box__status" :class="[ typeClass ]" v-if="typeClass && center"></div>
             <span>{{ title }}</span>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Fix when multiple messagebox with duplicate title, for-example, the first one has title option, but the second one hasn't, and click the first one then the second one has the first title.
[jsfiddle] (https://jsfiddle.net/maj51e8z/3/)