### PR TITLE
Progress: add custom circle color

### DIFF
--- a/examples/docs/en-US/progress.md
+++ b/examples/docs/en-US/progress.md
@@ -39,10 +39,11 @@ In this case the percentage takes no additional space.
 
 ### Circular progress bar
 
-:::demo You can specify `type` attribute to `circle` to use circular progress bar, and use `width` attribute to change the size of circle.
+:::demo You can specify `type` attribute to `circle` to use circular progress bar, and use `width` attribute to change the size of circle, and use `status` attribute to change the color of circle.
 ```html
 <el-progress type="circle" :percentage="0"></el-progress>
 <el-progress type="circle" :percentage="25"></el-progress>
+<el-progress type="circle" :percentage="80" status="8e71c7"></el-progress>
 <el-progress type="circle" :percentage="100" status="success"></el-progress>
 <el-progress type="circle" :percentage="50" status="exception"></el-progress>
 ``` 

--- a/examples/docs/es/progress.md
+++ b/examples/docs/es/progress.md
@@ -41,6 +41,7 @@ En este caso el porcentage no toma espacio adicional.
 ```html
 <el-progress type="circle" :percentage="0"></el-progress>
 <el-progress type="circle" :percentage="25"></el-progress>
+<el-progress type="circle" :percentage="80" status="8e71c7"></el-progress>
 <el-progress type="circle" :percentage="100" status="success"></el-progress>
 <el-progress type="circle" :percentage="50" status="exception"></el-progress>
 ```

--- a/examples/docs/zh-CN/progress.md
+++ b/examples/docs/zh-CN/progress.md
@@ -42,11 +42,12 @@
 
 ### 环形进度条
 
-:::demo Progress 组件可通过 `type` 属性来指定使用环形进度条，在环形进度条中，还可以通过 `width` 属性来设置其大小。
+:::demo Progress 组件可通过 `type` 属性来指定使用环形进度条，在环形进度条中，还可以通过 `width` 属性来设置其大小, 并通过在 `status` 属性中填写十六进制颜色代码来自定义颜色。
 
 ```html
 <el-progress type="circle" :percentage="0"></el-progress>
 <el-progress type="circle" :percentage="25"></el-progress>
+<el-progress type="circle" :percentage="80" status="8e71c7"></el-progress>
 <el-progress type="circle" :percentage="100" status="success"></el-progress>
 <el-progress type="circle" :percentage="50" status="exception"></el-progress>
 ```

--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -108,7 +108,11 @@
             ret = '#ff4949';
             break;
           default:
-            ret = '#20a0ff';
+            if (this.status) {
+              ret = '#' + this.status;
+            } else {
+              ret = '#20a0ff';
+            }
         }
         return ret;
       },


### PR DESCRIPTION
[Progress](http://element-cn.eleme.io/#/zh-CN/component/progress)
圆圈进度条可以通过设置 `status` 属性为十六进制颜色代码自定义色彩。
```
<el-progress type="circle" :percentage="80" status="8e71c7"></el-progress>
```
![image](https://user-images.githubusercontent.com/25154432/37861400-b46c208c-2f73-11e8-9ae4-c4fd5ac5c876.png)

---
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
