### PR TITLE
TimePicker: explicit declare box-sizing: content-box

### DIFF
--- a/packages/theme-chalk/src/date-picker/time-picker.scss
+++ b/packages/theme-chalk/src/date-picker/time-picker.scss
@@ -11,6 +11,7 @@
   left: 0;
   z-index: $--index-top;
   user-select: none;
+  box-sizing: content-box;
 
   @include e(content) {
     font-size: 0;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.


Many projects will increase the following css globally.
```css
*,
*:before,
*:after {
  box-sizing: inherit;
}
```

Such as [minireset](https://github.com/jgthms/minireset.css/blob/master/minireset.css), [bootstrap](https://github.com/twbs/bootstrap/blob/f803fb9903abd2daa033081894d310f97a371e70/scss/bootstrap-grid.scss) Or [article](https://www.paulirish.com/2012/box-sizing-border-box-ftw/).

But time-pick hs a display bug, because it will inherit  `el-date-range-picker__time-header` attr.

![image](https://user-images.githubusercontent.com/8121621/48181978-8c9af380-e364-11e8-90ef-24e53b298c61.png)

[Online demo](https://jsfiddle.net/tkdys3p0/)


