### PR TITLE
Theme-Chalk: No tab color on hover when tab is disabled

### DIFF
--- a/packages/theme-chalk/src/tabs.scss
+++ b/packages/theme-chalk/src/tabs.scss
@@ -224,7 +224,7 @@
         border-right-color: $--border-color-base;
         border-left-color: $--border-color-base;
       }
-      &:hover {
+      &:not(.is-disabled):hover {
         color: $--color-primary;
       }
     }


### PR DESCRIPTION
For tabs of style "border-card", don't set the color property on hover
if it is disabled.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
