### PR TITLE
MessageBox: Add "inputType" support for TypeScript

### DIFF
--- a/types/message-box.d.ts
+++ b/types/message-box.d.ts
@@ -22,6 +22,7 @@ export declare class ElMessageBoxComponent extends Vue {
   showClose: boolean
   inputValue: string
   inputPlaceholder: string
+  inputType: string
   inputPattern: RegExp
   inputValidator: MessageBoxInputValidator
   inputErrorMessage: string
@@ -109,6 +110,9 @@ export interface ElMessageBoxOptions {
 
   /** Regexp for the input */
   inputPattern?: RegExp
+
+  /** Input Type: text, textArea, password or number */
+  inputType?: string
 
   /** Validation function for the input. Should returns a boolean or string. If a string is returned, it will be assigned to inputErrorMessage */
   inputValidator?: MessageBoxInputValidator


### PR DESCRIPTION
inputType is added in source code, but not for typescript file

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
