### PR TITLE
Table: Adds header rendering slot

### DIFF
--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -2125,3 +2125,4 @@ You can customize row index in `type=index` columns.
 | Name | Description |
 |------|--------|
 | — | Custom content for table columns. The scope parameter is { row, column, $index } |
+| header | Custom content for table header. The scope parameter is { column, $index } |

--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -185,6 +185,23 @@
           amount2: '4.1',
           amount3: 15
         }],
+        tableData7: [{
+          date: '2016-05-02',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-04',
+          name: 'John',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-01',
+          name: 'Morgan',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-03',
+          name: 'Jessy',
+          address: 'No. 189, Grove St, Los Angeles',
+        }],
         currentRow: null,
         multipleSelection: [],
         search: '',
@@ -1508,7 +1525,7 @@ Customize table header so it can be even more customized.
 ```html
 <template>
   <el-table
-    :data="tableData.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
+    :data="tableData7.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
     style="width: 100%">
     <el-table-column
       label="Date"
@@ -1556,18 +1573,23 @@ Customize table header so it can be even more customized.
           address: 'No. 189, Grove St, Los Angeles'
         }, {
           date: '2016-05-02',
-          name: 'Tom',
+          name: 'John',
           address: 'No. 189, Grove St, Los Angeles'
         }, {
           date: '2016-05-04',
-          name: 'Tom',
+          name: 'Morgan',
           address: 'No. 189, Grove St, Los Angeles'
         }, {
           date: '2016-05-01',
-          name: 'Tom',
+          name: 'Jessy',
           address: 'No. 189, Grove St, Los Angeles'
-        }]
+        }],
+        search: '',
       }
+    },
+    methods: {
+      handleEdit(){},
+      handleDelete(){}
     },
   }
 </script>

--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -1536,13 +1536,6 @@ Customize table header so it can be even more customized.
       prop="name">
     </el-table-column>
     <el-table-column
-      v-for="header in extraColumns"
-      :key="header"
-      :label="header"
-      prop="name">
-    </el-table-column>
-    <el-table-column
-      label="Name"
       align="right">
       <template slot="header" slot-scope="slot">
         <el-input

--- a/examples/docs/en-US/table.md
+++ b/examples/docs/en-US/table.md
@@ -186,7 +186,8 @@
           amount3: 15
         }],
         currentRow: null,
-        multipleSelection: []
+        multipleSelection: [],
+        search: '',
       };
     },
 
@@ -1495,6 +1496,79 @@ Customize table column so it can be integrated with other components.
         console.log(index, row);
       }
     }
+  }
+</script>
+```
+:::
+
+### Table with custom header
+
+Customize table header so it can be even more customized.
+:::demo You can customize how the header looks by [Default slot content](https://vuejs.org/v2/guide/components-slots.html#Default-Slot-Content).
+```html
+<template>
+  <el-table
+    :data="tableData.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
+    style="width: 100%">
+    <el-table-column
+      label="Date"
+      prop="date">
+    </el-table-column>
+    <el-table-column
+      label="Name"
+      prop="name">
+    </el-table-column>
+    <el-table-column
+      v-for="header in extraColumns"
+      :key="header"
+      :label="header"
+      prop="name">
+    </el-table-column>
+    <el-table-column
+      label="Name"
+      align="right">
+      <template slot="header" slot-scope="slot">
+        <el-input
+          v-model="search"
+          size="mini"
+          placeholder="Type to search"/>
+      </template>
+      <template slot-scope="scope">
+        <el-button
+          size="mini"
+          @click="handleEdit(scope.$index, scope.row)">Edit</el-button>
+        <el-button
+          size="mini"
+          type="danger"
+          @click="handleDelete(scope.$index, scope.row)">Delete</el-button>
+      </template>
+    </el-table-column>
+  </el-table>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        tableData: [{
+          date: '2016-05-03',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-02',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-04',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-01',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }]
+      }
+    },
   }
 </script>
 ```

--- a/examples/docs/es/table.md
+++ b/examples/docs/es/table.md
@@ -186,7 +186,8 @@
           amount3: 15
         }],
         currentRow: null,
