### PR TITLE
fix 点击可搜索下拉框的箭头失效 bug

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -371,6 +371,7 @@
           this.previousQuery = null;
           this.selectedLabel = '';
           this.inputLength = 20;
+          this.menuVisibleOnFocus = false;
           this.resetHoverIndex();
           this.$nextTick(() => {
             if (this.$refs.input &&


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

当select组件带有`filterable`时，点击右侧小箭头需要点击两次方可显示下拉内容，所以在下拉内容隐藏时重置`this.menuVisibleOnFocus`为`false`可以解决