### PR TITLE
Input: fix success icon overlapping with text

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -8,7 +8,7 @@
       'el-input-group--append': $slots.append,
       'el-input-group--prepend': $slots.prepend,
       'el-input--prefix': $slots.prefix || prefixIcon,
-      'el-input--suffix': $slots.suffix || suffixIcon || clearable
+      'el-input--suffix': showSuffix
     }
     ]"
     @mouseenter="hovering = true"
@@ -50,7 +50,7 @@
       <!-- 后置内容 -->
       <span
         class="el-input__suffix"
-        v-if="$slots.suffix || suffixIcon || showClear || validateState && needStatusIcon">
+        v-if="showSuffix">
         <span class="el-input__suffix-inner">
           <template v-if="!showClear">
             <slot name="suffix"></slot>
@@ -199,6 +199,12 @@
           !this.readonly &&
           this.currentValue !== '' &&
           (this.focused || this.hovering);
+      },
+      showSuffix() {
+        return this.$slots.suffix ||
+          this.suffixIcon ||
+          this.showClear ||
+          (this.validateState && this.needStatusIcon);
       }
     },
 


### PR DESCRIPTION
When entering text into an input in success status the status icon overlaps with editing area. See image.
![image](https://user-images.githubusercontent.com/7266431/44577192-1f31ea80-a799-11e8-80fc-1001a5d64b79.png)

