### PR TITLE
Form: fix string type param bug

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -85,7 +85,10 @@
       },
       clearValidate(props = []) {
         const fields = props.length
-          ? this.fields.filter(field => props.indexOf(field.prop) > -1)
+          ? (typeof props === 'string' 
+              ? this.fields.filter(field => props === field.prop)
+              : this.fields.filter(field => props.indexOf(field.prop) > -1)
+            )
           : this.fields;
         fields.forEach(field => {
           field.clearValidate();


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

here's the explain, when we pass a string type param to `form.clearValidate` method it also will work, but in some situation it perform weird, e.g. if we have two `form-item`, their props contain same keyword, like` 'password'` and `'re-password'`, then if we use `form.clearValidate('re-password')`,both of them's status will be clear, but I only want to clear `re-password`.
I know the doc tell us to pass a array type param, but I think string type param should be supported.