### PR TITLE
select: add label-key property (#12713)

### DIFF
--- a/examples/docs/en-US/select.md
+++ b/examples/docs/en-US/select.md
@@ -665,6 +665,7 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 | multiple | whether multiple-select is activated | boolean | — | false |
 | disabled | whether Select is disabled | boolean | — | false |
 | value-key | unique identity key name for value, required when value is an object | string | — | value |
+| label-key | unique identity key name for label, required when value is an object | string | — | label |
 | size | size of Input | string | large/small/mini | — |
 | clearable | whether single select can be cleared | boolean | — | false |
 | collapse-tags | whether to collapse tags to a text when multiple selecting | boolean | — | false |

--- a/examples/docs/en-US/select.md
+++ b/examples/docs/en-US/select.md
@@ -665,7 +665,7 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 | multiple | whether multiple-select is activated | boolean | — | false |
 | disabled | whether Select is disabled | boolean | — | false |
 | value-key | unique identity key name for value, required when value is an object | string | — | value |
-| label-key | unique identity key name for label, required when value is an object | string | — | label |
+| label-key | unique identity key name for label. Use only when value is an object and the label doesn't display | string | — | label |
 | size | size of Input | string | large/small/mini | — |
 | clearable | whether single select can be cleared | boolean | — | false |
 | collapse-tags | whether to collapse tags to a text when multiple selecting | boolean | — | false |

--- a/examples/docs/es/select.md
+++ b/examples/docs/es/select.md
@@ -672,6 +672,7 @@ Si el valor de encuadernación de Select es un objeto, asegúrese de asignar `va
 | disabled             | si Select esta deshabilitado             | boolean  | —                 | false            |
 | collapse-tags        | si se colapsan los tags a un texto cuando `multiple` es `true`. | boolean  | —                 | false            |
 | value-key            | nombre de clave de identidad única para el valor, necesario cuando el valor es un objeto. | string   | —                 | value            |
+| label-key | unique identity key name for label. Use only when value is an object and the label doesn't display | string | — | label |
 | size                 | tamaño del Input                         | string   | large/small/mini  | —                |
 | clearable            | si el single select puede ser limpiable  | boolean  | —                 | false            |
 | multiple-limit       | maximo numero de opciones que el usuario puede seleccionar cuando `multiple` es `true`.  Sin límite cuando se fija a 0 | number   | —                 | 0                |

--- a/examples/docs/zh-CN/select.md
+++ b/examples/docs/zh-CN/select.md
@@ -660,6 +660,7 @@
 | multiple | 是否多选 | boolean | — | false |
 | disabled | 是否禁用 | boolean | — | false |
 | value-key | 作为 value 唯一标识的键名，绑定值为对象类型时必填 | string | — | value |
+| label-key | unique identity key name for label. Use only when value is an object and the label doesn't display | string | — | label |
 | size | 输入框尺寸 | string | medium/small/mini | — |
 | clearable | 单选时是否可以清空选项 | boolean | — | false |
 | collapse-tags | 多选时是否将选中值按文字的形式展示 | boolean | — | false |

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -303,6 +303,10 @@
         type: String,
         default: 'value'
       },
+      labelKey: {
+        type: String,
+        default: 'label'
+      },
       collapseTags: Boolean,
       popperAppendToBody: {
         type: Boolean,
@@ -533,8 +537,9 @@
           }
         }
         if (option) return option;
-        const label = (!isObject && !isNull)
-          ? value : '';
+        const label = (isObject && !isNull)
+          ? value[this.labelKey] ? value[this.labelKey] : ''
+          : (!isObject && !isNull) ? value : '';
         let newOption = {
           value: value,
           currentLabel: label

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -538,7 +538,7 @@
         }
         if (option) return option;
         const label = (isObject && !isNull)
-          ? value[this.labelKey] ? value[this.labelKey] : ''
+          ? (value[this.labelKey] || '')
           : (!isObject && !isNull) ? value : '';
         let newOption = {
           value: value,


### PR DESCRIPTION
Fix https://github.com/ElemeFE/element/issues/12713

Add in el-select a new property "label-key" which the same as value-key. This allow to set a label for tag element when we pass value as Object to select component.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
