### PR TITLE
Form: fix bug: form.validate skip the rules whose trigger is array(#2…

### DIFF
--- a/packages/form/src/form-item.vue
+++ b/packages/form/src/form-item.vue
@@ -241,7 +241,7 @@
         const rules = this.getRules();
 
         return rules.filter(rule => {
-          return !rule.trigger || rule.trigger.indexOf(trigger) !== -1;
+          return !rule.trigger || rule.trigger.indexOf(trigger) !== -1 || (Array.isArray(rule.trigger) && trigger === '');
         }).map(rule => objectAssign({}, rule));
       },
       onFieldBlur() {


### PR DESCRIPTION
修复运行`form.validate`时会跳过`trigger`为数组的规则