### PR TITLE
date table: simplify implementation, fix #12980, follow up #8156

### DIFF
--- a/packages/date-picker/src/basic/date-table.vue
+++ b/packages/date-picker/src/basic/date-table.vue
@@ -96,9 +96,7 @@
         default() {
           return {
             endDate: null,
-            selecting: false,
-            row: null,
-            column: null
+            selecting: false
           };
         }
       }
@@ -242,7 +240,9 @@
 
     data() {
       return {
-        tableRows: [ [], [], [], [], [], [] ]
+        tableRows: [ [], [], [], [], [], [] ],
+        lastRow: null,
+        lastColumn: null
       };
     },
 
@@ -361,17 +361,18 @@
         }
         if (target.tagName !== 'TD') return;
 
-        const column = target.cellIndex;
         const row = target.parentNode.rowIndex - 1;
-        const { row: oldRow, column: oldColumn } = this.rangeState;
+        const column = target.cellIndex;
 
-        if (oldRow !== row || oldColumn !== column) {
+        // only update rangeState when mouse moves to a new cell
+        // this avoids frequent Date object creation and improves performance
+        if (row !== this.lastRow || column !== this.lastColumn) {
+          this.lastRow = row;
+          this.lastColumn = column;
           this.$emit('changerange', {
             minDate: this.minDate,
             maxDate: this.maxDate,
             rangeState: {
-              row,
-              column,
               selecting: true,
               endDate: this.getDateOfCell(row, column)
             }


### PR DESCRIPTION
简化内部实现

* issue https://github.com/ElemeFE/element/issues/12980 的问题在 2.0.0 的时候就有了
* `rangeState.{row, column}` 改到 date-table 内部了，这个没必要暴露给外面的组件。
* pr #8156 引入了会高亮已禁用日期的 bug，一并修了


删代码真开心 （x
