### PR TITLE
Tweak A11Y for Checkbox/Radio

### DIFF
--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -26,6 +26,7 @@
         v-if="trueLabel || falseLabel"
         class="el-checkbox__original"
         type="checkbox"
+        aria-hidden="true"
         :name="name"
         :disabled="isDisabled"
         :true-value="trueLabel"
@@ -38,6 +39,7 @@
         v-else
         class="el-checkbox__original"
         type="checkbox"
+        aria-hidden="true"
         :disabled="isDisabled"
         :value="label"
         :name="name"

--- a/packages/radio/src/radio.vue
+++ b/packages/radio/src/radio.vue
@@ -25,6 +25,7 @@
         class="el-radio__original"
         :value="label"
         type="radio"
+        aria-hidden="true"
         v-model="model"
         @focus="focus = true"
         @blur="focus = false"


### PR DESCRIPTION
Native `input` elements already carry a11y semantics. Current declarations produce duplicated nodes in the accessibility tree:

![image](https://user-images.githubusercontent.com/1726061/38917599-dc5e66aa-431d-11e8-84f9-c3f8e9243f2d.png)

As `indeterminate` state is not synced to the native inputs, we can just ignore them with `aria-hidden="true"`. Otherwise we can remove those additional `role` & `aria-*` declarations.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
