### PR TITLE
message-box: close/cancel

### DIFF
--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -22,8 +22,8 @@
             class="el-message-box__headerbtn"
             aria-label="Close"
             v-if="showClose"
-            @click="handleAction('cancel')"
-            @keydown.enter="handleAction('cancel')">
+            @click="handleAction('close')"
+            @keydown.enter="handleAction('close')">
             <i class="el-message-box__close el-icon-close"></i>
           </button>
         </div>
@@ -173,7 +173,7 @@
 
       handleWrapperClick() {
         if (this.closeOnClickModal) {
-          this.handleAction('cancel');
+          this.handleAction('close');
         }
       },
 

--- a/test/unit/specs/message-box.spec.js
+++ b/test/unit/specs/message-box.spec.js
@@ -193,7 +193,7 @@ describe('MessageBox', () => {
     setTimeout(() => {
       document.querySelector('.el-message-box__close').click();
       setTimeout(() => {
-        expect(msgAction).to.equal('cancel');
+        expect(msgAction).to.equal('close');
         done();
       }, 10);
     }, 10);


### PR DESCRIPTION
We needed 3 states for our confirm. In Tipe if you make an edit and leave the page we ask if they want to Cancel (discard changes) or Success (save and continue). We needed a Close state for when they click on [x] or click out of the modal to close the modal without doing anything
* Success
* Cancel
* Close

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
