### PR TITLE
form: replace reject(valid) with resolve(valid)

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -102,7 +102,7 @@
         if (typeof callback !== 'function' && window.Promise) {
           promise = new window.Promise((resolve, reject) => {
             callback = function(valid) {
-              valid ? resolve(valid) : reject(valid);
+              resolve(valid);
             };
           });
         }


### PR DESCRIPTION
For now, if the "valid" is false, it will return a `reject(valid)` in `await` and we must wrap the validate call with a `try catch`:

```js
let result = false
try {
  result = await this.$refs.investForm.validate()
} catch (error) {
  result = false
}
if (result) {
// xxx
}
```

If we use resolve(valid), it will be very suitable to handle the validator result:

```js
const result = await this.$refs.form.validate()
if (result) {
// xxx
}
```

"validator result" is a result value, not an exception.
I think `valid === false` is an expected result, it's better to resolve(valid) instead of reject(valid).