### PR TITLE
Icon/Button: ability to use custom icon sets(such as iconfont)

### DIFF
--- a/examples/docs/zh-CN/button.md
+++ b/examples/docs/zh-CN/button.md
@@ -60,12 +60,13 @@
 </el-row>
 
 <el-row>
-  <el-button icon="el-icon-search" circle></el-button>
-  <el-button type="primary" icon="el-icon-edit" circle></el-button>
-  <el-button type="success" icon="el-icon-check" circle></el-button>
-  <el-button type="info" icon="el-icon-message" circle></el-button>
-  <el-button type="warning" icon="el-icon-star-off" circle></el-button>
-  <el-button type="danger" icon="el-icon-delete" circle></el-button>
+  <el-button icon="search" circle></el-button>
+  <el-button type="primary" icon="edit" circle></el-button>
+  <el-button type="success" icon="check" circle></el-button>
+  <el-button type="info" icon="message" circle></el-button>
+  <el-button type="warning" icon="star-off" circle></el-button>
+  <el-button type="danger" icon="delete" circle></el-button>
+  <el-button type="danger" icon-class="el-icon-delete" circle></el-button>
 </el-row>
 ```
 :::
@@ -112,14 +113,14 @@
 
 带图标的按钮可增强辨识度（有文字）或节省空间（无文字）。
 
-:::demo 设置`icon`属性即可，icon 的列表可以参考 Element 的 icon 组件，也可以设置在文字右边的 icon ，只要使用`i`标签即可，可以使用自定义图标。
+:::demo 设置`icon` 或者 `iconClass` 属性。区别是 `iconClass` 提供完整的图标类名，`icon` 会自动补上前缀。默认前缀为 `el-icon-`，如`icon="share"` 会生成 `class="el-icon-share"`。可以配置 `Vue.prototype.$ELEMENT.iconPrefix` 修改前缀，方便使用自己的图标集合（假如配置 `Vue.prototype.$ELEMENT.iconPrefix="iconfont icon-"`，属性 `icon="delete"` 会生成 `class="iconfont icon-delete"`）。内置的图标列表可以参考 Element 的 Icon 组件。
 
 ```html
-<el-button type="primary" icon="el-icon-edit"></el-button>
-<el-button type="primary" icon="el-icon-share"></el-button>
-<el-button type="primary" icon="el-icon-delete"></el-button>
-<el-button type="primary" icon="el-icon-search">搜索</el-button>
-<el-button type="primary">上传<i class="el-icon-upload el-icon--right"></i></el-button>
+<el-button type="primary" icon="edit"></el-button>
+<el-button type="primary" icon="share"></el-button>
+<el-button type="primary" icon="delete"></el-button>
+<el-button type="primary" icon="search">搜索</el-button>
+<el-button type="primary">上传<i class="el-icon-upload el-icon-right"></i></el-button>
 ```
 :::
 
@@ -131,13 +132,13 @@
 
 ```html
 <el-button-group>
-  <el-button type="primary" icon="el-icon-arrow-left">上一页</el-button>
-  <el-button type="primary">下一页<i class="el-icon-arrow-right el-icon--right"></i></el-button>
+  <el-button type="primary" icon="arrow-left">上一页</el-button>
+  <el-button type="primary">下一页<i class="el-icon-arrow-right el-icon-right"></i></el-button>
 </el-button-group>
 <el-button-group>
-  <el-button type="primary" icon="el-icon-edit"></el-button>
-  <el-button type="primary" icon="el-icon-share"></el-button>
-  <el-button type="primary" icon="el-icon-delete"></el-button>
+  <el-button type="primary" icon="edit"></el-button>
+  <el-button type="primary" icon="share"></el-button>
+  <el-button type="primary" icon="delete"></el-button>
 </el-button-group>
 ```
 :::

--- a/examples/docs/zh-CN/icon.md
+++ b/examples/docs/zh-CN/icon.md
@@ -85,8 +85,9 @@
 <i class="el-icon-edit"></i>
 <i class="el-icon-share"></i>
 <i class="el-icon-delete"></i>
+<el-icon name="share"></el-icon>
+<el-icon name="delete"></el-icon>
 <el-button type="primary" icon="el-icon-search">搜索</el-button>
-
 ```
 :::
 

--- a/packages/button/src/button.vue
+++ b/packages/button/src/button.vue
@@ -18,11 +18,13 @@
     ]"
   >
     <i class="el-icon-loading" v-if="loading"></i>
-    <i :class="icon" v-if="icon && !loading"></i>
+    <i :class="userIconClass" v-if="userIconClass && !loading"></i>
     <span v-if="$slots.default"><slot></slot></span>
   </button>
 </template>
 <script>
+  import { getIconClass } from 'element-ui/src/utils/icon';
+
   export default {
     name: 'ElButton',
 
@@ -42,6 +44,10 @@
       },
       size: String,
       icon: {
+        type: String,
+        default: ''
+      },
+      iconClass: {
         type: String,
         default: ''
       },
