### PR TITLE
Date,DateRange: Remove arrow functions from inline expressions

### DIFF
--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -31,7 +31,7 @@
                   @input.native="handleDateInput($event, 'min')"
                   @change.native="handleDateChange($event, 'min')" />
               </span>
-              <span class="el-date-range-picker__time-picker-wrap" v-clickoutside="() => minTimePickerVisible = false">
+              <span class="el-date-range-picker__time-picker-wrap" v-clickoutside="handleMinTimeClose">
                 <el-input
                   size="small"
                   :disabled="rangeState.selecting"
@@ -62,7 +62,7 @@
                   @input.native="handleDateInput($event, 'max')"
                   @change.native="handleDateChange($event, 'max')" />
               </span>
-              <span class="el-date-range-picker__time-picker-wrap" v-clickoutside="() => maxTimePickerVisible = false">
+              <span class="el-date-range-picker__time-picker-wrap" v-clickoutside="handleMaxTimeClose">
                 <el-input
                   size="small"
                   :disabled="rangeState.selecting"
@@ -539,6 +539,10 @@
         }
       },
 
+      handleMinTimeClose() {
+        this.minTimePickerVisible = false;
+      },
+
       handleMaxTimePick(value, visible, first) {
         if (this.maxDate && value) {
           this.maxDate = modifyTime(this.maxDate, value.getHours(), value.getMinutes(), value.getSeconds());
@@ -551,6 +555,10 @@
         if (this.maxDate && this.minDate && this.minDate.getTime() > this.maxDate.getTime()) {
           this.minDate = new Date(this.maxDate);
         }
+      },
+
+      handleMaxTimeClose() {
+        this.maxTimePickerVisible = false;
       },
 
       // leftPrev*, rightNext* need to take care of `unlinkPanels`

--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -27,7 +27,7 @@
                 @input="val => userInputDate = val"
                 @change="handleVisibleDateChange" />
             </span>
-            <span class="el-date-picker__editor-wrap" v-clickoutside="() => timePickerVisible = false">
+            <span class="el-date-picker__editor-wrap" v-clickoutside="handleTimePickClose">
               <el-input
                 ref="input"
                 @focus="timePickerVisible = true"
@@ -315,6 +315,10 @@
         if (!first) {
           this.timePickerVisible = visible;
         }
+      },
+
+      handleTimePickClose() {
+        this.timePickerVisible = false;
       },
 
       handleMonthPick(month) {


### PR DESCRIPTION
I believe I've discovered an issue with the date/date range components when being used on Internet Explorer. These components use an inline expression with arrow functions. I suspect that Babel isn't able to identify that these expressions need to be parsed (or it's simply unable to parse them) and so it can't convert them back to the traditional function syntax for older browsers.

By moving these expressions into normal Vue methods it should allow these components to be handled by Babel correctly and work on Internet Explorer 11.