### PR TITLE
Fix filterPanel position bug when table columns is changed

### DIFF
--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -329,6 +329,8 @@ export default {
         filterPanel.cell = cell;
         filterPanel.column = column;
         !this.$isServer && filterPanel.$mount(document.createElement('div'));
+      } else {
+        filterPanel.popperJS._reference = cell;
       }
 
       setTimeout(() => {


### PR DESCRIPTION
The position of filterPanel is wrong when the table header column is changed.So pass the event target to popperJS.

#6159

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
