### PR TITLE
Autocomplete: add mousedown event on suggestions

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -42,7 +42,8 @@
         v-for="(item, index) in suggestions"
         :key="index"
         :class="{'highlighted': highlightedIndex === index}"
-        @click="select(item)"
+        @mousedown="handleMousedown(item)"
+        @mouseup="clearSuggestions"
         :id="`${id}-item-${index}`"
         role="option"
         :aria-selected="highlightedIndex === index"
@@ -203,13 +204,21 @@
           });
         }
       },
-      select(item) {
+      handleMousedown(item) {
+        // mousedown triggered before blur so the validation onblur will recevie the selected value
         this.$emit('input', item[this.valueKey]);
         this.$emit('select', item);
+      },
+      clearSuggestions() {
         this.$nextTick(_ => {
           this.suggestions = [];
           this.highlightedIndex = -1;
         });
+      },
+      select(item) {
+        this.$emit('input', item[this.valueKey]);
+        this.$emit('select', item);
+        this.clearSuggestions();
       },
       highlight(index) {
         if (!this.suggestionVisible || this.loading) { return; }

--- a/test/unit/specs/autocomplete.spec.js
+++ b/test/unit/specs/autocomplete.spec.js
@@ -1,4 +1,4 @@
-import { createVue, triggerClick, destroyVM, triggerKeyDown } from '../util';
+import { createVue, triggerClick, triggerEvent, destroyVM, triggerKeyDown } from '../util';
 
 describe('Autocomplete', () => {
   let vm;
@@ -117,7 +117,8 @@ describe('Autocomplete', () => {
     setTimeout(_ => {
       const suggestions = autocomplete.$refs.suggestions.$el;
       const suggestionList = suggestions.querySelectorAll('.el-autocomplete-suggestion__list li');
-      suggestionList[1].click();
+      triggerEvent(suggestionList[1], 'mousedown');
+      triggerEvent(suggestionList[1], 'mouseup');
       setTimeout(_ => {
         expect(inputElm.value).to.be.equal('Hot honey 首尔炸鸡（仙霞路）');
         expect(vm.state).to.be.equal('Hot honey 首尔炸鸡（仙霞路）');
@@ -316,7 +317,8 @@ describe('Autocomplete', () => {
       const suggestions = autocomplete.$refs.suggestions.$el;
       const suggestionList = suggestions.querySelectorAll('.el-autocomplete-suggestion__list li');
       expect(suggestionList[1].innerHTML === '上海市长宁区淞虹路661号');
-      suggestionList[1].click();
+      triggerEvent(suggestionList[1], 'mousedown');
+      triggerEvent(suggestionList[1], 'mouseup');
       setTimeout(_ => {
         expect(inputElm.value).to.be.equal('上海市长宁区淞虹路661号');
         expect(vm.state).to.be.equal('上海市长宁区淞虹路661号');


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

**Fix https://github.com/ElemeFE/element/issues/6488**

#### Support autocomplete validation
- When the user selects one item on the suggestion list, the validation function will receive the the selected the value.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
