### PR TITLE
Dropdown: Added slots to documentation

### DIFF
--- a/examples/docs/en-US/dropdown.md
+++ b/examples/docs/en-US/dropdown.md
@@ -331,6 +331,13 @@ Besides default size, Dropdown component provides three additional sizes for you
 | show-timeout | Delay time before show a dropdown (only works when trigger is `hover`) | number | — | 250 |
 | hide-timeout | Delay time before hide a dropdown (only works when trigger is `hover`) | number | — | 150 |
 
+### Dropdown Slots
+
+| Name | Description |
+|------|--------|
+| — | content of Dropdown. Notice: Must be a valid html dom element (ex. `<span>, <button> etc.`) or `el-component`, to attach the trigger listener  |
+| dropdown | content of the Dropdown Menu, usually a `<el-dropdown-menu>` element |
+
 ### Dropdown Events
 | Event Name | Description | Parameters |
 |---------- |-------- |---------- |

--- a/examples/docs/es/dropdown.md
+++ b/examples/docs/es/dropdown.md
@@ -333,6 +333,13 @@ Además del tamaño predeterminado, el componente Dropdown proporciona tres tama
 | show-timeout  | Tiempo de retardo antes de mostrar un dropdown (solamente trabaja cuando se dispara `hover`) | number  | —                                        | 250         |
 | hide-timeout  | Tiempo de retardo antes de ocultar un dropdown (solamente trabaja cuando se dispara `hover`) | number  | —                                        | 150         |
 
+### Dropdown Slots
+
+| Nombre | Descripción |
+|------|--------|
+| — | content of Dropdown. Notice: Must be a valid html dom element (ex. `<span>, <button> etc.`) or `el-component`, to attach the trigger listener  |
+| dropdown | content of the Dropdown Menu, usually a `<el-dropdown-menu>` element |
+
 ### Dropdown Eventos
 | Nombre         | Descripción                              | Parametros                               |
 | -------------- | ---------------------------------------- | ---------------------------------------- |

--- a/examples/docs/zh-CN/dropdown.md
+++ b/examples/docs/zh-CN/dropdown.md
@@ -341,8 +341,8 @@ Dropdown 组件提供除了默认值以外的三种尺寸，可以在不同场�
 
 | Name | 说明 |
 |------|--------|
-| — | content of Dropdown. Notice: Must be a valid html dom element (ex. `<span>, <button> etc.`) or `el-component`, to attach the trigger listener  |
-| dropdown | content of the Dropdown Menu, usually a `<el-dropdown-menu>` element |
+| — | 触发下拉列表显示的元素。 注意： 必须是一个元素或者或者组件  |
+| dropdown | 下拉列表，通常是 `<el-dropdown-menu>` 组件     |
 
 ### Dropdown Events
 | 事件名称      | 说明    | 回调参数      |

--- a/examples/docs/zh-CN/dropdown.md
+++ b/examples/docs/zh-CN/dropdown.md
@@ -337,6 +337,13 @@ Dropdown 组件提供除了默认值以外的三种尺寸，可以在不同场�
 | show-timeout  | 展开下拉菜单的延时（仅在 trigger 为 hover 时有效）| number          | — | 250 |
 | hide-timeout  | 收起下拉菜单的延时（仅在 trigger 为 hover 时有效）| number          | — | 150 |
 
+### Dropdown Slots
+
+| Name | 说明 |
+|------|--------|
+| — | content of Dropdown. Notice: Must be a valid html dom element (ex. `<span>, <button> etc.`) or `el-component`, to attach the trigger listener  |
+| dropdown | content of the Dropdown Menu, usually a `<el-dropdown-menu>` element |
+
 ### Dropdown Events
 | 事件名称      | 说明    | 回调参数      |
 |---------- |-------- |---------- |


### PR DESCRIPTION
Added slots section in English to documentation for Dropdown component. Chinese and Spanish translation missing (I placed an English version semi-translated).

Please make sure these boxes are checked before submitting your PR, thank you!

* [√] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [√] Make sure you are merging your commits to `dev` branch.
* [√] Add some descriptions and refer relative issues for you PR.