-        multipleSelection: []
+        multipleSelection: [],
+        search: '',
       };
     },
 
@@ -1494,6 +1495,79 @@ Personalice la columna de la tabla para que pueda integrarse con otros component
         console.log(index, row);
       }
     }
+  }
+</script>
+```
+:::
+
+### Table with custom header
+
+Customize table header so it can be even more customized.
+:::demo You can customize how the header looks by [Default slot content](https://vuejs.org/v2/guide/components-slots.html#Default-Slot-Content).
+```html
+<template>
+  <el-table
+    :data="tableData.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
+    style="width: 100%">
+    <el-table-column
+      label="Date"
+      prop="date">
+    </el-table-column>
+    <el-table-column
+      label="Name"
+      prop="name">
+    </el-table-column>
+    <el-table-column
+      v-for="header in extraColumns"
+      :key="header"
+      :label="header"
+      prop="name">
+    </el-table-column>
+    <el-table-column
+      label="Name"
+      align="right">
+      <template slot="header" slot-scope="slot">
+        <el-input
+          v-model="search"
+          size="mini"
+          placeholder="Type to search"/>
+      </template>
+      <template slot-scope="scope">
+        <el-button
+          size="mini"
+          @click="handleEdit(scope.$index, scope.row)">Edit</el-button>
+        <el-button
+          size="mini"
+          type="danger"
+          @click="handleDelete(scope.$index, scope.row)">Delete</el-button>
+      </template>
+    </el-table-column>
+  </el-table>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        tableData: [{
+          date: '2016-05-03',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-02',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-04',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-01',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }]
+      }
+    },
   }
 </script>
 ```

--- a/examples/docs/es/table.md
+++ b/examples/docs/es/table.md
@@ -185,6 +185,23 @@
           amount2: '4.1',
           amount3: 15
         }],
+        tableData7: [{
+          date: '2016-05-02',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-04',
+          name: 'John',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-01',
+          name: 'Morgan',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-03',
+          name: 'Jessy',
+          address: 'No. 189, Grove St, Los Angeles',
+        }],
         currentRow: null,
         multipleSelection: [],
         search: '',
@@ -1507,7 +1524,7 @@ Customize table header so it can be even more customized.
 ```html
 <template>
   <el-table
-    :data="tableData.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
+    :data="tableData7.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
     style="width: 100%">
     <el-table-column
       label="Date"
@@ -1550,23 +1567,28 @@ Customize table header so it can be even more customized.
     data() {
       return {
         tableData: [{
-          date: '2016-05-03',
-          name: 'Tom',
-          address: 'No. 189, Grove St, Los Angeles'
-        }, {
           date: '2016-05-02',
           name: 'Tom',
-          address: 'No. 189, Grove St, Los Angeles'
+          address: 'No. 189, Grove St, Los Angeles',
         }, {
           date: '2016-05-04',
-          name: 'Tom',
-          address: 'No. 189, Grove St, Los Angeles'
+          name: 'John',
+          address: 'No. 189, Grove St, Los Angeles',
         }, {
           date: '2016-05-01',
-          name: 'Tom',
-          address: 'No. 189, Grove St, Los Angeles'
-        }]
+          name: 'Morgan',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-03',
+          name: 'Jessy',
+          address: 'No. 189, Grove St, Los Angeles',
+        }],
+        search: ''
       }
+    },
+    methods: {
+      handleEdit(){},
+      handleDelete(){}
     },
   }
 </script>

--- a/examples/docs/es/table.md
+++ b/examples/docs/es/table.md
@@ -1535,13 +1535,6 @@ Customize table header so it can be even more customized.
       prop="name">
     </el-table-column>
     <el-table-column
