### PR TITLE
Steps: Fix same finish & process color, line fail to display bug

### DIFF
--- a/packages/steps/src/step.vue
+++ b/packages/steps/src/step.vue
@@ -137,24 +137,25 @@ export default {
   methods: {
     updateStatus(val) {
       const prevChild = this.$parent.$children[this.index - 1];
+      let currentProcessStatus = false;
 
       if (val > this.index) {
         this.internalStatus = this.$parent.finishStatus;
       } else if (val === this.index && this.prevStatus !== 'error') {
         this.internalStatus = this.$parent.processStatus;
+        currentProcessStatus = true;
       } else {
         this.internalStatus = 'wait';
       }
-
-      if (prevChild) prevChild.calcProgress(this.internalStatus);
+      if (prevChild) prevChild.calcProgress(this.internalStatus, currentProcessStatus);
     },
 
-    calcProgress(status) {
+    calcProgress(status, currentProcessStatus) {
       let step = 100;
       const style = {};
 
       style.transitionDelay = 150 * this.index + 'ms';
-      if (status === this.$parent.processStatus) {
+      if (currentProcessStatus) {
         step = this.currentStatus !== 'error' ? 0 : 0;
       } else if (status === 'wait') {
         step = 0;


### PR DESCRIPTION
- Closes #13068 

if `finish-status` and `process-status` are same color, it will think `finish-status` is `process-status` thus removing the line(s).

I think in the future should include option for user to toggle line color for process too.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
