### PR TITLE
Tree: Remove watcher on defaultExpandedKeys and defaultCheckedKeys(#8…

### DIFF
--- a/packages/tree/src/model/tree-store.js
+++ b/packages/tree/src/model/tree-store.js
@@ -124,13 +124,6 @@ export default class TreeStore {
     }
   }
 
-  setDefaultCheckedKey(newVal) {
-    if (newVal !== this.defaultCheckedKeys) {
-      this.defaultCheckedKeys = newVal;
-      this._initDefaultCheckedNodes();
-    }
-  }
-
   registerNode(node) {
     const key = this.key;
     if (!key || !node || !node.data) return;
@@ -287,16 +280,6 @@ export default class TreeStore {
     });
 
     this._setCheckedKeys(key, leafOnly, checkedKeys);
-  }
-
-  setDefaultExpandedKeys(keys) {
-    keys = keys || [];
-    this.defaultExpandedKeys = keys;
-
-    keys.forEach((key) => {
-      const node = this.getNode(key);
-      if (node) node.expand(null, this.autoExpandParent);
-    });
   }
 
   setChecked(data, checked, deep) {

--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -120,14 +120,6 @@
     },
 
     watch: {
-      defaultCheckedKeys(newVal) {
-        this.store.defaultCheckedKeys = newVal;
-        this.store.setDefaultCheckedKey(newVal);
-      },
-      defaultExpandedKeys(newVal) {
-        this.store.defaultExpandedKeys = newVal;
-        this.store.setDefaultExpandedKeys(newVal);
-      },
       data(newVal) {
         this.store.setData(newVal);
       },

--- a/test/unit/specs/tree.spec.js
+++ b/test/unit/specs/tree.spec.js
@@ -216,21 +216,6 @@ describe('Tree', () => {
     expect(vm.$el.querySelectorAll('.el-tree-node.is-expanded').length).to.equal(2);
   });
 
-  it('defaultExpandedKeys set', (done) => {
-    vm = getTreeVm(':props="defaultProps" :default-expanded-keys="defaultExpandedKeys" node-key="id"', {
-      created() {
-        this.defaultExpandedKeys = [1, 3];
-      }
-    });
-    expect(vm.$el.querySelectorAll('.el-tree-node.is-expanded').length).to.equal(2);
-    vm.defaultExpandedKeys = [2];
-    vm.data = JSON.parse(JSON.stringify(vm.data));
-    setTimeout(() => {
-      expect(vm.$el.querySelectorAll('.el-tree-node.is-expanded').length).to.equal(1);
-      done();
-    }, 50);
-  });
-
   it('filter-node-method', (done) => {
     vm = getTreeVm(':props="defaultProps" :filter-node-method="filterNode"', {
       methods: {


### PR DESCRIPTION
默认值应该只在初始化阶段起作用，后续的改变不应再影响组件状态，因此不需要再监听这两者的状态。
当`default-expaned-keys`和`default-checked-keys`的值以字符串数组形式传入时，有时会突然传入一个新数组触发监听器，会导致如#8815 和#6633 的Bug