### PR TITLE
Menu: fix updateActiveIndex bug

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -154,7 +154,7 @@
     },
     methods: {
       updateActiveIndex(val) {
-        const item =(val === 'string' ? this.items[val] : this.items[this.activeIndex]) || this.items[this.defaultActive];
+        const item = (val === 'string' ? this.items[val] : this.items[this.activeIndex]) || this.items[this.defaultActive];
         if (item) {
           this.activeIndex = item.index;
           this.initOpenedMenu();

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -154,7 +154,7 @@
     },
     methods: {
       updateActiveIndex(val) {
-        const item =(val === 'string' ? this.items[val] : this.items[this.activeIndex]) || this.items[this.defaultActive]
+        const item =(val === 'string' ? this.items[val] : this.items[this.activeIndex]) || this.items[this.defaultActive];
         if (item) {
           this.activeIndex = item.index;
           this.initOpenedMenu();

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -154,7 +154,7 @@
     },
     methods: {
       updateActiveIndex(val) {
-        const item = this.items[val] || this.items[this.activeIndex] || this.items[this.defaultActive];
+        const item =(val === 'string' ? this.items[val] : this.items[this.activeIndex]) || this.items[this.defaultActive]
         if (item) {
           this.activeIndex = item.index;
           this.initOpenedMenu();

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -154,7 +154,7 @@
     },
     methods: {
       updateActiveIndex(val) {
-        const item = (val === 'string' ? this.items[val] : this.items[this.activeIndex]) || this.items[this.defaultActive];
+        const item = (typeof val === 'string' ? this.items[val] : this.items[this.activeIndex]) || this.items[this.defaultActive];
         if (item) {
           this.activeIndex = item.index;
           this.initOpenedMenu();


### PR DESCRIPTION
In actual development, `menu` are often bind with `route`. 
Such as: `default-active="$route.path"`.
But not all declared routes will be displayed in the menu.

We often use `router.push(xxx)` to change view.

**But now we jump to a new route that is not declared in the menu, and the menu will remain highlighted before.**

Because of this code `this.items[this.activeIndex]`.

I think this logic is only needed when menu collapse changed to save menu state.

https://github.com/ElemeFE/element/pull/12178

[侧边栏的问题](https://github.com/PanJiaChen/vue-element-admin/issues/997)