### PR TITLE
Card: add shadow attribute

### DIFF
--- a/examples/docs/en-US/card.md
+++ b/examples/docs/en-US/card.md
@@ -183,8 +183,34 @@ export default {
 ```
 :::
 
+### Shadow
+
+Set the conditions that appear for shadow.
+
+:::demo Use attribute `shadow` to set shadow with `always`, `hover` or `never`.
+```html
+<el-row :gutter="12">
+  <el-col :span="8">
+    <el-card shadow="always">
+      Always
+    </el-card>
+  </el-col>
+  <el-col :span="8">
+    <el-card shadow="hover">
+      Hover
+    </el-card>
+  </el-col>
+  <el-col :span="8">
+    <el-card shadow="never">
+      Never
+  </el-col>
+</el-row>
+```
+:::
+
 ### Attributes
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
 |---------- |-------- |---------- |-------------  |-------- |
 | header | Title of the card. Also accepts a DOM passed by `slot#header` | string| — | — |
 | body-style | CSS style of body | object| — | { padding: '20px' } |
+| shadow | Status of shadow | string | always/hover/never | always |

--- a/examples/docs/es/card.md
+++ b/examples/docs/es/card.md
@@ -185,8 +185,34 @@ export default {
 ```
 :::
 
+### Shadow
+
+Set the conditions that appear for shadow.
+
+:::demo Use attribute `shadow` to set shadow with `always`, `hover` or `never`.
+```html
+<el-row :gutter="12">
+  <el-col :span="8">
+    <el-card shadow="always">
+      Always
+    </el-card>
+  </el-col>
+  <el-col :span="8">
+    <el-card shadow="hover">
+      Hover
+    </el-card>
+  </el-col>
+  <el-col :span="8">
+    <el-card shadow="never">
+      Never
+  </el-col>
+</el-row>
+```
+:::
+
 ### Atributos
-| Atributo   | Descripción                              | Tipo   | Valores aceptados | Por defecto         |
-| ---------- | ---------------------------------------- | ------ | ----------------- | ------------------- |
-| header     | Titulo del card. También acepta DOM pasado por `slot#header` | string | —                 | —                   |
-| body-style | Estilo CSS del cuerpo                    | object | —                 | { padding: '20px' } |
+| Atributo   | Descripción                              | Tipo   | Valores aceptados  | Por defecto         |
+| ---------- | ---------------------------------------- | ------ | -----------------  | ------------------- |
+| header     | Titulo del card. También acepta DOM pasado por `slot#header` | string  | —                 | —                   |
+| body-style | Estilo CSS del cuerpo                    | object | —                  | { padding: '20px' } |
+| shadow     | Status of shadow                         | string | always/hover/never | always              |

--- a/examples/docs/zh-CN/card.md
+++ b/examples/docs/zh-CN/card.md
@@ -56,7 +56,7 @@
 
 :::demo Card 组件包括`header`和`body`部分，`header`部分需要有显式具名 slot 分发，同时也是可选的。
 ```html
-<el-card class="box-card">
+<el-card class="box-card" shadow="always">
   <div slot="header" class="clearfix">
     <span>卡片名称</span>
     <el-button style="float: right; padding: 3px 0" type="text">操作按钮</el-button>
@@ -184,8 +184,34 @@ export default {
 ```
 :::
 
+### 卡片阴影
+
+可对阴影的显示情况进行配置。
+
+:::demo `always`、`hover`、`never`，通过设置`shadow`属性来配置卡片阴影。
+```html
+<el-row :gutter="12">
+  <el-col :span="8">
+    <el-card shadow="always">
+      总是显示
+    </el-card>
+  </el-col>
+  <el-col :span="8">
+    <el-card shadow="hover">
+      鼠标悬浮时显示
+    </el-card>
+  </el-col>
+  <el-col :span="8">
+    <el-card shadow="never">
+      从不显示
+  </el-col>
+</el-row>
+```
+:::
+
 ### Attributes
 | 参数      | 说明    | 类型      | 可选值       | 默认值   |
 |---------- |-------- |---------- |-------------  |-------- |
 | header | 设置 header，也可以通过 `slot#header` 传入 DOM | string| — | — |
 | body-style | 设置 body 的样式| object| — | { padding: '20px' } |
+| shadow | 设置 shadow 状态| string | always/hover/never | always |

--- a/examples/docs/zh-CN/card.md
+++ b/examples/docs/zh-CN/card.md
@@ -56,7 +56,7 @@
 
 :::demo Card 组件包括`header`和`body`部分，`header`部分需要有显式具名 slot 分发，同时也是可选的。
 ```html
-<el-card class="box-card" shadow="always">
+<el-card class="box-card">
   <div slot="header" class="clearfix">
     <span>卡片名称</span>
     <el-button style="float: right; padding: 3px 0" type="text">操作按钮</el-button>

--- a/packages/card/src/main.vue
+++ b/packages/card/src/main.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="el-card" :class="{'is-shadow': hasShadow, 'is-hover-shadow': hasHoverShadow}">
+  <div class="el-card" :class="shadow ? 'is-' + shadow + '-shadow' : 'is-always-shadow'">
     <div class="el-card__header" v-if="$slots.header || header">
       <slot name="header">{{ header }}</slot>
     </div>
@@ -16,34 +16,7 @@
       header: null,
       bodyStyle: null,
       shadow: {
-        type: String,
-        default: 'always'
-      }
-    },
-    computed: {
-      hasShadow() {
-        switch (this.shadow) {
-          case 'always':
-            return true;
-          case 'hover':
-            return false;
-          case 'never':
-            return false;
-          default:
-            return true;
-        }
-      },
-      hasHoverShadow() {
-        switch (this.shadow) {
-          case 'always':
-            return false;
-          case 'hover':
-            return true;
-          case 'never':
-            return false;
-          default:
-            return false;
-        }
+        type: String
       }
     }
   };

--- a/packages/card/src/main.vue
+++ b/packages/card/src/main.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="el-card">
+  <div class="el-card" :class="{'is-shadow': hasShadow, 'is-hover-shadow': hasHoverShadow}">
     <div class="el-card__header" v-if="$slots.header || header">
       <slot name="header">{{ header }}</slot>
     </div>
@@ -12,7 +12,39 @@
 <script>
   export default {
     name: 'ElCard',
-
-    props: ['header', 'bodyStyle']
+    props: {
+      header: null,
+      bodyStyle: null,
+      shadow: {
+        type: String,
+        default: 'always'
+      }
+    },
+    computed: {
+      hasShadow() {
+        switch (this.shadow) {
+          case 'always':
+            return true;
+          case 'hover':
+            return false;
+          case 'never':
+            return false;
+          default:
+            return true;
+        }
+      },
+      hasHoverShadow() {
+        switch (this.shadow) {
+          case 'always':
+            return false;
+          case 'hover':
+            return true;
+          case 'never':
+            return false;
+          default:
+            return false;
+        }
+      }
+    }
   };
 </script>

--- a/packages/card/src/main.vue
+++ b/packages/card/src/main.vue
@@ -13,8 +13,8 @@
   export default {
     name: 'ElCard',
     props: {
-      header: null,
-      bodyStyle: null,
+      header: {},
+      bodyStyle: {},
       shadow: {
         type: String
       }

--- a/packages/theme-chalk/src/card.scss
+++ b/packages/theme-chalk/src/card.scss
@@ -9,7 +9,7 @@
   color: $--color-text-primary;
   transition: 0.3s;
 
-  @include when(shadow) {
+  @include when(always-shadow) {
     box-shadow: $--box-shadow-light;
   }
 

--- a/packages/theme-chalk/src/card.scss
+++ b/packages/theme-chalk/src/card.scss
@@ -6,8 +6,19 @@
   border: 1px solid $--card-border-color;
   background-color: $--color-white;
   overflow: hidden;
-  box-shadow: $--box-shadow-light;
   color: $--color-text-primary;
+  transition: 0.3s;
+
+  @include when(shadow) {
+    box-shadow: $--box-shadow-light;
+  }
+
+  @include when(hover-shadow) {
+    &:hover,
+    &:focus {
+      box-shadow: $--box-shadow-light;
+    }
+  }
 
   @include e(header) {
     padding: #{$--card-padding - 2 $--card-padding};

--- a/test/unit/specs/card.spec.js
+++ b/test/unit/specs/card.spec.js
@@ -32,4 +32,27 @@ describe('Card', () => {
 
     expect(vm.$el.querySelector('.el-card__body').style.padding).to.equal('10px');
   });
+
+  it('shadow', () => {
+    vm = createTest(Card, {
+      shadow: 'always'
+    });
+    expect(vm.$el.classList.contains('is-shadow')).to.be.true;
+  });
+
+  it('shadow', () => {
+    vm = createTest(Card, {
+      shadow: 'hover'
+    });
+    expect(vm.$el.classList.contains('is-shadow')).to.be.false;
+    expect(vm.$el.classList.contains('is-hover-shadow')).to.be.true;
+  });
+
+  it('shadow', () => {
+    vm = createTest(Card, {
+      shadow: 'none'
+    });
+    expect(vm.$el.classList.contains('is-shadow')).to.be.false;
+    expect(vm.$el.classList.contains('is-hover-shadow')).to.be.false;
+  });
 });

--- a/test/unit/specs/card.spec.js
+++ b/test/unit/specs/card.spec.js
@@ -50,7 +50,7 @@ describe('Card', () => {
 
   it('shadow', () => {
     vm = createTest(Card, {
-      shadow: 'none'
+      shadow: 'never'
     });
     expect(vm.$el.classList.contains('is-shadow')).to.be.false;
     expect(vm.$el.classList.contains('is-hover-shadow')).to.be.false;

--- a/test/unit/specs/card.spec.js
+++ b/test/unit/specs/card.spec.js
@@ -37,14 +37,13 @@ describe('Card', () => {
     vm = createTest(Card, {
       shadow: 'always'
     });
-    expect(vm.$el.classList.contains('is-shadow')).to.be.true;
+    expect(vm.$el.classList.contains('is-always-shadow')).to.be.true;
   });
 
   it('shadow', () => {
     vm = createTest(Card, {
       shadow: 'hover'
     });
-    expect(vm.$el.classList.contains('is-shadow')).to.be.false;
     expect(vm.$el.classList.contains('is-hover-shadow')).to.be.true;
   });
 
@@ -52,7 +51,6 @@ describe('Card', () => {
     vm = createTest(Card, {
       shadow: 'never'
     });
-    expect(vm.$el.classList.contains('is-shadow')).to.be.false;
-    expect(vm.$el.classList.contains('is-hover-shadow')).to.be.false;
+    expect(vm.$el.classList.contains('is-never-shadow')).to.be.true;
   });
 });


### PR DESCRIPTION
[Card](http://element-cn.eleme.io/#/zh-CN/component/card)
卡片增加 `shadow` 属性，可以对设置卡片阴影出现情况。默认值为 `always` 。
`always` 总是出现阴影，`hover` 鼠标悬浮时出现，`never` 从不出现阴影。
![image](https://user-images.githubusercontent.com/25154432/38025105-c44689d6-32b9-11e8-871d-c6bf48f408dd.png)

---
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
