### PR TITLE
Input: fix style error -  border-spacing should not depend on default…

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -224,6 +224,7 @@
   display: inline-table;
   width: 100%;
   border-collapse: separate;
+  border-spacing:0;
 
   > .el-input__inner {
     vertical-align: middle;


### PR DESCRIPTION
Fix input style:  border-spacing must be specified  for input (#11990)
issue reproduction link : [https://jsfiddle.net/mmx38qxw/3665/](https://jsfiddle.net/mmx38qxw/3665/)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
