### PR TITLE
Table: current row will set to the row which has the same rowKey when data changes

### DIFF
--- a/packages/table/src/table-store.js
+++ b/packages/table/src/table-store.js
@@ -597,6 +597,20 @@ TableStore.prototype.updateCurrentRow = function() {
   const oldCurrentRow = states.currentRow;
 
   if (data.indexOf(oldCurrentRow) === -1) {
+    if (states.rowKey && oldCurrentRow) {
+      let newCurrentRow = null;
+      for (let i = 0; i < data.length; i++) {
+        const item = data[i];
+        if (item && item[states.rowKey] === oldCurrentRow[states.rowKey]) {
+          newCurrentRow = item;
+          break;
+        }
+      }
+      if (newCurrentRow) {
+        states.currentRow = newCurrentRow;
+        return;
+      }
+    }
     states.currentRow = null;
 
     if (states.currentRow !== oldCurrentRow) {


### PR DESCRIPTION
- Closes #3023

如果table包含`row-key`，当表格数据变化时，如果新数据内某行包含有相同的rowKey，则将其设为currentRow