### PR TITLE
FormItem: Pass full form model to form item validation

### DIFF
--- a/packages/form/src/form-item.vue
+++ b/packages/form/src/form-item.vue
@@ -190,7 +190,7 @@
         descriptor[this.prop] = rules;
 
         const validator = new AsyncValidator(descriptor);
-        const model = {};
+        const model = objectAssign({}, this.form.model);
 
         model[this.prop] = this.fieldValue;
 


### PR DESCRIPTION
In some cases a form field needs complex validation logic that depends on other fields in the form (for example, a form has a country select and a phone number / bank card input that is validated by selected country). So the custom `validator` function needs access to the full form model.
The `descriptor` object contains only rules for the current field anyway, so extra fields on the validated model won't affect the validation.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
