### PR TITLE
Table: Fix the column parent that destroys the table-column in the ne…

### DIFF
--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -330,7 +330,7 @@ export default {
 
   destroyed() {
     if (!this.$parent) return;
-    const parent = this.$parent;
+    const parent = this.columnOrTableParent;
     this.owner.store.commit('removeColumn', this.columnConfig, this.isSubColumn ? parent.columnConfig : null);
   },
 


### PR DESCRIPTION
Fix the column parent that destroys the table-column in the nested component

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

当自定义组件包含table-column时，多级嵌套下，移除相应的自定义组件会导致table-column找不到真实父级

https://jsfiddle.net/minfive/eywraw8t/448433/
