### PR TITLE
Menu: submenu is-active  bug

### DIFF
--- a/packages/theme-chalk/src/menu.scss
+++ b/packages/theme-chalk/src/menu.scss
@@ -113,10 +113,10 @@
         line-height: 36px;
         padding: 0 10px;
         color: $--color-text-secondary;
-
-        &.is-active {
-          color: $--color-text-primary;
-        }
+      }
+      & .el-menu-item.is-active,
+      & .el-submenu.is-active > .el-submenu__title {
+        color: $--color-text-primary;
       }
     }
     & .el-menu-item:not(.is-disabled):hover,


### PR DESCRIPTION
选中submenu下的菜单，submenu没有激活样式式象错误

官网样式
![2](https://user-images.githubusercontent.com/12825624/44514797-9e6ce300-a6f3-11e8-89ff-9b40ff74f67e.png)

修改后样式
![1](https://user-images.githubusercontent.com/12825624/44514876-c1979280-a6f3-11e8-9d2c-18f763114330.png)


