### PR TITLE
fix default-checked-nodes

### DIFF
--- a/packages/tree/src/model/tree-store.js
+++ b/packages/tree/src/model/tree-store.js
@@ -107,14 +107,14 @@ export default class TreeStore {
   _initDefaultCheckedNodes() {
     const defaultCheckedKeys = this.defaultCheckedKeys || [];
     const nodesMap = this.nodesMap;
-    
-    for(let nodeKey in nodesMap) {
-      if(!nodesMap.hasOwnProperty(nodeKey)) {
-        continue
+
+    for (let nodeKey in nodesMap) {
+      if (!nodesMap.hasOwnProperty(nodeKey)) {
+        continue;
       }
-      if(defaultCheckedKeys.indexOf(nodeKey) >= 0) {
+      if (defaultCheckedKeys.indexOf(nodeKey) >= 0) {
         nodesMap[nodeKey].setChecked(true, !this.checkStrictly);
-        continue
+        continue;
       }
       nodesMap[nodeKey].setChecked(false, !this.checkStrictly);
     }

--- a/packages/tree/src/model/tree-store.js
+++ b/packages/tree/src/model/tree-store.js
@@ -107,14 +107,17 @@ export default class TreeStore {
   _initDefaultCheckedNodes() {
     const defaultCheckedKeys = this.defaultCheckedKeys || [];
     const nodesMap = this.nodesMap;
-
-    defaultCheckedKeys.forEach((checkedKey) => {
-      const node = nodesMap[checkedKey];
-
-      if (node) {
-        node.setChecked(true, !this.checkStrictly);
+    
+    for(let nodeKey in nodesMap) {
+      if(!nodesMap.hasOwnProperty(nodeKey)) {
+        continue
       }
-    });
+      if(defaultCheckedKeys.indexOf(nodeKey) >= 0) {
+        nodesMap[nodeKey].setChecked(true, !this.checkStrictly);
+        continue
+      }
+      nodesMap[nodeKey].setChecked(false, !this.checkStrictly);
+    }
   }
 
   _initDefaultCheckedNode(node) {


### PR DESCRIPTION
修复了el-tree 初始化后再次改变default-checked-keys的值无法正常更新的问题,原因在于el-tree检测到default-checked-keys变化后再次set check的时候,并未取消之前node的选中状态