@@ -66,6 +72,10 @@
       },
       buttonDisabled() {
         return this.disabled || (this.elForm || {}).disabled;
+      },
+
+      userIconClass() {
+        return this.iconClass || (this.icon ? getIconClass(this.icon) : '');
       }
     },
 

--- a/packages/carousel/src/main.vue
+++ b/packages/carousel/src/main.vue
@@ -39,6 +39,7 @@
       :class="{ 'el-carousel__indicators--labels': hasLabel, 'el-carousel__indicators--outside': indicatorPosition === 'outside' || type === 'card' }">
       <li
         v-for="(item, index) in items"
+        :key="index"
         class="el-carousel__indicator"
         :class="{ 'is-active': index === activeIndex }"
         @mouseenter="throttledIndicatorHover(index)"

--- a/packages/icon/src/icon.vue
+++ b/packages/icon/src/icon.vue
@@ -1,13 +1,21 @@
 <template>
-  <i :class="'el-icon-' + name"></i>
+  <i :class="iconClass"></i>
 </template>
 
 <script>
+  import { getIconClass } from 'element-ui/src/utils/icon';
+
   export default {
     name: 'ElIcon',
 
     props: {
       name: String
+    },
+
+    computed: {
+      iconClass() {
+        return getIconClass(this.name);
+      }
     }
   };
 </script>

--- a/packages/slider/src/main.vue
+++ b/packages/slider/src/main.vue
@@ -45,7 +45,8 @@
       </slider-button>
       <div
         class="el-slider__stop"
-        v-for="item in stops"
+        v-for="(item, index) in stops"
+        :key="index"
         :style="vertical ? { 'bottom': item + '%' } : { 'left': item + '%' }"
         v-if="showStops">
       </div>

--- a/src/index.js
+++ b/src/index.js
@@ -153,7 +153,8 @@ const install = function(Vue, opts = {}) {
 
   Vue.prototype.$ELEMENT = {
     size: opts.size || '',
-    zIndex: opts.zIndex || 2000
+    zIndex: opts.zIndex || 2000,
+    iconPrefix: opts.iconPrefix || 'el-icon-'
   };
 
   Vue.prototype.$loading = Loading.service;

--- a/src/utils/icon.js
+++ b/src/utils/icon.js
@@ -1,6 +1,11 @@
 import Vue from 'vue';
 
 export const getIconClass = name => {
-  const prefix = (Vue.prototype.$ELEMENT || {}).iconPrefix || 'el-icon-';
+  const defaultPrefix = 'el-icon-';
+  if (name.indexOf(defaultPrefix) === 0) {
+    // 向后兼容
+    return name;
+  }
+  const prefix = (Vue.prototype.$ELEMENT || {}).iconPrefix || defaultPrefix;
   return `${prefix}${name}`;
 };

--- a/src/utils/icon.js
+++ b/src/utils/icon.js
@@ -1,0 +1,6 @@
+import Vue from 'vue';
+
+export const getIconClass = name => {
+  const prefix = (Vue.prototype.$ELEMENT || {}).iconPrefix || 'el-icon-';
+  return `${prefix}${name}`;
+};

--- a/test/unit/specs/button.spec.js
+++ b/test/unit/specs/button.spec.js
@@ -21,6 +21,20 @@ describe('Button', () => {
     let buttonElm = vm.$el;
     expect(buttonElm.querySelector('.el-icon-search')).to.be.ok;
   });
+  it('icon', () => {
+    vm = createTest(Button, {
+      icon: 'search'
+    }, true);
+    let buttonElm = vm.$el;
+    expect(buttonElm.querySelector('.el-icon-search')).to.be.ok;
+  });
+  it('iconClass', () => {
+    vm = createTest(Button, {
+      iconClass: 'some-random-class'
+    }, true);
+    let buttonElm = vm.$el;
+    expect(buttonElm.querySelector('.some-random-class')).to.be.ok;
+  });
   it('nativeType', () => {
     vm = createTest(Button, {
       nativeType: 'submit'


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Users can apply third party icon sets such as `iconfont` by rewrite `Vue.prototype.$ELEMENT.iconPrefix`, let's say to `iconfont icon-`,

### For Button component

```jsx
<el-button icon="delete"></el-button>
```
will produce

```html
<button>
  ...
  <i class="iconfont icon-delete"></i>
</button>
```

and users can still use `iconClass` prop to define full class name

```jsx
<el-button icon-class="iconfont icon-delete"></el-button>
```

will produce the same as above.

### For Icon component

```jsx
<el-icon name="share"></el-icon>
```

will produce

```html
<i class="iconfont icon-share"></i>
```

### Compatibility

Default `iconPrefix` is `el-icon-` , so is completely compatible backwards. 


