### PR TITLE
Dialog: click .v-modal to close Dialog

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -149,6 +149,9 @@
         if (!this.closeOnClickModal) return;
         this.handleClose();
       },
+      onClose() {
+        this.handleWrapperClick();
+      },
       handleClose() {
         if (typeof this.beforeClose === 'function') {
           this.beforeClose(this.hide);

--- a/src/utils/popup/index.js
+++ b/src/utils/popup/index.js
@@ -219,6 +219,10 @@ export default {
     },
 
     close() {
+      if (!this.opened) {
+        return ;
+      }
+
       if (this.willClose && !this.willClose()) return;
 
       if (this._openTimer !== null) {


### PR DESCRIPTION
If the `Dialog` is smaller than the `.v-modal` (for example, put `left:200px` on Dialog's style), you can't close Dialog by clicking `.v-modal`. This pr solves this problem.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Add some descriptions and refer relative issues for you PR.
* [x] Make sure you are merging your commits to `dev` branch.
