### PR TITLE
Fix the Scrollbar Component to appear native horizontal scrollbars in Chrome and Firefox

### DIFF
--- a/packages/scrollbar/src/main.js
+++ b/packages/scrollbar/src/main.js
@@ -45,7 +45,7 @@ export default {
 
     if (gutter) {
       const gutterWith = `-${gutter}px`;
-      const gutterStyle = `margin-bottom: ${gutterWith}; margin-right: ${gutterWith};`;
+      const gutterStyle = `margin-bottom: ${gutterWith}; margin-right: ${gutterWith}; padding-bottom: ${gutter}px;`;
 
       if (Array.isArray(this.wrapStyle)) {
         style = toObject(this.wrapStyle);

--- a/packages/theme-chalk/src/scrollbar.scss
+++ b/packages/theme-chalk/src/scrollbar.scss
@@ -18,6 +18,11 @@
     overflow: scroll;
     height: 100%;
 
+    &::-webkit-scrollbar {
+      width: 0;
+      height: 0;
+    }
+
     @include m(hidden-default) {
       &::-webkit-scrollbar {
         width: 0;


### PR DESCRIPTION
解决在Chrome和Firefox会出现原生滚动条的问题
-
原生和模拟的滚动条同时出现有点难看，具体看图：
[Chrome]

![image](https://user-images.githubusercontent.com/19665552/46242810-96454900-c3ff-11e8-8cbc-36a253c2973f.png)

[Firefox]

![image](https://user-images.githubusercontent.com/19665552/46242800-65651400-c3ff-11e8-9bbe-d7bf57d34c05.png)
