### PR TITLE
[Feature Request] Carousel: Provide access to the active index

### DIFF
--- a/packages/carousel/src/main.vue
+++ b/packages/carousel/src/main.vue
@@ -31,7 +31,7 @@
           <i class="el-icon-arrow-right"></i>
         </button>
       </transition>
-      <slot></slot>
+      <slot :active-index="activeIndex"></slot>
     </div>
     <ul
       class="el-carousel__indicators"


### PR DESCRIPTION
This can be useful. For example: I want to get this using a `slot-scope` for dynamic loading of slide images.