### PR TITLE
Radio: fix hardcoded component name

### DIFF
--- a/packages/radio/index.js
+++ b/packages/radio/index.js
@@ -2,7 +2,7 @@ import Radio from './src/radio';
 
 /* istanbul ignore next */
 Radio.install = function(Vue) {
-  Vue.component('el-radio', Radio);
+  Vue.component(Radio.name, Radio);
 };
 
 export default Radio;


### PR DESCRIPTION
When using 'On demand' mode and load `Radio`. `<ElRadio>` can not used in the template, must use `<el-radio>`.
I fix it.
