### PR TITLE
Menu: fix updateActiveIndex bug

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -154,7 +154,7 @@
     },
     methods: {
       updateActiveIndex(val) {
-        const item = this.items[val] || this.items[this.activeIndex] || this.items[this.defaultActive];
+        const item = this.items[val] || this.items[this.defaultActive];
         if (item) {
           this.activeIndex = item.index;
           this.initOpenedMenu();


### PR DESCRIPTION
In actual development, `menu` are often bind with `route`. 
Such as `:default-active="$route.path"`

But not all declared routes will be displayed in the menu.

We often use `router.push(xxx)`.

**But now we jump to a route that is not declared in the menu, and the menu will remain highlighted before.**
