### PR TITLE
为日期时间的范围选择器，添加了一个属性auto-close

### DIFF
--- a/examples/docs/en-US/datetime-picker.md
+++ b/examples/docs/en-US/datetime-picker.md
@@ -258,7 +258,8 @@ DateTimePicker is derived from DatePicker and TimePicker. For a more detailed ex
       align="right"
       start-placeholder="Start Date"
       end-placeholder="End Date"
-      :default-time="['12:00:00', '08:00:00']">
+      :default-time="['12:00:00', '08:00:00']"
+      auto-close>
     </el-date-picker>
   </div>
 </template>
@@ -301,6 +302,7 @@ DateTimePicker is derived from DatePicker and TimePicker. For a more detailed ex
 | unlink-panels | unllink two date-panels in range-picker | boolean | — | false |
 | prefix-icon | Custom prefix icon class | string | — | el-icon-date |
 | clear-icon | Custom clear icon class | string | — | el-icon-circle-close |
+| auto-close | When the range date was picked, auto close the panel | boolean | — | false
 
 ### Picker Options
 | Attribute      | Description          | Type      | Accepted Values       | Default  |

--- a/examples/docs/es/datetime-picker.md
+++ b/examples/docs/es/datetime-picker.md
@@ -259,7 +259,8 @@ DateTimePicker se deriva de DatePicker y TimePicker. Por una explicación más d
       align="right"
       start-placeholder="Start Date"
       end-placeholder="End Date"
-      :default-time="['12:00:00', '08:00:00']">
+      :default-time="['12:00:00', '08:00:00']"
+      auto-close>
     </el-date-picker>
   </div>
 </template>
@@ -302,7 +303,7 @@ DateTimePicker se deriva de DatePicker y TimePicker. Por una explicación más d
 | unlink-panels      | desconectar dos date-panels en range-picker | boolean           | —                                        | false                |
 | prefix-icon        | Clase personalizada para el icono prefijado | string            | —                                        | el-icon-date         |
 | clear-icon         | Clase personalizada para el icono `clear` | string            | —                                        | el-icon-circle-close |
-
+| auto-close | Cuando se seleccionó la fecha de rango, auto cierre el panel | boolean | — | false
 ### Picker Options
 | Atributo       | Descripción                              | Tipo     | Valores aceptados | Por defecto |
 | -------------- | ---------------------------------------- | -------- | ----------------- | ----------- |

--- a/examples/docs/zh-CN/datetime-picker.md
+++ b/examples/docs/zh-CN/datetime-picker.md
@@ -257,7 +257,8 @@ DateTimePicker 由 DatePicker 和 TimePicker 派生，`Picker Options` 或者其
       align="right"
       start-placeholder="开始日期"
       end-placeholder="结束日期"
-      :default-time="['12:00:00', '08:00:00']">
+      :default-time="['12:00:00', '08:00:00']"
+      auto-close>
     </el-date-picker>
   </div>
 </template>
@@ -300,6 +301,7 @@ DateTimePicker 由 DatePicker 和 TimePicker 派生，`Picker Options` 或者其
 | unlink-panels | 在范围选择器里取消两个日期面板之间的联动 | boolean | — | false |
 | prefix-icon | 自定义头部图标的类名 | string | — | el-icon-date |
 | clear-icon | 自定义清空图标的类名 | string | — | el-icon-circle-close |
+| auto-close | 当选择完日期后，自动确认并关闭| boolean | — | false
 
 ### Picker Options
 | 参数      | 说明          | 类型      | 可选值                           | 默认值  |

--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -329,7 +329,8 @@
         maxTimePickerVisible: false,
         format: '',
         arrowControl: false,
-        unlinkPanels: false
+        unlinkPanels: false,
+        autoClose: false
       };
     },
 
@@ -513,7 +514,7 @@
           this.maxDate = maxDate;
           this.minDate = minDate;
         }, 10);
-        if (!close || this.showTime) return;
+        if (!close || (!this.autoClose && this.showTime)) return;
         this.handleConfirm();
       },
 

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -382,7 +382,8 @@ export default {
       default: '-'
     },
     pickerOptions: {},
-    unlinkPanels: Boolean
+    unlinkPanels: Boolean,
+    autoClose: Boolean
   },
 
   components: { ElInput },
@@ -814,6 +815,7 @@ export default {
       this.picker.selectionMode = this.selectionMode;
       this.picker.unlinkPanels = this.unlinkPanels;
       this.picker.arrowControl = this.arrowControl || this.timeArrowControl || false;
+      this.picker.autoClose = this.autoClose || false;
       this.picker.selectedDate = Array.isArray(this.value) && this.value || [];
       this.$watch('format', (format) => {
         this.picker.format = format;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

该属性的作用就是，当选择好了日期范围后，自动关闭弹出面板，不需要多一步用户去点击确认按钮。
在一定场景下，这个属性的使用，可以很好的优化用户体验。