### PR TITLE
ColorPicker: 一些情况下取色光标定位不准问题修复

### DIFF
--- a/packages/color-picker/src/components/sv-panel.vue
+++ b/packages/color-picker/src/components/sv-panel.vue
@@ -47,9 +47,7 @@
         const value = this.color.get('value');
 
         const el = this.$el;
-        let { width, height } = el.getBoundingClientRect();
-
-        if (!height) height = width * 3 / 4;
+        let { clientWidth: width, clientHeight: height } = el;
 
         this.cursorLeft = saturation * width / 100;
         this.cursorTop = (100 - value) * height / 100;


### PR DESCRIPTION
https://github.com/ElemeFE/element/blob/b70da53f157ee25ec6cd3a763e5b8ce3882a24ee/packages/color-picker/src/components/sv-panel.vue#L48-L53
```
        const el = this.$el;
        // let { width, height } = el.getBoundingClientRect();

        // if (!height) height = width * 3 / 4; 
        let { clientWidth: width, clientHeight: height } = el;
```
1. 选色容器的 宽高比应为 14/9 , 非 4/3
2. 此处获取的width,height是给取点定位用的, 不应该使用getBoundingClientRect(), getBoundingClientRect() 获取的数值受CSS transform 影响, 导致打开取色面版的动画期间取值为0,或取值错误, 使用 `clientWidth` , `clientHeight` 属性更好, 不受CSS transform 影响

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
