### PR TITLE
terminal condition

### DIFF
--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -380,7 +380,10 @@ export default {
     currentPage: {
       immediate: true,
       handler(val) {
-        this.internalCurrentPage = val;
+        if (val != this.internalCurrentPage) {
+           this.internalCurrentPage = val;
+           this.lastEmittedPage = -1;
+        }
       }
     },
 


### PR DESCRIPTION
When the server returns a currentPage that is not equal to internalCurrentPage for the component, clicking internalCurrentPage again will not trigger the "current-change" event, causing currentPage to not equal internalCurrentPage,   resetting lastEmittedPage will solve the problem

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
