### PR TITLE
Progress: add text status

### DIFF
--- a/examples/docs/en-US/progress.md
+++ b/examples/docs/en-US/progress.md
@@ -48,7 +48,8 @@ In this case the percentage takes no additional space.
 <el-progress type="circle" :percentage="80" color="#8e71c7"></el-progress>
 <el-progress type="circle" :percentage="100" status="success"></el-progress>
 <el-progress type="circle" :percentage="50" status="exception"></el-progress>
-``` 
+<el-progress type="circle" :percentage="100" status="text">Done</el-progress>
+```
 :::
 
 ### Attributes
@@ -58,7 +59,7 @@ In this case the percentage takes no additional space.
 | type | the type of progress bar | string | line/circle | line |
 | stroke-width | the width of progress bar | number | — | 6 |
 | text-inside | whether to place the percentage inside progress bar, only works when `type` is 'line' | boolean | — | false |
-| status | the current status of progress bar | string | success/exception | — |
+| status | the current status of progress bar | string | success/exception/text | — |
 | color  | background color of progress bar. Overrides `status` prop | string | — | — |
 | width | the canvas width of circle progress bar | number | — | 126 |
 | show-text | whether to show percentage | boolean | — | true |

--- a/examples/docs/es/progress.md
+++ b/examples/docs/es/progress.md
@@ -46,6 +46,7 @@ En este caso el porcentage no toma espacio adicional.
 <el-progress type="circle" :percentage="80" color="#8e71c7"></el-progress>
 <el-progress type="circle" :percentage="100" status="success"></el-progress>
 <el-progress type="circle" :percentage="50" status="exception"></el-progress>
+<el-progress type="circle" :percentage="100" status="text">Done</el-progress>
 ```
 :::
 
@@ -56,7 +57,7 @@ En este caso el porcentage no toma espacio adicional.
 | type         | tipo de barra de progreso                | string  | line/circle       | line        |
 | stroke-width | ancho de la barra de progreso            | number  | —                 | 6           |
 | text-inside  | mostrar el porcentaje dentro de la barra de progreso, solo funciona cuando `type` es 'line' | boolean | —                 | false       |
-| status       | estado actual de la barra de progreso    | string  | success/exception | —           |
+| status       | estado actual de la barra de progreso    | string  | success/exception/text | —           |
 | color        | color de fondo de la barra de progreso. Sobreescribe la propiedad `status` | string     | — |       — |
 | width        | ancho del canvas que contiene la barra de progreso circula | number  | —                 | 126         |
 | show-text    | mostrar porcentaje                       | boolean | —                 | true        |

--- a/examples/docs/zh-CN/progress.md
+++ b/examples/docs/zh-CN/progress.md
@@ -52,6 +52,7 @@
 <el-progress type="circle" :percentage="80" color="#8e71c7"></el-progress>
 <el-progress type="circle" :percentage="100" status="success"></el-progress>
 <el-progress type="circle" :percentage="50" status="exception"></el-progress>
+<el-progress type="circle" :percentage="100" status="text">Done</el-progress>
 ```
 :::
 
@@ -62,7 +63,7 @@
 | type          | 进度条类型           | string         | line/circle | line |
 | stroke-width  | 进度条的宽度，单位 px | number          | — | 6 |
 | text-inside  | 进度条显示文字内置在进度条内（只在 type=line 时可用） | boolean | — | false |
-| status  | 进度条当前状态 | string | success/exception | — |
+| status  | 进度条当前状态 | string | success/exception/text | — |
 | color  | 进度条背景色（会覆盖 status 状态颜色） | string | — | — |
 | width  | 环形进度条画布宽度（只在 type=circle 时可用） | number |  | 126 |
 | show-text  | 是否显示进度条文字内容 | boolean | — | true |

--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -1,12 +1,19 @@
 <template>
-  <div class="el-progress" :class="[
+  <div
+    class="el-progress"
+    :class="[
       'el-progress--' + type,
       status ? 'is-' + status : '',
       {
         'el-progress--without-text': !showText,
         'el-progress--text-inside': textInside,
       }
-    ]" role="progressbar" :aria-valuenow="percentage" aria-valuemin="0" aria-valuemax="100">
+    ]"
+    role="progressbar"
+    :aria-valuenow="percentage"
+    aria-valuemin="0"
+    aria-valuemax="100"
+  >
     <div class="el-progress-bar" v-if="type === 'line'">
       <div class="el-progress-bar__outer" :style="{height: strokeWidth + 'px'}">
         <div class="el-progress-bar__inner" :style="barStyle">

