### PR TITLE
eslint ignore font file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,5 @@ lib
 coverage
 *.md
 *.scss
+*.woff
+*.ttf


### PR DESCRIPTION
在windows下执行npm run test 以后eslint检查字体文件的时候会报错
