### PR TITLE
Message: fix type definition of ElMessageOptions, support VNode as message type

### DIFF
--- a/types/message.d.ts
+++ b/types/message.d.ts
@@ -1,4 +1,4 @@
-import Vue from 'vue'
+import Vue, {VNode} from 'vue'
 
 export type MessageType = 'success' | 'warning' | 'info' | 'error'
 
@@ -20,7 +20,7 @@ export interface CloseEventHandler {
 /** Options used in Message */
 export interface ElMessageOptions {
   /** Message text */
-  message: string
+  message: string | VNode
 
   /** Message type */
   type?: MessageType


### PR DESCRIPTION
ElMessageOptions 类型定义中，message选项无法设置为VNode, 故增加VNode可选类型选项

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
