### PR TITLE
Tabs: fix order of TabNav when array is sorted

### DIFF
--- a/packages/tabs/src/tab-pane.vue
+++ b/packages/tabs/src/tab-pane.vue
@@ -49,17 +49,6 @@
       }
     },
 
-    mounted() {
-      this.$parent.addPanes(this);
-    },
-
-    destroyed() {
-      if (this.$el && this.$el.parentNode) {
-        this.$el.parentNode.removeChild(this.$el);
-      }
-      this.$parent.removePanes(this);
-    },
-
     watch: {
       label() {
         this.$parent.$forceUpdate();

--- a/packages/tabs/src/tabs.vue
+++ b/packages/tabs/src/tabs.vue
@@ -53,6 +53,17 @@
     },
 
     methods: {
+      calcPaneInstances() {
+        if (this.$slots.default) {
+          const paneSlots = this.$slots.default.filter(vnode => vnode.tag &&
+            vnode.componentOptions && vnode.componentOptions.Ctor.options.name === 'ElTabPane');
+          // update indeed
+          const panes = paneSlots.map(({ componentInstance }) => componentInstance);
+          if (!(panes.length === this.panes.length && panes.every((pane, index) => pane === this.panes[index]))) {
+            this.panes = panes;
+          }
+        }
+      },
       handleTabClick(tab, tabName, event) {
         if (tab.disabled) return;
         this.setCurrentName(tabName);
@@ -89,17 +100,7 @@
         }
       }
     },
-    updated() {
-      if (this.$slots.default) {
-        const paneSlots = this.$slots.default.filter(vnode => vnode.tag &&
-          vnode.componentOptions && vnode.componentOptions.Ctor.options.name === 'ElTabPane');
-        // update indeed
-        const panes = paneSlots.map(({ componentInstance }) => componentInstance);
-        if (!(panes.length === this.panes.length && panes.every((pane, index) => pane === this.panes[index]))) {
-          this.panes = panes;
-        }
-      }
-    },
+
     render(h) {
       let {
         type,
@@ -162,10 +163,19 @@
         </div>
       );
     },
+  
     created() {
       if (!this.currentName) {
         this.setCurrentName('0');
       }
+    },
+
+    mounted() {
+      this.calcPaneInstances();
+    },
+
+    updated() {
+      this.calcPaneInstances();
     }
   };
 </script>

--- a/packages/tabs/src/tabs.vue
+++ b/packages/tabs/src/tabs.vue
@@ -87,18 +87,16 @@
         } else {
           changeCurrentName();
         }
-      },
-      addPanes(item) {
-        const index = this.$slots.default.filter(item => {
-          return item.elm.nodeType === 1 && /\bel-tab-pane\b/.test(item.elm.className) || item.elm.nodeType === 8;
-        }).indexOf(item.$vnode);
-        this.panes.splice(index, 0, item);
-      },
-      removePanes(item) {
-        const panes = this.panes;
-        const index = panes.indexOf(item);
-        if (index > -1) {
-          panes.splice(index, 1);
+      }
+    },
+    updated() {
+      if (this.$slots.default) {
+        const paneSlots = this.$slots.default.filter(vnode => vnode.tag &&
+          vnode.componentOptions && vnode.componentOptions.Ctor.options.name === 'ElTabPane');
+        // update indeed
+        const panes = paneSlots.map(({ componentInstance }) => componentInstance);
+        if (!(panes.length === this.panes.length && panes.every((pane, index) => pane === this.panes[index]))) {
+          this.panes = panes;
         }
       }
     },

--- a/test/unit/specs/tabs.spec.js
+++ b/test/unit/specs/tabs.spec.js
@@ -223,19 +223,19 @@ describe('Tabs', () => {
       const paneList = vm.$el.querySelector('.el-tabs__content').children;
 
       tabList[1].querySelector('.el-icon-close').click();
-      vm.$nextTick(_ => {
+      setTimeout(_ => {
         expect(tabList.length).to.be.equal(2);
         expect(paneList.length).to.be.equal(2);
         expect(tabList[1].classList.contains('is-active')).to.be.true;
 
         vm.$refs.tabs.$el.querySelector('.el-tabs__new-tab').click();
-        vm.$nextTick(_ => {
+        setTimeout(_ => {
           expect(tabList.length).to.be.equal(3);
           expect(paneList.length).to.be.equal(3);
           expect(tabList[2].classList.contains('is-active')).to.be.true;
           done();
-        });
-      });
+        }, 100);
+      }, 100);
     }, 100);
   });
   it('addable & closable', done => {
@@ -310,19 +310,19 @@ describe('Tabs', () => {
 
       vm.$refs.tabs.$el.querySelector('.el-tabs__new-tab').click();
 
-      vm.$nextTick(_ => {
+      setTimeout(_ => {
         expect(tabList.length).to.be.equal(3);
         expect(paneList.length).to.be.equal(3);
         expect(tabList[2].classList.contains('is-active')).to.be.true;
 
         tabList[2].querySelector('.el-icon-close').click();
-        vm.$nextTick(_ => {
+        setTimeout(_ => {
           expect(tabList.length).to.be.equal(2);
           expect(paneList.length).to.be.equal(2);
           expect(tabList[1].classList.contains('is-active')).to.be.true;
           done();
-        });
-      });
+        }, 100);
+      }, 100);
     }, 100);
   });
   it('closable in tab-pane', (done) => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

- Closes #12549
- 一个类似的 pr #12577 

更改 Tabs 的部分实现，Tabs 中的 panes 属性完全由 default slot  计算出来，这样避免了排序之后，TabNav 没有渲染的问题。
这种解决方案有一个弊端是：TabPane 不能被其他元素包裹。不过一般情况下，也不会出现这种问题。

