### PR TITLE
Tooltip: invoke 'doDestory' by hand when disabled

### DIFF
--- a/packages/tooltip/src/main.js
+++ b/packages/tooltip/src/main.js
@@ -191,6 +191,10 @@ export default {
         clearTimeout(this.timeoutPending);
       }
       this.showPopper = false;
+
+      if (this.disabled) {
+        this.doDestroy();
+      }
     },
 
     setExpectedState(expectedState) {


### PR DESCRIPTION
`doDestroy` is not invoked when the tooltip is disabled because `<transition>` won't call `onAfterLeave`  when its content is not shown.
So `:popper-options="{removeOnDestroy:true}"` won't work when the tooltip is disabled.
https://jsfiddle.net/blackmiaool/3okg7754/4/

This pr solves this problem.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
