### PR TITLE
date-picker: improve form change validation

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -430,7 +430,7 @@ export default {
       }
     },
     value(val, oldVal) {
-      if (!valueEquals(val, oldVal)) {
+      if (!valueEquals(val, oldVal) && !this.pickerVisible) {
         this.dispatch('ElFormItem', 'el.form.change', val);
       }
     }
@@ -899,6 +899,7 @@ export default {
       // determine user real change only
       if (!valueEquals(val, this.valueOnOpen)) {
         this.$emit('change', val);
+        this.dispatch('ElFormItem', 'el.form.change', val);
         this.valueOnOpen = val;
       }
     },


### PR DESCRIPTION
补充 pr https://github.com/ElemeFE/element/pull/12328

因为 time-picker 内部实现的问题，每次选择时间都会触发表单验证 （更合理的行为应该是 在用户确定时，和程序改变值的时候 触发）； pr https://github.com/ElemeFE/element/pull/12347 重构日期多选后会有类似的问题。

所以，`watch.value`会判断面板是否可见，从而决定是否触发表单验证。

虽然存在边缘情况，但应该能满足绝大多数场景