### PR TITLE
TimePicker: time panel hide seconds when format is 'HH:mm'

### DIFF
--- a/packages/date-picker/src/panel/time.vue
+++ b/packages/date-picker/src/panel/time.vue
@@ -44,7 +44,8 @@
 
     props: {
       visible: Boolean,
-      timeArrowControl: Boolean
+      timeArrowControl: Boolean,
+      format: { type: String, default: 'HH:mm:ss' }
     },
 
     watch: {
@@ -86,7 +87,6 @@
     data() {
       return {
         popperClass: '',
-        format: 'HH:mm:ss',
         value: '',
         defaultValue: null,
         date: new Date(),


### PR DESCRIPTION
在TimePicker中允许通过format参数隐藏秒那一列
