### PR TITLE
Table: update getRowClass

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -267,10 +267,10 @@ export default {
     },
 
     getRowClass(row, rowIndex) {
-      const currentRow = this.store.states.currentRow;
-      const classes = this.table.highlightCurrentRow && currentRow === row
-        ? ['el-table__row', 'current-row']
-        : ['el-table__row'];
+      const classes = ['el-table__row'];
+      if (this.table.highlightCurrentRow && row === this.store.states.currentRow) {
+        classes.push('current-row');
+      }
 
       if (this.stripe && rowIndex % 2 === 1) {
         classes.push('el-table__row--striped');

--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -392,7 +392,7 @@ export default {
     },
 
     handleClick(event, row) {
-      this.table.highlightCurrentRow && this.store.commit('setCurrentRow', row);
+      this.store.commit('setCurrentRow', row);
       this.handleEvent(event, row, 'click');
     },
 

--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -392,7 +392,7 @@ export default {
     },
 
     handleClick(event, row) {
-      this.store.commit('setCurrentRow', row);
+      this.table.highlightCurrentRow && this.store.commit('setCurrentRow', row);
       this.handleEvent(event, row, 'click');
     },
 

--- a/packages/table/src/table-store.js
+++ b/packages/table/src/table-store.js
@@ -320,9 +320,7 @@ TableStore.prototype.mutations = {
 
   setCurrentRow(states, row) {
     const oldCurrentRow = states.currentRow;
-    if (this.table.highlightCurrentRow) {
-      states.currentRow = row;
-    }
+    states.currentRow = row;
 
     if (oldCurrentRow !== row) {
       this.table.$emit('current-change', row, oldCurrentRow);

--- a/packages/table/src/table-store.js
+++ b/packages/table/src/table-store.js
@@ -320,7 +320,9 @@ TableStore.prototype.mutations = {
 
   setCurrentRow(states, row) {
     const oldCurrentRow = states.currentRow;
-    states.currentRow = row;
+    if (this.table.highlightCurrentRow) {
+      states.currentRow = row;
+    }
 
     if (oldCurrentRow !== row) {
       this.table.$emit('current-change', row, oldCurrentRow);


### PR DESCRIPTION
避免在 `highlight-current-row` 为 false 时，点击某一行触发重新渲染。参考：#11836。