### PR TITLE
Remove submenu type duplicate key

### DIFF
--- a/types/submenu.d.ts
+++ b/types/submenu.d.ts
@@ -8,9 +8,6 @@ export declare class ElSubmenu extends ElementUIComponent {
   /** Delay time before show a sub-menu */
   showTimeout: number
 
-  /** Delay time before showing a sub-menu */
-  showTimeout: number
-
   /** Delay time before hiding a sub-menu */
   hideTimeout: number
 


### PR DESCRIPTION
Submenu type have a duplicate key. This error throw an error with Typescript from version 2.8 and failed the build.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
