### PR TITLE
fix #10929, 外部v-model.number等导致this.currentValue与this.value不一致

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -278,8 +278,12 @@
           this.resizeTextarea();
         });
         this.currentValue = value;
+        // 外部v-model.number等导致this.currentValue与this.value不一致
+        this.$nextTick(_ => {
+          this.currentValue = this.value;
+        });
         if (this.validateEvent) {
-          this.dispatch('ElFormItem', 'el.form.change', [value]);
+          this.dispatch('ElFormItem', 'el.form.change');
         }
       },
       calcIconOffset(place) {


### PR DESCRIPTION
使用v-model.number后, 当输入前面部分为数字, 后面不为数字时, v-model绑定的值与el-input显示的值不一致.
相关issues: [#10929](https://github.com/ElemeFE/element/issues/10929)