### PR TITLE
Select: add Select Attributes `width-type`

### DIFF
--- a/examples/docs/en-US/select.md
+++ b/examples/docs/en-US/select.md
@@ -686,6 +686,7 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 | default-first-option | select first matching option on enter key. Use with `filterable` or `remote` | boolean | - | false |
 | popper-append-to-body| whether to append the popper menu to body. If the positioning of the popper is wrong, you can try to set this prop to false | boolean | - | true |
 | automatic-dropdown | for non-filterable Select, this prop decides if the option menu pops up when the input is focused | boolean | - | false |
+| width-type | Popup width type. Fixed width can be used when the content is longer to avoid the problem of pop-up block positioning | string | width/minWidth | minWidth |
 
 ### Select Events
 | Event Name | Description | Parameters |

--- a/examples/docs/zh-CN/select.md
+++ b/examples/docs/zh-CN/select.md
@@ -681,6 +681,7 @@
 | default-first-option | 在输入框按下回车，选择第一个匹配项。需配合 `filterable` 或 `remote` 使用 | boolean | - | false |
 | popper-append-to-body | 是否将弹出框插入至 body 元素。在弹出框的定位出现问题时，可将该属性设置为 false | boolean | - | true |
 | automatic-dropdown | 对于不可搜索的 Select，是否在输入框获得焦点后自动弹出选项菜单 | boolean | - | false |
+| width-type | 弹出框宽度类型。当内容较长时可使用固定宽度，避免弹出框定位问题。 | string | width/minWidth | minWidth |
 
 ### Select Events
 | 事件名称 | 说明 | 回调参数 |

--- a/packages/select/src/select-dropdown.vue
+++ b/packages/select/src/select-dropdown.vue
@@ -2,7 +2,7 @@
   <div
     class="el-select-dropdown el-popper"
     :class="[{ 'is-multiple': $parent.multiple }, popperClass]"
-    :style="{ minWidth: minWidth }">
+    :style="{ [$parent.widthType]: width }">
     <slot></slot>
   </div>
 </template>
@@ -46,7 +46,7 @@
 
     data() {
       return {
-        minWidth: ''
+        width: ''
       };
     },
 
@@ -58,7 +58,7 @@
 
     watch: {
       '$parent.inputWidth'() {
-        this.minWidth = this.$parent.$el.getBoundingClientRect().width + 'px';
+        this.width = this.$parent.$el.getBoundingClientRect().width + 'px';
       }
     },
 

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -298,6 +298,10 @@
       popperAppendToBody: {
         type: Boolean,
         default: true
+      },
+      widthType: {
+        type: String,
+        default: 'minWidth'
       }
     },
 


### PR DESCRIPTION
增加 `width-type` 弹出框宽度类型。当内容较长时可使用固定宽度，避免弹出框定位问题。

相关issues
- [#9352](https://github.com/ElemeFE/element/issues/9352)
- [#issuecomment-415352470](https://github.com/ElemeFE/element/issues/12418#issuecomment-415352470)