### PR TITLE
i18n: Update Danish locale

### DIFF
--- a/src/locale/lang/da.js
+++ b/src/locale/lang/da.js
@@ -16,11 +16,11 @@ export default {
       startTime: 'Starttidspunkt',
       endDate: 'Slutdato',
       endTime: 'Sluttidspunkt',
-      prevYear: 'Previous Year', // to be translated
-      nextYear: 'Next Year', // to be translated
-      prevMonth: 'Previous Month', // to be translated
-      nextMonth: 'Next Month', // to be translated
-      year: 'År',
+      prevYear: 'Forrige år',
+      nextYear: 'Næste år',
+      prevMonth: 'Forrige måned',
+      nextMonth: 'Næste måned',
+      year: '',
       month1: 'Januar',
       month2: 'Februar',
       month3: 'Marts',
@@ -81,7 +81,7 @@ export default {
       error: 'Ugyldig input'
     },
     upload: {
-      deleteTip: 'press delete to remove', // to be translated
+      deleteTip: 'tryk slet for at fjerne',
       delete: 'Slet',
       preview: 'Forhåndsvisning',
       continue: 'Fortsæt'
@@ -91,7 +91,7 @@ export default {
       confirmFilter: 'Bekræft',
       resetFilter: 'Nulstil',
       clearFilter: 'Alle',
-      sumText: 'Sum' // to be translated
+      sumText: 'Sum'
     },
     tree: {
       emptyText: 'Ingen data'
@@ -99,10 +99,10 @@ export default {
     transfer: {
       noMatch: 'Ingen matchende data',
       noData: 'Ingen data',
-      titles: ['List 1', 'List 2'], // to be translated
-      filterPlaceholder: 'Enter keyword', // to be translated
-      noCheckedFormat: '{total} items', // to be translated
-      hasCheckedFormat: '{checked}/{total} checked' // to be translated
+      titles: ['Liste 1', 'Liste 2'],
+      filterPlaceholder: 'Indtast søgeord',
+      noCheckedFormat: '{total} emner',
+      hasCheckedFormat: '{checked}/{total} valgt'
     }
   }
 };


### PR DESCRIPTION
Translate remaining strings. Clear translation for `datepicker.year` since it shouldn't be used for this locale (like the English locale).

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
