### PR TITLE
Input: fix success icon overlapping with text

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -8,7 +8,7 @@
       'el-input-group--append': $slots.append,
       'el-input-group--prepend': $slots.prepend,
       'el-input--prefix': $slots.prefix || prefixIcon,
-      'el-input--suffix': $slots.suffix || suffixIcon || clearable
+      'el-input--suffix': showSuffix
     }
     ]"
     @mouseenter="hovering = true"
@@ -50,7 +50,7 @@
       <!-- 后置内容 -->
       <span
         class="el-input__suffix"
-        v-if="$slots.suffix || suffixIcon || showClear || validateState && needStatusIcon">
+        v-if="showSuffix">
         <span class="el-input__suffix-inner">
           <template v-if="!showClear">
             <slot name="suffix"></slot>
@@ -199,6 +199,12 @@
           !this.readonly &&
           this.currentValue !== '' &&
           (this.focused || this.hovering);
+      },
+      showSuffix() {
+        return this.$slots.suffix ||
+          this.suffixIcon ||
+          this.showClear ||
+          (this.validateState && this.needStatusIcon);
       }
     },
 


### PR DESCRIPTION
When entering text into an input in success status the status icon overlaps with editing area. See image.
![image](https://user-images.githubusercontent.com/7266431/44579057-d892bf00-a79d-11e8-8dbe-f6ca7d3d0f89.png)