--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -33,7 +33,12 @@
       :style="{fontSize: progressTextSize + 'px'}"
     >
       <template v-if="!status">{{percentage}}%</template>
-      <i v-else :class="iconClass"></i>
+      <template v-if="status && status === 'text'">
+        <slot></slot>
+      </template>
+      <template v-if="status && status !== 'text'">
+        <i :class="iconClass"></i>
+      </template>
     </div>
   </div>
 </template>
@@ -53,7 +58,8 @@
         validator: val => val >= 0 && val <= 100
       },
       status: {
-        type: String
+        type: String,
+        validator: val => ['text', 'success', 'exception'].indexOf(val) > -1
       },
       strokeWidth: {
         type: Number,

--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -1,19 +1,12 @@
 <template>
-  <div
-    class="el-progress"
-    :class="[
+  <div class="el-progress" :class="[
       'el-progress--' + type,
       status ? 'is-' + status : '',
       {
         'el-progress--without-text': !showText,
         'el-progress--text-inside': textInside,
       }
-    ]"
-    role="progressbar"
-    :aria-valuenow="percentage"
-    aria-valuemin="0"
-    aria-valuemax="100"
-  >
+    ]" role="progressbar" :aria-valuenow="percentage" aria-valuemin="0" aria-valuemax="100">
     <div class="el-progress-bar" v-if="type === 'line'">
       <div class="el-progress-bar__outer" :style="{height: strokeWidth + 'px'}">
         <div class="el-progress-bar__inner" :style="barStyle">
@@ -27,17 +20,11 @@
         <path class="el-progress-circle__path" :d="trackPath" stroke-linecap="round" :stroke="stroke" :stroke-width="relativeStrokeWidth" fill="none" :style="circlePathStyle"></path>
       </svg>
     </div>
-    <div
-      class="el-progress__text"
-      v-if="showText && !textInside"
-      :style="{fontSize: progressTextSize + 'px'}"
-    >
+    <div class="el-progress__text" v-if="showText && !textInside" :style="{fontSize: progressTextSize + 'px'}">
       <template v-if="!status">{{percentage}}%</template>
-      <template v-if="status && status === 'text'">
-        <slot></slot>
-      </template>
-      <template v-if="status && status !== 'text'">
-        <i :class="iconClass"></i>
+      <template v-else>
+        <slot v-if="status === 'text'"></slot>
+        <i v-else :class="iconClass"></i>
       </template>
     </div>
   </div>

--- a/test/unit/specs/progress.spec.js
+++ b/test/unit/specs/progress.spec.js
@@ -33,6 +33,7 @@ describe('Progress', () => {
           <el-progress ref="lineException" :percentage="0" status="exception"></el-progress>
           <el-progress type="circle" ref="circleSuccess" :percentage="100" status="success"></el-progress>
           <el-progress type="circle" ref="circleException" :percentage="0" status="exception"></el-progress>
+          <el-progress type="circle" ref="textException" :percentage="100" status="text">Done</el-progress>
         </div>
       `
     }, true);
@@ -45,6 +46,7 @@ describe('Progress', () => {
     expect(vm.$refs.circleSuccess.$el.querySelector('.el-progress__text .el-icon-check')).to.be.exist;
     expect(vm.$refs.circleException.$el.classList.contains('is-exception')).to.be.true;
     expect(vm.$refs.circleException.$el.querySelector('.el-progress__text .el-icon-close')).to.be.exist;
+    expect(vm.$refs.textException.$el.querySelector('.el-progress__text').innerText).to.be.equal('Done');
   });
   it('text inside', () => {
     vm = createVue({

--- a/types/progress.d.ts
+++ b/types/progress.d.ts
@@ -1,7 +1,7 @@
 import { ElementUIComponent } from './component'
 
 export type ProgressType = 'line' | 'circle'
-export type ProgressStatus = 'success' | 'exception'
+export type ProgressStatus = 'success' | 'exception' | 'text'
 
 /** Progress Component */
 export declare class ElProgress extends ElementUIComponent {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Hi there

With the current version of ElementUI, we can not use the special text inner circle progress content, and I have added this feature, for instance:

```javascript
<Progress :percentage="100" :stroke-width="10" :width="100" status="text" type="circle">Done</Progress>
```

And it will be:
<img width="131" alt="screen shot 2018-10-29 at 1 53 09 am" src="https://user-images.githubusercontent.com/9049092/47622707-692ea800-db1d-11e8-9fdf-68f8d6fabf88.png">

I hope it will be useful.