### PR TITLE
Tabs: fix 'beforeLeave' can't handler Promise.reject

### DIFF
--- a/packages/tabs/src/tabs.vue
+++ b/packages/tabs/src/tabs.vue
@@ -95,7 +95,7 @@
               changeCurrentName();
 
               this.$refs.nav && this.$refs.nav.removeFocus();
-            });
+            }).catch(() => {});
           } else if (before !== false) {
             changeCurrentName();
           }


### PR DESCRIPTION
 Please make sure these boxes are checked before submitting your PR, thank you!
- [x] Make sure you follow Element's contributing guide (中文 | English | Español).
- [x] Make sure you are merging your commits to dev branch.
- [x] Add some descriptions and refer relative issues for you PR.

当返回给beforeLeave的为Promise.resolve()时，可以正确执行，当传入Promsie.reject()时，缺少对Promise.reject的处理，导致浏览器提示报错信息 error: Uncaught (in promise)