### PR TITLE
ElTable: enhanced table sorting when clicking on the arrow

### DIFF
--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -466,7 +466,9 @@ export default {
 
     handleSortClick(event, column, givenOrder) {
       event.stopPropagation();
-      let order = givenOrder || this.toggleOrder(column);
+      let order = column.order === givenOrder
+        ? null
+        : (givenOrder || this.toggleOrder(column));
 
       let target = event.target;
       while (target && target.tagName !== 'TH') {


### PR DESCRIPTION
点击箭头排序时，比如是`ascending`，再次点击向上的箭头，一直保持`ascending`状态。
本次的pr，可以在`ascending`下再次点击按钮，恢复到未排序状态。

---


When clicking the arrow to sort, for example, `ascending`, click the up arrow again to keep the `ascending` state.
This time pr, you can click the button again under `ascending` to return to the unsorted state.
