### PR TITLE
Popup: fix the scroll disabling method

### DIFF
--- a/src/utils/popup/index.js
+++ b/src/utils/popup/index.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import merge from 'element-ui/src/utils/merge';
 import PopupManager from 'element-ui/src/utils/popup/popup-manager';
-import getScrollBarWidth from '../scrollbar-width';
 import { getStyle } from '../dom';
 
 let idSeed = 1;
@@ -114,8 +113,9 @@ export default {
   data() {
     return {
       opened: false,
-      bodyOverflow: null,
-      bodyPaddingRight: null,
+      bodyWidth: null,
+      bodyPosition: null,
+      bodyOverflowY: null,
       rendered: false
     };
   },
@@ -186,17 +186,14 @@ export default {
         }
         PopupManager.openModal(this._popupId, PopupManager.nextZIndex(), this.modalAppendToBody ? undefined : dom, props.modalClass, props.modalFade);
         if (props.lockScroll) {
-          if (!this.bodyOverflow) {
-            this.bodyPaddingRight = document.body.style.paddingRight;
-            this.bodyOverflow = document.body.style.overflow;
+          if (!this.bodyOverflowY) {
+            this.bodyWidth = document.body.style.width;
+            this.bodyPosition = document.body.style.position || 'static';
+            this.bodyOverflowY = document.body.style.overflowY;
           }
-          scrollBarWidth = getScrollBarWidth();
-          let bodyHasOverflow = document.documentElement.clientHeight < document.body.scrollHeight;
-          let bodyOverflowY = getStyle(document.body, 'overflowY');
-          if (scrollBarWidth > 0 && (bodyHasOverflow || bodyOverflowY === 'scroll')) {
-            document.body.style.paddingRight = scrollBarWidth + 'px';
-          }
-          document.body.style.overflow = 'hidden';
+          document.body.style.width = '100%';
+          document.body.style.position = 'fixed';
+          document.body.style.overflowY = 'scroll';
         }
       }
 
@@ -246,12 +243,14 @@ export default {
 
       if (this.lockScroll) {
         setTimeout(() => {
-          if (this.modal && this.bodyOverflow !== 'hidden') {
-            document.body.style.overflow = this.bodyOverflow;
-            document.body.style.paddingRight = this.bodyPaddingRight;
+          if (this.modal && this.bodyOverflowY !== 'scroll') {
+            document.body.style.width = this.bodyWidth;
+            document.body.style.position = this.bodyPosition;
+            document.body.style.overflowY = this.bodyOverflowY;
           }
-          this.bodyOverflow = null;
-          this.bodyPaddingRight = null;
+          this.bodyWidth = null;
+          this.bodyPosition = null;
+          this.bodyOverflowY = null;
         }, 200);
       }
 

--- a/src/utils/popup/index.js
+++ b/src/utils/popup/index.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import merge from 'element-ui/src/utils/merge';
 import PopupManager from 'element-ui/src/utils/popup/popup-manager';
-import { getStyle } from '../dom';
 
 let idSeed = 1;
 const transitions = [];
@@ -37,8 +36,6 @@ const hookTransition = (transition) => {
     }
   });
 };
-
-let scrollBarWidth;
 
 const getDOM = function(dom) {
   if (dom.nodeType === 3) {

--- a/test/unit/specs/mixin.vue-popup.spec.js
+++ b/test/unit/specs/mixin.vue-popup.spec.js
@@ -49,13 +49,15 @@ describe('Mixin:vue-popup', () => {
   it('lock scroll', done => {
     vm = createTest(Popup, { modal: true });
     vm.open();
-    expect(document.body.style.overflow).to.equal('hidden');
+    expect(document.body.style.position).to.equal('fixed');
+    expect(document.body.style.overflowY).to.equal('scroll');
     vm.close();
     destroyVM(vm);
     setTimeout(() => {
       vm = createTest(Popup, { modal: true, lockScroll: false });
       vm.open();
-      expect(document.body.style.overflow).to.not.equal('hidden');
+      expect(document.body.style.position).to.not.equal('fixed');
+      expect(document.body.style.overflowY).to.not.equal('scroll');
       done();
     }, 200);
   });


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

The padding way to disable scrolling, is not compatible when some elements are in fixed layout. The requested source code use the fixed body to do only the same thing, but no computation on the width of scroll bar.
