### PR TITLE
fix el-select unexpected blur event bug

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -1,7 +1,7 @@
 <template>
   <li
     @mouseenter="hoverItem"
-    @click.stop="selectOptionClick"
+    @mousedown="selectOptionClick"
     class="el-select-dropdown__item"
     v-show="visible"
     :class="{

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -581,13 +581,11 @@
       },
 
       handleBlur(event) {
-        setTimeout(() => {
-          if (this.isSilentBlur) {
+        if (this.isSilentBlur) {
             this.isSilentBlur = false;
-          } else {
-            this.$emit('blur', event);
-          }
-        }, 50);
+        } else {
+          this.$emit('blur', event);
+        }
         this.softFocus = false;
       },
 
@@ -708,7 +706,7 @@
         this.softFocus = true;
         const input = this.$refs.input || this.$refs.reference;
         if (input) {
-          input.focus();
+          this.$nextTick(() => input.focus());
         }
       },
 


### PR DESCRIPTION
when change option of el-select, it will trigger blur event. i use mousedown event to replace click event, and use $nextTick method to focus el-input. setTimeout is not so good to resolve this issue.