### PR TITLE
TimeSelect: fix resetField not work when user inputs an invalid value…

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -502,6 +502,8 @@ export default {
       gpuAcceleration: false
     };
     this.placement = PLACEMENT_MAP[this.align] || PLACEMENT_MAP.left;
+
+    this.$on('fieldReset', this.handleFieldReset);
   },
 
   methods: {
@@ -632,6 +634,10 @@ export default {
 
     handleClose() {
       this.pickerVisible = false;
+    },
+
+    handleFieldReset(initialValue) {
+      this.userInput = initialValue;
     },
 
     handleFocus() {

--- a/packages/date-picker/src/picker/time-select.js
+++ b/packages/date-picker/src/picker/time-select.js
@@ -6,8 +6,16 @@ export default {
 
   name: 'ElTimeSelect',
 
+  componentName: 'ElTimeSelect',
+
+  props: {
+    type: {
+      type: String,
+      default: 'time-select'
+    }
+  },
+
   beforeCreate() {
-    this.type = 'time-select';
     this.panel = Panel;
   }
 };

--- a/packages/form/src/form-item.vue
+++ b/packages/form/src/form-item.vue
@@ -227,6 +227,8 @@
            这里需要强行触发一次，刷新 validateDisabled 的值，
            确保 Select 下一次值改变时能正确触发校验 */
         this.broadcast('ElSelect', 'fieldReset');
+
+        this.broadcast('ElTimeSelect', 'fieldReset', this.initialValue);
       },
       getRules() {
         let formRules = this.form.rules;


### PR DESCRIPTION
当用户输入一个非法值时，TimeSelect的实际值为空字符串；而调用`resetField`，也是将TimeSelect的值变为空字符串，值未发生改变，不会触发监听函数将显示值重置。因此需要手动修改显示值。