### PR TITLE
Fix TS2300: Duplicate identifier 'showTimeout'

### DIFF
--- a/types/submenu.d.ts
+++ b/types/submenu.d.ts
@@ -5,9 +5,6 @@ export declare class ElSubmenu extends ElementUIComponent {
   /** Unique identification */
   index: string
 
-  /** Delay time before show a sub-menu */
-  showTimeout: number
-
   /** Delay time before showing a sub-menu */
   showTimeout: number
 


### PR DESCRIPTION
Fix the following error when using Typescript.

```
ERROR in [at-loader] ./node_modules/element-ui/types/submenu.d.ts:12:3 
    TS2300: Duplicate identifier 'showTimeout'.
```
