### PR TITLE
MessageBox: fix hashchange EventListener just Listener once

### DIFF
--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -274,9 +274,13 @@
     },
 
     mounted() {
+      const self = this;
       this.$nextTick(() => {
         if (this.closeOnHashChange) {
-          window.addEventListener('hashchange', this.close);
+          window.addEventListener('hashchange', function close(event) {
+            self.close();
+            event.currentTarget.removeEventListener(event.type, close);
+          });
         }
       });
     },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

The listenchange event in the MessageBox is not deleted in time, causing the page router change to continuously trigger the close function.

There is also a question about message-box using `document.body.appendChild(instance.$el);` when inserting DOM `beforeDestroy` does not trigger, can it be deleted?
