### PR TITLE
Popover: Fix set reference in loop

### DIFF
--- a/packages/popover/src/directive.js
+++ b/packages/popover/src/directive.js
@@ -1,8 +1,11 @@
 const getReference = (el, binding, vnode) => {
   const _ref = binding.expression ? binding.value : binding.arg;
   const popper = vnode.context.$refs[_ref];
-  if (popper) {
+  const isArray = Array.isArray(popper);
+  if (popper && !isArray) {
     popper.$refs.reference = el;
+  } else if (isArray) {
+    popper[0].$refs.reference = el;
   }
 };
 

--- a/packages/popover/src/directive.js
+++ b/packages/popover/src/directive.js
@@ -1,11 +1,12 @@
 const getReference = (el, binding, vnode) => {
   const _ref = binding.expression ? binding.value : binding.arg;
   const popper = vnode.context.$refs[_ref];
-  const isArray = Array.isArray(popper);
-  if (popper && !isArray) {
-    popper.$refs.reference = el;
-  } else if (isArray) {
-    popper[0].$refs.reference = el;
+  if (popper) {
+    if (Array.isArray(popper)) {
+      popper[0].$refs.reference = el;
+    } else {
+      popper.$refs.reference = el;
+    }
   }
 };
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

## situation like following...  
https://jsfiddle.net/akifo/eywraw8t/64650/

## If double loops be careful that ref will be unique

Clarify that the vComponent referenced by a " `var popper = vnode.context.$refs[_ref];` " should be one

```
<div v-for="i in loop">
  <div v-for="j in loop2">
    <el-popover
      :ref="i + '_' +j"
      placement="right"
      title="Title1"
      width="200"
      trigger="focus"
      content="this is content, this is content, this is content">
    </el-popover>
    <el-button v-popover="i + '_' +j">Focus to activate</el-button>
  </div>
</div>
```