### PR TITLE
Upload: fix Error when `beforeUpload` hook return promise of file object

### DIFF
--- a/packages/upload/src/upload.vue
+++ b/packages/upload/src/upload.vue
@@ -94,8 +94,16 @@ export default {
           const fileType = Object.prototype.toString.call(processedFile);
 
           if (fileType === '[object File]' || fileType === '[object Blob]') {
-            processedFile.name = rawFile.name;
-            processedFile.uid = rawFile.uid;
+            if (fileType === '[object Blob]') {
+              processedFile = new File([processedFile], rawFile.name, {
+                type: rawFile.type
+              });
+            }
+            for (const p in rawFile) {
+              if (rawFile.hasOwnProperty(p)) {
+                processedFile[p] = rawFile[p];
+              }
+            }
             this.post(processedFile);
           } else {
             this.post(rawFile);

--- a/types/upload.d.ts
+++ b/types/upload.d.ts
@@ -9,13 +9,17 @@ export interface FileListItem {
   status?: FileUploadStatus
 }
 
+export interface ElUploadInternalRawFile extends File {
+  uid: number
+}
+
 export interface ElUploadInternalFileDetail {
   status: FileUploadStatus,
   name: string,
   size: number,
   percentage: number,
   uid: number,
-  raw: File,
+  raw: ElUploadInternalRawFile,
   url?: string
 }
 
@@ -83,7 +87,7 @@ export declare class ElUpload extends ElementUIComponent {
   onChange: (file: ElUploadInternalFileDetail, fileList: ElUploadInternalFileDetail[]) => void
 
   /** Hook function before uploading with the file to be uploaded as its parameter. If false or a Promise is returned, uploading will be aborted */
-  beforeUpload: (file: ElUploadInternalFileDetail) => boolean | Promise<File | boolean>
+  beforeUpload: (file: ElUploadInternalRawFile) => boolean | Promise<File | Blob | boolean>
 
   /** Whether thumbnail is displayed */
   thumbnailMode: boolean


### PR DESCRIPTION
related commit: https://github.com/ElemeFE/element/commit/117f731f6eda217ce5901379f8bd467a6a2acb7d

related review comment: [assign name and uid to processedFile in beforeUpload hook](https://github.com/ElemeFE/element/pull/11210/files/8ba2a4cf63ae050a0b77cf39691b7c17331da63e)