### PR TITLE
Input: Do not call calcTextareaHeight if unnecessary for performance

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -245,7 +245,7 @@
         if (type !== 'textarea') return;
         if (!autosize) {
           this.textareaCalcStyle = {
-            minHeight: calcTextareaHeight(this.$refs.textarea).minHeight
+            minHeight: this.textareaCalcStyle.minHeight || calcTextareaHeight(this.$refs.textarea).minHeight
           };
           return;
         }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Calling `scrollHeight` forces layout / reflow and sometimes causes serious performance issue (especially at Edge, in my environment).

![image](https://user-images.githubusercontent.com/8841470/41032510-9007e96c-69be-11e8-8f92-0a62d4db3a25.png)

`Input` component having type `textarea` calls `calcTextareaHeight ` by every input event. 
https://github.com/ElemeFE/element/blob/4b3edc13abbac373d58503f9bc5223a7853d6df0/packages/input/src/input.vue#L206-L220
https://github.com/ElemeFE/element/blob/4b3edc13abbac373d58503f9bc5223a7853d6df0/packages/input/src/input.vue#L224-L228

And `calcTextareaHeight` calls  `scrollHeight` everytime at this point.
https://github.com/ElemeFE/element/blob/4b3edc13abbac373d58503f9bc5223a7853d6df0/packages/input/src/calcTextareaHeight.js#L73

I think it's unecessary to recalculate `textarea` minHeight for every input event, if autosize option is false. Because minHeight will not change in most usecases.

This change improves Input component(having type `textarea` and not having `autosize` option)  performance.

FYI: https://gist.github.com/paulirish/5d52fb081b3570c81e3a