### PR TITLE
date-picker: fix dates selection date jump

### DIFF
--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -188,6 +188,7 @@
       },
 
       value(val) {
+        if (this.selectionMode === 'dates' && this.value) return;
         if (isDate(val)) {
           this.date = new Date(val);
         } else {

--- a/packages/date-picker/src/util/index.js
+++ b/packages/date-picker/src/util/index.js
@@ -28,6 +28,7 @@ export const toDate = function(date) {
 export const isDate = function(date) {
   if (date === null || date === undefined) return false;
   if (isNaN(new Date(date).getTime())) return false;
+  if (Array.isArray(date)) return false; // deal with `new Date([ new Date() ]) -> new Date()`
   return true;
 };
 


### PR DESCRIPTION
see issue https://github.com/ElemeFE/element/issues/10890

Caused by `[val]` being coerced to `val.toString()` during `new Date()`.

Changes:
1. strict type check in `isDate`
2. in dates selection, do not reset panel date unless value is falsy.
