### PR TITLE
fixbug: active item not change when rerender "el-menu"

### DIFF
--- a/packages/menu/src/menu-item.vue
+++ b/packages/menu/src/menu-item.vue
@@ -104,6 +104,10 @@
       this.parentMenu.addItem(this);
       this.rootMenu.addItem(this);
     },
+    updated() {
+      this.parentMenu.addItem(this);
+      this.rootMenu.addItem(this);
+    },
     beforeDestroy() {
       this.parentMenu.removeItem(this);
       this.rootMenu.removeItem(this);

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -306,6 +306,9 @@
         new Menubar(this.$el); // eslint-disable-line
       }
       this.$watch('items', this.updateActiveIndex);
+    },
+    beforeUpdate() {
+      this.items = {};
     }
   };
 </script>


### PR DESCRIPTION
This bug can reproduction when render and rerender "el-menu" "el-menu-item" in jsx mode, because the component "el-menu-item" is reuse , so the "mounted" hook well not allway dispatch. but "updated" hook not.
chinese: 抱歉，我英文基本差到为0 , 中文解释下 . 这个bug在 使用 jsx 组装和重新渲染 el-menu 的时候。因为 vue 复用了组件实例，所以 “mounted” 勾子不一定每次都会调用，然而 “updated” 每次都会调用。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
