### PR TITLE
TimeSelect: fix fieldReset when initialValue is empty string

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -713,7 +713,7 @@ export default {
     },
 
     handleFieldReset(initialValue) {
-      this.userInput = initialValue;
+      this.userInput = initialValue === '' ? null : initialValue;
     },
 
     handleFocus() {


### PR DESCRIPTION
Fixes #11979 