### PR TITLE
Menu: Press space key won't trigger click event(#8812)

### DIFF
--- a/src/utils/menu/aria-menuitem.js
+++ b/src/utils/menu/aria-menuitem.js
@@ -35,7 +35,6 @@ MenuItem.prototype.addListeners = function() {
         Utils.triggerEvent(event.currentTarget, 'mouseleave');
         break;
       case keys.enter:
-      case keys.space:
         prevDef = true;
         event.currentTarget.click();
         break;

--- a/src/utils/menu/aria-submenu.js
+++ b/src/utils/menu/aria-submenu.js
@@ -42,7 +42,6 @@ SubMenu.prototype.addListeners = function() {
           Utils.triggerEvent(parentNode, 'mouseleave');
           break;
         case keys.enter:
-        case keys.space:
           prevDef = true;
           event.currentTarget.click();
           break;


### PR DESCRIPTION
Fix #8812 ：当用户按下space键时，Menu拦截了事件并在当前菜单item触发click事件，导致内部input无法收到input事件