### PR TITLE
Tree: fix model.TreeStore.checkStrictly doesn't change along with the…

### DIFF
--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -162,6 +162,10 @@
         Array.prototype.forEach.call(val, (checkbox) => {
           checkbox.setAttribute('tabindex', -1);
         });
+      },
+
+      checkStrictly(newVal) {
+        this.store.checkStrictly = !!newVal;
       }
     },
 

--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -165,7 +165,7 @@
       },
 
       checkStrictly(newVal) {
-        this.store.checkStrictly = !!newVal;
+        this.store.checkStrictly = newVal;
       }
     },
 


### PR DESCRIPTION
… change of tree.props.checkStrictly

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Fixes #10865 

the reason is that ,  `Node.setChecked` function returned when the `checkStrictly` attribute of `TreeStore` Instance is `true`, which prevents the check status updating  recursively.  

```
if (this.store.checkStrictly) return;
``` 
https://github.com/ElemeFE/element/blob/8ce14faacc103f665e564dff20d683c17be587de/packages/tree/src/model/node.js#L357


then i find out that the  `checkStrictly` attribute of `TreeStore` Instance comes in the `created` lifecycle method in `Tree` component, and doesn't update when the source prop change.


