### PR TITLE
Chore: specify travis Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
-node_js: lts/*
+node_js: 8
 before_install:
 - export CHROME_BIN=chromium-browser
 - export DISPLAY=:99.0


### PR DESCRIPTION
自昨天起，Node.js LTS 变成了 v10。目前使用的 node-sass 不支持最新版本的 Node。
指定版本号，暂时不升级 sass 依赖了。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
