### PR TITLE
Pagination: handle NaN on props

### DIFF
--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -379,23 +379,26 @@ export default {
       }
     },
 
-    internalCurrentPage(newVal, oldVal) {
-      newVal = parseInt(newVal, 10);
+    internalCurrentPage: {
+      immediate: true,
+      handler(newVal, oldVal) {
+        newVal = parseInt(newVal, 10);
 
-      /* istanbul ignore if */
-      if (isNaN(newVal)) {
-        newVal = oldVal || 1;
-      } else {
-        newVal = this.getValidCurrentPage(newVal);
-      }
+        /* istanbul ignore if */
+        if (isNaN(newVal)) {
+          newVal = oldVal || 1;
+        } else {
+          newVal = this.getValidCurrentPage(newVal);
+        }
 
-      if (newVal !== undefined) {
-        this.internalCurrentPage = newVal;
-        if (oldVal !== newVal) {
+        if (newVal !== undefined) {
+          this.internalCurrentPage = newVal;
+          if (oldVal !== newVal) {
+            this.$emit('update:currentPage', newVal);
+          }
+        } else {
           this.$emit('update:currentPage', newVal);
         }
-      } else {
-        this.$emit('update:currentPage', newVal);
       }
     },
 

--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -375,7 +375,7 @@ export default {
     pageSize: {
       immediate: true,
       handler(val) {
-        this.internalPageSize = val;
+        this.internalPageSize = isNaN(val) ? 10 : val;
       }
     },
 

--- a/test/unit/specs/pagination.spec.js
+++ b/test/unit/specs/pagination.spec.js
@@ -129,6 +129,17 @@ describe('Pagination', () => {
     expect(vm.$el.querySelector('li.number.active')).to.have.property('textContent').to.equal('3');
   });
 
+  it('currentPage: NaN', () => {
+    vm = createTest(Pagination, {
+      pageSize: 20,
+      total: 200,
+      currentPage: NaN
+    });
+
+    expect(vm.$el.querySelector('li.number.active')).to.have.property('textContent').to.equal('1');
+    expect(vm.$el.querySelectorAll('li.number')).to.length(7);
+  });
+
   it('set currentPage & total', (done) => {
     vm = createVue({
       template: `

--- a/test/unit/specs/pagination.spec.js
+++ b/test/unit/specs/pagination.spec.js
@@ -82,6 +82,16 @@ describe('Pagination', () => {
     expect(vm.$el.querySelectorAll('li.number')).to.length(4);
   });
 
+  it('pageSize: NaN', () => {
+    vm = createTest(Pagination, {
+      pageSize: NaN,
+      total: 100
+    });
+
+    const pagers = vm.$el.querySelectorAll('li.number');
+    expect(pagers).to.length(7);
+  });
+
   it('pageCount', () => {
     const vm = createTest(Pagination, {
       pageSize: 25,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Pagination component breaks when `NaN` is passed on the prop `currentPage` or `pageSize`. Here is a demo reproducing the issue.

https://jsfiddle.net/xroupdkf/2/
![screen shot 2018-04-09 at 5 48 11 pm](https://user-images.githubusercontent.com/36145478/38488372-34fd584a-3c1e-11e8-8dc2-9ec79f55eb74.png)


I added a little protection code to keep it safe from `NaN`.
- With `NaN`, `pageSize` returns default value (which is `1`).
- `currentPage` already had a nice handling code inside `internalCurrentPage` watcher but it is not invoked at initial phase, so I made it to be called immediately.

It passes all of the test cases and I added more of it.

Thank you for maintaining this amazing repository. 




