### PR TITLE
Added `noChange` parameter to `toggleRowExpansion` due to infinite recursion problems

### DIFF
--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -2003,7 +2003,7 @@ You can customize row index in `type=index` columns.
 |------|--------|-------|
 | clearSelection | used in multiple selection Table, clear user selection | — |
 | toggleRowSelection | used in multiple selection Table, toggle if a certain row is selected. With the second parameter, you can directly set if this row is selected | row, selected |
-| toggleRowExpansion | used in expandable Table, toggle if a certain row is expanded. With the second parameter, you can directly set if this row is expanded or collapsed | row, expanded |
+| toggleRowExpansion | used in expandable Table, toggle if a certain row is expanded. With the second parameter, you can directly set if this row is expanded or collapsed. if `supressChangeEvent` is `true`, the `expand-change` event won't be triggered | row, expanded, supressChangeEvent |
 | setCurrentRow | used in single selection Table, set a certain row selected. If called without any parameter, it will clear selection. | row |
 | clearSort | clear sorting, restore data to the original order | — |
 | clearFilter | clear filter | — |

--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -2003,7 +2003,7 @@ You can customize row index in `type=index` columns.
 |------|--------|-------|
 | clearSelection | used in multiple selection Table, clear user selection | — |
 | toggleRowSelection | used in multiple selection Table, toggle if a certain row is selected. With the second parameter, you can directly set if this row is selected | row, selected |
-| toggleRowExpansion | used in expandable Table, toggle if a certain row is expanded. With the second parameter, you can directly set if this row is expanded or collapsed. if `supressChangeEvent` is `true`, the `expand-change` event won't be triggered | row, expanded, supressChangeEvent |
+| toggleRowExpansion | used in expandable Table, toggle if a certain row is expanded. With the second parameter, you can directly set if this row is expanded or collapsed. if `noChange` is `true`, the `expand-change` event won't be triggered | row, expanded, noChange |
 | setCurrentRow | used in single selection Table, set a certain row selected. If called without any parameter, it will clear selection. | row |
 | clearSort | clear sorting, restore data to the original order | — |
 | clearFilter | clear filter | — |

--- a/packages/table/src/table-store.js
+++ b/packages/table/src/table-store.js
@@ -415,10 +415,10 @@ TableStore.prototype.toggleRowSelection = function(row, selected) {
   }
 };
 
-TableStore.prototype.toggleRowExpansion = function(row, expanded, supressChangeEvent = false) {
+TableStore.prototype.toggleRowExpansion = function(row, expanded, noChange = false) {
   const changed = toggleRowExpansion(this.states, row, expanded);
   if (changed) {
-    if (!supressChangeEvent) {
+    if (!noChange) {
       this.table.$emit('expand-change', row, this.states.expandRows);
     }
     this.scheduleLayout();

--- a/packages/table/src/table-store.js
+++ b/packages/table/src/table-store.js
@@ -415,10 +415,12 @@ TableStore.prototype.toggleRowSelection = function(row, selected) {
   }
 };
 
-TableStore.prototype.toggleRowExpansion = function(row, expanded) {
+TableStore.prototype.toggleRowExpansion = function(row, expanded, supressChangeEvent = false) {
   const changed = toggleRowExpansion(this.states, row, expanded);
   if (changed) {
-    this.table.$emit('expand-change', row, this.states.expandRows);
+    if (!supressChangeEvent) {
+      this.table.$emit('expand-change', row, this.states.expandRows);
+    }
     this.scheduleLayout();
   }
 };


### PR DESCRIPTION
In order to solve the issue without the proposed parameter, one needs to add a global flag and check manually on the handler for `expand-change`. I feel this should be added to the API as it's simple to achieve.