### PR TITLE
Tree: fix a bug dropNode doesn't change background when the dropNode is the grandfather's father of the dragging node

### DIFF
--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -438,7 +438,7 @@
         dragState.showDropIndicator = dropType === 'before' || dropType === 'after';
         dragState.allowDrop = dragState.showDropIndicator || userAllowDropInner;
         dragState.dropType = dropType;
-        this.$emit('node-drag-over', draggingNode.node, dropNode.node,dropType, event);
+        this.$emit('node-drag-over', draggingNode.node, dropNode.node, dropType, event);
       });
 
       this.$on('tree-node-drag-end', (event) => {

--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -438,7 +438,7 @@
         dragState.showDropIndicator = dropType === 'before' || dropType === 'after';
         dragState.allowDrop = dragState.showDropIndicator || userAllowDropInner;
         dragState.dropType = dropType;
-        this.$emit('node-drag-over', draggingNode.node, dropNode.node, event);
+        this.$emit('node-drag-over', draggingNode.node, dropNode.node,dropType, event);
       });
 
       this.$on('tree-node-drag-end', (event) => {


### PR DESCRIPTION
when I drag a node to its grandfater's father, the background of the grandfather's father is expected to be blue, but the background don't change.  
I add the dropType to the emit event "node-drag-over" and change the background in my project by the "node-drag-over" and "node-drag-leave" event. 

