### PR TITLE
TableColumn: add prop for renderCell like renderHeader

### DIFF
--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -151,6 +151,7 @@ export default {
     prop: String,
     width: {},
     minWidth: {},
+    renderCell: Function,
     renderHeader: Function,
     sortable: {
       type: [String, Boolean],
@@ -251,7 +252,7 @@ export default {
       labelClassName: this.labelClassName,
       property: this.prop || this.property,
       type,
-      renderCell: null,
+      renderCell: this.renderCell,
       renderHeader: this.renderHeader,
       minWidth,
       width,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

### Description
This PR brings the ability to set `renderCell` method outside a `TableHeader` component.
It works like a charm :)