### PR TITLE
[Tree]: fix #12383

### DIFF
--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -465,6 +465,7 @@ export default class Node {
         this.doCreateChildren(children, defaultProps);
 
         this.updateLeafState();
+        reInitChecked(this);
         if (callback) {
           callback.call(this, children);
         }

--- a/test/unit/specs/tree.spec.js
+++ b/test/unit/specs/tree.spec.js
@@ -302,23 +302,16 @@ describe('Tree', () => {
     expect(vm.$el.querySelectorAll('.el-checkbox .is-checked').length).to.equal(1);
   });
 
-  it('defaultCheckedKeys & lazy, checked children length as expected', (done) => {
+  it('defaultCheckedKeys & lazy, checked children length as expected', () => {
     vm = getTreeVm(':load="loadNode" :props="defaultProps" :default-checked-keys="defaultCheckedKeys" node-key="id" :default-expanded-keys="[1]" lazy show-checkbox ', {
-      data() {
-        return {
-          defaultCheckedKeys: [2, 3],
-          defaultProps: {
-            children: 'children',
-            label: 'label'
-          }
-        };
+      created() {
+        this.defaultCheckedKeys = [2, 3];
       },
       methods: {
         loadNode(node, resolve) {
           if (node.level === 0) {
             return resolve([{ label: 'head', id: 1} ]);
           }
-
           return resolve([
             {
               label: '#1',
@@ -336,10 +329,7 @@ describe('Tree', () => {
         }
       }
     });
-    setTimeout(() => {
-      expect(vm.$el.querySelectorAll('.el-checkbox.is-checked').length).to.equal(2);
-      done();
-    });
+    expect(vm.$el.querySelectorAll('.el-checkbox.is-checked').length).to.equal(2);
   });
 
   it('show checkbox', done => {

--- a/test/unit/specs/tree.spec.js
+++ b/test/unit/specs/tree.spec.js
@@ -302,7 +302,7 @@ describe('Tree', () => {
     expect(vm.$el.querySelectorAll('.el-checkbox .is-checked').length).to.equal(1);
   });
 
-  it.only('defaultCheckedKeys & lazy, checked children length as expected', (done) => {
+  it('defaultCheckedKeys & lazy, checked children length as expected', (done) => {
     vm = getTreeVm(':load="loadNode" :props="defaultProps" :default-checked-keys="defaultCheckedKeys" node-key="id" :default-expanded-keys="[1]" lazy show-checkbox ', {
       data() {
         return {
@@ -334,11 +334,11 @@ describe('Tree', () => {
             }
           ]);
         }
-      },
-      mounted() {
-        expect(this.$el.querySelectorAll('.el-checkbox.is-checked').length).to.equal(2);
-        done();
       }
+    });
+    setTimeout(() => {
+      expect(vm.$el.querySelectorAll('.el-checkbox.is-checked').length).to.equal(2);
+      done();
     });
   });
 

--- a/test/unit/specs/tree.spec.js
+++ b/test/unit/specs/tree.spec.js
@@ -302,6 +302,46 @@ describe('Tree', () => {
     expect(vm.$el.querySelectorAll('.el-checkbox .is-checked').length).to.equal(1);
   });
 
+  it.only('defaultCheckedKeys & lazy, checked children length as expected', (done) => {
+    vm = getTreeVm(':load="loadNode" :props="defaultProps" :default-checked-keys="defaultCheckedKeys" node-key="id" :default-expanded-keys="[1]" lazy show-checkbox ', {
+      data() {
+        return {
+          defaultCheckedKeys: [2, 3],
+          defaultProps: {
+            children: 'children',
+            label: 'label'
+          }
+        };
+      },
+      methods: {
+        loadNode(node, resolve) {
+          if (node.level === 0) {
+            return resolve([{ label: 'head', id: 1} ]);
+          }
+
+          return resolve([
+            {
+              label: '#1',
+              id: 2
+            },
+            {
+              label: '#3',
+              id: 3
+            },
+            {
+              label: '$4',
+              id: 5
+            }
+          ]);
+        }
+      },
+      mounted() {
+        expect(this.$el.querySelectorAll('.el-checkbox.is-checked').length).to.equal(2);
+        done();
+      }
+    });
+  });
+
   it('show checkbox', done => {
     vm = getTreeVm(':props="defaultProps" show-checkbox');
     const tree = vm.$children[0];


### PR DESCRIPTION
fix #12383 

bug 原因: 

异步的情况下会执行 doCreateChildren , 如果刚好children 的前两个或多个是 default-checked-keys 中设置的, 那么会将 parent.checked 设置为 true.

在 `callback` 中 会执行 `setChecked(true, true)`, 将所有的 children 的 check 的设置为true

解决办法:
在 执行 callback 之前, 再次检查该节点的 children.

---

~~如果需要的话 可以添加 tests, 但是我碰到有个问题, 在 windows 环境下 测试跑不通~~



