### PR TITLE
fix table blinking in firefox when from hide to show

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -422,12 +422,12 @@
         const { width: oldWidth, height: oldHeight } = this.resizeState;
 
         const width = el.offsetWidth;
-        if (oldWidth !== width) {
+        if (oldWidth !== width && width !== 0) {
           shouldUpdateLayout = true;
         }
 
         const height = el.offsetHeight;
-        if ((this.height || this.shouldUpdateHeight) && oldHeight !== height) {
+        if ((this.height || this.shouldUpdateHeight) && oldHeight !== height && height !== 0) {
           shouldUpdateLayout = true;
         }
 


### PR DESCRIPTION
Element UI version
2.4.7

OS/Browsers version
Firefox for Ubuntu 62.0

Vue version
2.5.17

Reproduction Link
https://jsfiddle.net/7n8er90a/9/

Steps to reproduce
switch tab page

What is Expected?
table show normally

What is actually happening?
the table blinking in firefox,which in chrome is ok.

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
