### PR TITLE
MenuItem: emit contextmenu to support right click

### DIFF
--- a/packages/menu/src/menu-item.vue
+++ b/packages/menu/src/menu-item.vue
@@ -8,6 +8,7 @@
       'is-disabled': disabled
     }"
     @click="handleClick"
+    @click.right="handleRightClick"
     @mouseenter="onMouseEnter"
     @focus="onMouseEnter"
     @blur="onMouseLeave"
@@ -98,6 +99,9 @@
           this.dispatch('ElMenu', 'item-click', this);
           this.$emit('click', this);
         };
+      },
+      handleRightClick() {
+        this.$emit('contextmenu', this);
       }
     },
     created() {


### PR DESCRIPTION
In electron env, right click menuItem and show context menu is common use cases. So menuItem should support emit right click event :)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.


