### PR TITLE
Table: tooltip content prefer to use innerText instead of textContent

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -328,7 +328,7 @@ export default {
       if ((rangeWidth + padding > cellChild.offsetWidth || cellChild.scrollWidth > cellChild.offsetWidth) && this.$refs.tooltip) {
         const tooltip = this.$refs.tooltip;
         // TODO 会引起整个 Table 的重新渲染，需要优化
-        this.tooltipContent = cell.textContent || cell.innerText;
+        this.tooltipContent = cell.innerText || cell.textContent;
         tooltip.referenceElm = cell;
         tooltip.$refs.popper && (tooltip.$refs.popper.style.display = 'none');
         tooltip.doDestroy();


### PR DESCRIPTION
- Closes #13111

表格内overflow-tooltip的内容优先使用innerText的返回值，innerText不会返回被隐藏的文本内容。overflow-tooltip根据特性名应显示的是溢出的内容，而不是把隐藏的文本都显示出来