### PR TITLE
Table: support range selection

### DIFF
--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -1177,12 +1177,13 @@ Single row selection is supported.
 
 You can also select multiple rows.
 
-:::demo Activating multiple selection is easy: simply add an `el-table-column` with its `type` set to `selection`. Apart from multiple selection, this example also uses `show-overflow-tooltip`: by default, if the content is too long, it will break into multiple lines. If you want to keep it in one line, use attribute `show-overflow-tooltip`, which accepts a `Boolean` value. When set `true`, the extra content will show in tooltip when hover on the cell.
+:::demo Activating multiple selection is easy: simply add an `el-table-column` with its `type` set to `selection`. Apart from multiple selection, this example also uses `show-overflow-tooltip`: by default, if the content is too long, it will break into multiple lines. If you want to keep it in one line, use attribute `show-overflow-tooltip`, which accepts a `Boolean` value. When set `true`, the extra content will show in tooltip when hover on the cell. By setting `row-key`, you can press *shift* to select a range.
 ```html
 <template>
   <el-table
     ref="multipleTable"
     :data="tableData3"
+    row-key="date"
     style="width: 100%"
     @selection-change="handleSelectionChange">
     <el-table-column
@@ -1965,7 +1966,7 @@ You can customize row index in `type=index` columns.
 | header-row-style | function that returns custom style for a row in table header, or an object assigning custom style for every row in table header | Function({row, rowIndex})/Object | — | — |
 | header-cell-class-name | function that returns custom class names for a cell in table header, or a string assigning class names for every cell in table header | Function({row, column, rowIndex, columnIndex})/String | — | — |
 | header-cell-style | function that returns custom style for a cell in table header, or an object assigning custom style for every cell in table header | Function({row, column, rowIndex, columnIndex})/Object | — | — |
-| row-key | key of row data, used for optimizing rendering. Required if `reserve-selection` is on. When its type is String, multi-level access is supported, e.g. `user.info.id`, but `user.info[0].id` is not supported, in which case `Function` should be used. | Function(row)/String | — | — |
+| row-key | key of row data, used for optimizing rendering. Required to enable range selection or if `reserve-selection` is on. When its type is String, multi-level access is supported, e.g. `user.info.id`, but `user.info[0].id` is not supported, in which case `Function` should be used. | Function(row)/String | — | — |
 | empty-text | Displayed text when data is empty. You can customize this area with `slot="empty"` | String | — | No Data |
 | default-expand-all | whether expand all rows by default, only works when the table has a column type="expand" | Boolean | — | false |
 | expand-row-keys | set expanded rows by this prop, prop's value is the keys of expand rows, you should set row-key before using this prop | Array | — | |

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -662,6 +662,7 @@
         store,
         isHidden: false,
         isPressingShift: false,
+        anchorRow: null,
         renderExpanded: null,
         resizeProxyVisible: false,
         resizeState: {

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -447,6 +447,24 @@
 
       sort(prop, order) {
         this.store.commit('sort', { prop, order });
+      },
+
+      addEventListeners() {
+        window.addEventListener('keydown', this.onKeydown);
+        window.addEventListener('keyup', this.onKeyup);
+      },
+
+      removeEventListeners() {
+        window.removeEventListener('keydown', this.onKeydown);
+        window.removeEventListener('keyup', this.onKeyup);
+      },
+
+      onKeydown({keyCode}) {
+        if (keyCode === 16) this.isPressingShift = true;
+      },
+
+      onKeyup({keyCode}) {
+        if (keyCode === 16) this.isPressingShift = false;
       }
     },
 
@@ -599,12 +617,14 @@
 
     destroyed() {
       if (this.resizeListener) removeResizeListener(this.$el, this.resizeListener);
+      this.removeEventListeners();
     },
 
     mounted() {
       this.bindEvents();
       this.store.updateColumns();
       this.doLayout();
+      this.addEventListeners();
 
       this.resizeState = {
         width: this.$el.offsetWidth,
@@ -641,6 +661,7 @@
         layout,
         store,
         isHidden: false,
+        isPressingShift: false,
         renderExpanded: null,
         resizeProxyVisible: false,
         resizeState: {

--- a/test/unit/specs/table.spec.js
+++ b/test/unit/specs/table.spec.js
@@ -1,4 +1,4 @@
-import { createVue, triggerEvent, destroyVM } from '../util';
+import { createVue, triggerEvent, destroyVM, triggerKeyDown } from '../util';
 
 const DELAY = 10;
 const testDataArr = [];
@@ -859,7 +859,7 @@ describe('Table', () => {
       const createTable = function(type) {
         return createVue({
           template: `
-            <el-table :data="testData" @selection-change="change">
+            <el-table row-key="id" :data="testData" @selection-change="change">
               <el-table-column type="${type}" />
               <el-table-column prop="name" label="name" />
               <el-table-column prop="release" label="release" />
@@ -922,6 +922,24 @@ describe('Table', () => {
             setTimeout(_ => {
               expect(vm2.selected).to.length(1);
               expect(vm2.selected[0].name).to.equal(getTestData()[0].name);
+              destroyVM(vm2);
+              done();
+            }, DELAY);
+          }, DELAY);
+        });
+
+        it('select range', done => {
+          const vm2 = createTable('selection');
+
+          setTimeout(_ => {
+            const checkboxes = vm2.$el.querySelectorAll('.el-checkbox');
+            checkboxes[1].click();
+            triggerKeyDown(window, 16); // shift
+            checkboxes[3].click();
+
+            setTimeout(_ => {
+              expect(vm2.selected).to.length(3);
+              expect(vm2.selected.map(m => m.name)).to.include(getTestData()[1].name);
               destroyVM(vm2);
               done();
             }, DELAY);


### PR DESCRIPTION
With this PR, you can press `shift` to enable range selection. My team is asking for this feature for a while, and I believe others would love this as well.

![2018-07-14 18 19 16](https://user-images.githubusercontent.com/10570165/42723569-dd26bb64-8792-11e8-9906-2f7c3c1679dd.gif)

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
