### PR TITLE
ColorPicker:(fix) default color red dont activate watch

### DIFF
--- a/packages/color-picker/src/components/picker-dropdown.vue
+++ b/packages/color-picker/src/components/picker-dropdown.vue
@@ -109,8 +109,11 @@
         }
       },
 
-      currentColor(val) {
-        this.customInput = val;
+      currentColor: {
+        immediate: true,
+        handler(val) {
+          this.customInput = val;
+        }
       }
     }
   };

--- a/packages/color-picker/src/main.vue
+++ b/packages/color-picker/src/main.vue
@@ -165,6 +165,7 @@
         enableAlpha: this.showAlpha,
         format: this.colorFormat
       });
+
       return {
         color,
         showPicker: false,


### PR DESCRIPTION
#12994 Color default value is #ff0000, without immediate, the default value has no change.

Please make sure these boxes are checked before submitting your PR, thank you!

* [-] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [-] Make sure you are merging your commits to `dev` branch.
* [-] Add some descriptions and refer relative issues for you PR.
