### PR TITLE
Select: improve collapse-tags for more tags

### DIFF
--- a/examples/docs/zh-CN/select.md
+++ b/examples/docs/zh-CN/select.md
@@ -345,6 +345,20 @@
       :value="item.value">
     </el-option>
   </el-select>
+
+  <el-select
+    v-model="value11"
+    multiple
+    collapse-tags="2"
+    style="margin-left: 20px;"
+    placeholder="请选择">
+    <el-option
+      v-for="item in options"
+      :key="item.value"
+      :label="item.label"
+      :value="item.value">
+    </el-option>
+  </el-select>
 </template>
 
 <script>

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -9,26 +9,28 @@
       v-if="multiple"
       ref="tags"
       :style="{ 'max-width': inputWidth - 32 + 'px' }">
-      <span v-if="collapseTags && selected.length">
+      <span v-if="isCollapseTags && selected.length">
         <el-tag
+          v-for="item in selected.slice(0, collapseTagsCount)"
+          :key="getValueKey(item)"
           :closable="!selectDisabled"
           :size="collapseTagSize"
-          :hit="selected[0].hitState"
+          :hit="item.hitState"
           type="info"
-          @close="deleteTag($event, selected[0])"
+          @close="deleteTag($event, item)"
           disable-transitions>
-          <span class="el-select__tags-text">{{ selected[0].currentLabel }}</span>
+          <span class="el-select__tags-text">{{ item.currentLabel }}</span>
         </el-tag>
         <el-tag
-          v-if="selected.length > 1"
+          v-if="selected.length > collapseTagsCount"
           :closable="false"
           :size="collapseTagSize"
           type="info"
           disable-transitions>
-          <span class="el-select__tags-text">+ {{ selected.length - 1 }}</span>
+          <span class="el-select__tags-text">+ {{ selected.length - collapseTagsCount }}</span>
         </el-tag>
       </span>
-      <transition-group @after-leave="resetInputHeight" v-if="!collapseTags">
+      <transition-group @after-leave="resetInputHeight" v-if="!isCollapseTags ">
         <el-tag
           v-for="item in selected"
           :key="getValueKey(item)"
@@ -240,6 +242,13 @@
         return ['small', 'mini'].indexOf(this.selectSize) > -1
           ? 'mini'
           : 'small';
+      },
+
+      collapseTagsCount() {
+        return Number(this.collapseTags) || 1;
+      },
+      isCollapseTags() {
+        return this.collapseTags !== false;
       }
     },
 
@@ -294,7 +303,17 @@
         type: String,
         default: 'value'
       },
-      collapseTags: Boolean,
+      collapseTags: {
+        type: [Boolean, Number, String],
+        validator(value) {
+          // check for postive number, integer, and strings
+          return parseInt(Number(value), 10) === Number(value)
+            ? value === false || value === ''
+              ? true
+              : Number(value) > 0
+            : false;
+        }
+      },
       popperAppendToBody: {
         type: Boolean,
         default: true


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

在相容原本 API 的前提下，加強了隱藏過多標籤的功能。
從原本只能顯示一個，改成可以顯示任意多個。

Improve collapse-tag options for numbers, 
So it can support more tag right now.

Example
![image](https://user-images.githubusercontent.com/22124891/40491555-f6d14288-5fa0-11e8-8ba3-f15e363eb257.png)