-      v-for="header in extraColumns"
-      :key="header"
-      :label="header"
-      prop="name">
-    </el-table-column>
-    <el-table-column
-      label="Name"
       align="right">
       <template slot="header" slot-scope="slot">
         <el-input

--- a/examples/docs/es/table.md
+++ b/examples/docs/es/table.md
@@ -2128,3 +2128,4 @@ Puede personalizar el índice de la fila con la propiedad `type=index` de las co
 | Name | Description |
 |------|--------|
 | — | Custom content for table columns. The scope parameter is { row, column, $index } |
+| header | Custom content for table header. The scope parameter is { column, $index } |

--- a/examples/docs/zh-CN/table.md
+++ b/examples/docs/zh-CN/table.md
@@ -226,7 +226,8 @@
           amount3: 15
         }],
         currentRow: null,
-        multipleSelection: []
+        multipleSelection: [],
+        search: '',
       };
     },
 
@@ -1648,6 +1649,79 @@
 ```
 :::
 
+### Table with custom header
+
+Customize table header so it can be even more customized.
+:::demo You can customize how the header looks by [Default slot content](https://vuejs.org/v2/guide/components-slots.html#Default-Slot-Content).
+```html
+<template>
+  <el-table
+    :data="tableData.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
+    style="width: 100%">
+    <el-table-column
+      label="Date"
+      prop="date">
+    </el-table-column>
+    <el-table-column
+      label="Name"
+      prop="name">
+    </el-table-column>
+    <el-table-column
+      v-for="header in extraColumns"
+      :key="header"
+      :label="header"
+      prop="name">
+    </el-table-column>
+    <el-table-column
+      label="Name"
+      align="right">
+      <template slot="header" slot-scope="slot">
+        <el-input
+          v-model="search"
+          size="mini"
+          placeholder="Type to search"/>
+      </template>
+      <template slot-scope="scope">
+        <el-button
+          size="mini"
+          @click="handleEdit(scope.$index, scope.row)">Edit</el-button>
+        <el-button
+          size="mini"
+          type="danger"
+          @click="handleDelete(scope.$index, scope.row)">Delete</el-button>
+      </template>
+    </el-table-column>
+  </el-table>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        tableData: [{
+          date: '2016-05-03',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-02',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-04',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }, {
+          date: '2016-05-01',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles'
+        }]
+      }
+    },
+  }
+</script>
+```
+:::
+
 ### 表尾合计行
 
 若表格展示的是各类数字，可以在表尾显示各列的合计。
@@ -2111,3 +2185,4 @@
 | name | 说明 |
 |------|--------|
 | — | 自定义列的内容，参数为 { row, column, $index } |
+| header | Custom content for table header. The scope parameter is { column, $index } |

--- a/examples/docs/zh-CN/table.md
+++ b/examples/docs/zh-CN/table.md
@@ -1684,13 +1684,6 @@ Customize table header so it can be even more customized.
       prop="name">
     </el-table-column>
     <el-table-column
-      v-for="header in extraColumns"
-      :key="header"
-      :label="header"
-      prop="name">
-    </el-table-column>
-    <el-table-column
-      label="Name"
       align="right">
       <template slot="header" slot-scope="slot">
         <el-input

--- a/examples/docs/zh-CN/table.md
+++ b/examples/docs/zh-CN/table.md
@@ -225,6 +225,23 @@
           amount2: '4.1',
           amount3: 15
         }],
+        tableData7: [{
+          date: '2016-05-02',
+          name: 'Tom',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-04',
+          name: 'John',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-01',
+          name: 'Morgan',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-03',
+          name: 'Jessy',
+          address: 'No. 189, Grove St, Los Angeles',
+        }],
         currentRow: null,
         multipleSelection: [],
         search: '',
@@ -1656,7 +1673,7 @@ Customize table header so it can be even more customized.
 ```html
 <template>
   <el-table
-    :data="tableData.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
+    :data="tableData7.filter(data => !search || data.name.toLowerCase().includes(search.toLowerCase()))"
     style="width: 100%">
     <el-table-column
       label="Date"
