### PR TITLE
input: fix cursor goes to the end when typing chinese quickly

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -10,9 +10,6 @@
     <el-input
       ref="input"
       v-bind="$props"
-      @compositionstart.native="handleComposition"
-      @compositionupdate.native="handleComposition"
-      @compositionend.native="handleComposition"
       @input="handleChange"
       @focus="handleFocus"
       @blur="handleBlur"
@@ -122,7 +119,6 @@
     data() {
       return {
         activated: false,
-        isOnComposition: false,
         suggestions: [],
         loading: false,
         highlightedIndex: -1
@@ -163,17 +159,9 @@
           }
         });
       },
-      handleComposition(event) {
-        if (event.type === 'compositionend') {
-          this.isOnComposition = false;
-          this.handleChange(event.target.value);
-        } else {
-          this.isOnComposition = true;
-        }
-      },
       handleChange(value) {
         this.$emit('input', value);
-        if (this.isOnComposition || (!this.triggerOnFocus && !value)) {
+        if (!this.triggerOnFocus && !value) {
           this.suggestions = [];
           return;
         }

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -130,7 +130,8 @@
         suffixOffset: null,
         hovering: false,
         focused: false,
-        isOnComposition: false
+        isOnComposition: false,
+        valueBeforeComposition: null
       };
     },
 
@@ -260,28 +261,34 @@
       handleComposition(event) {
         if (event.type === 'compositionend') {
           this.isOnComposition = false;
+          this.currentValue = this.valueBeforeComposition;
+          this.valueBeforeComposition = null;
           this.handleInput(event);
         } else {
           const text = event.target.value;
           const lastCharacter = text[text.length - 1] || '';
           this.isOnComposition = !isKorean(lastCharacter);
+          if (this.isOnComposition && event.type === 'compositionstart') {
+            this.valueBeforeComposition = text;
+          }
         }
       },
       handleInput(event) {
-        if (this.isOnComposition) return;
         const value = event.target.value;
-        this.$emit('input', value);
         this.setCurrentValue(value);
+        if (this.isOnComposition) return;
+        this.$emit('input', value);
       },
       handleChange(event) {
         this.$emit('change', event.target.value);
       },
       setCurrentValue(value) {
-        if (value === this.currentValue) return;
+        if (this.isOnComposition && value === this.valueBeforeComposition) return;
+        this.currentValue = value;
+        if (this.isOnComposition) return;
         this.$nextTick(_ => {
           this.resizeTextarea();
         });
-        this.currentValue = value;
         if (this.validateEvent) {
           this.dispatch('ElFormItem', 'el.form.change', [value]);
         }


### PR DESCRIPTION
bugfix #11199 

修改后在 `window 7 / [chrome 66 | ie11]` 下能正常使用. 受开发环境限制, 没有进行其他兼容性测试, 建议进一步测试.

另外没有处理韩文相关经验, commit里只简单保留了相关判断, 并简单用朝鲜语IME输入试了下没问题, 不太清楚对 #10611 是否有影响.

产生原因:
上一个文字键入后`currentValue`发生变化, 并在vue同步变化到dom前又迅速键入了其他字符, 触发输入法选择. 此时dom上的内容包括了新键入的字符, 但`currentValue`不包含. 
vue将`currentValue`变化同步到dom上时将`currenValue`的值替换掉实际dom上的值使得光标跳到末尾处.

解决方案:
在`isOnComposition`为`true`时也修改`currentValue`, 但不emit `input`事件和`el.form.change`事件, 保持内部`currentValue`与dom上`value`保持一致.
保存`compositionstart`事件触发时dom上的值到`valueBeforeComposition`, 在`isOnComposition`为`true`时只有新值与`valueBeforeComposition`不同时才能修改`currentValue`, 应对组件`props.value`的其他变动能正确反映到`currentValue`上.

其他修改:
由于input组件进行了`composition`相应处理, autocomplete无需再处理一次, 因此移除了相关处理.