### PR TITLE
Menu: save menu state when change collapse and expand menu(#10622)

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -153,8 +153,8 @@
       }
     },
     methods: {
-      updateActiveIndex() {
-        const item = this.items[this.defaultActive];
+      updateActiveIndex(val) {
+        const item = this.items[val] || this.items[this.activeIndex] || this.items[this.defaultActive];
         if (item) {
           this.activeIndex = item.index;
           this.initOpenedMenu();


### PR DESCRIPTION
fix bug #10622 
对Menu的参数命名觉得奇怪，`defaultActive`是指默认状态，从命名上来看应该是只在初始化时生效，如果要动态改变menu的active item，应该命名为`active`或`active-index`，这样更好理解一些