@@ -1699,23 +1716,28 @@ Customize table header so it can be even more customized.
     data() {
       return {
         tableData: [{
-          date: '2016-05-03',
-          name: 'Tom',
-          address: 'No. 189, Grove St, Los Angeles'
-        }, {
           date: '2016-05-02',
           name: 'Tom',
-          address: 'No. 189, Grove St, Los Angeles'
+          address: 'No. 189, Grove St, Los Angeles',
         }, {
           date: '2016-05-04',
-          name: 'Tom',
-          address: 'No. 189, Grove St, Los Angeles'
+          name: 'John',
+          address: 'No. 189, Grove St, Los Angeles',
         }, {
           date: '2016-05-01',
-          name: 'Tom',
-          address: 'No. 189, Grove St, Los Angeles'
-        }]
+          name: 'Morgan',
+          address: 'No. 189, Grove St, Los Angeles',
+        }, {
+          date: '2016-05-03',
+          name: 'Jessy',
+          address: 'No. 189, Grove St, Los Angeles',
+        }],
+        search: ''
       }
+    },
+    methods: {
+      handleEdit(){},
+      handleDelete(){}
     },
   }
 </script>

--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -444,6 +444,10 @@ export default {
       columnIndex = [].indexOf.call(parent.$el.children, this.$el);
     }
 
+    if (this.$scopedSlots.header) {
+      this.columnConfig.renderHeader = this.$scopedSlots.header;
+    }
+
     owner.store.commit('insertColumn', this.columnConfig, columnIndex, this.isSubColumn ? parent.columnConfig : null);
   }
 };

--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -294,6 +294,11 @@ export default {
       }
     });
 
+    // Deprecation warning for renderHeader property
+    if (this.renderHeader) {
+      console.warn('[Element Warn][Table Column]\'render-header\' property will be deprecated in next major version. please use scoped-slot \'header\' instead.');
+    }
+
     this.columnConfig = column;
 
     let renderCell = column.renderCell;

--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -452,8 +452,9 @@ export default {
     if (this.$scopedSlots.header) {
       if (this.type === 'selection') {
         console.warn('[Element Warn][TableColumn]Selection column doesn\'t allow to set scoped-slot header.');
+      } else {
+        this.columnConfig.renderHeader = this.$scopedSlots.header;
       }
-      this.columnConfig.renderHeader = this.$scopedSlots.header;
     }
 
     owner.store.commit('insertColumn', this.columnConfig, columnIndex, this.isSubColumn ? parent.columnConfig : null);

--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -296,7 +296,7 @@ export default {
 
     // Deprecation warning for renderHeader property
     if (this.renderHeader) {
-      console.warn('[Element Warn][Table Column]\'render-header\' property will be deprecated in next major version. please use scoped-slot \'header\' instead.');
+      console.warn('[Element Warn][Table Column] Comparing to render-header, scoped-slot header is easier to use. We recommend users to use scoped-slot header.');
     }
 
     this.columnConfig = column;
@@ -450,6 +450,9 @@ export default {
     }
 
     if (this.$scopedSlots.header) {
+      if (this.type === 'selection') {
+        console.warn('[Element Warn][TableColumn]Selection column doesn\'t allow to set scoped-slot header.');
+      }
       this.columnConfig.renderHeader = this.$scopedSlots.header;
     }
 

--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -451,7 +451,7 @@ export default {
 
     if (this.$scopedSlots.header) {
       if (this.type === 'selection') {
-        console.warn('[Element Warn][TableColumn]Selection column doesn\'t allow to set scoped-slot header.');
+        console.warn('[Element Warn][TableColumn] Selection column doesn\'t allow to set scoped-slot header.');
       } else {
         this.columnConfig.renderHeader = this.$scopedSlots.header;
       }


### PR DESCRIPTION
Fixes #4909 
Fixes #4908
Related #11807
Related #6573 


Now it is possible to assign custom headers directly to templates, exactly as renderHeader does.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
