### PR TITLE
Popover: add closeDelay prop

### DIFF
--- a/packages/popover/src/main.vue
+++ b/packages/popover/src/main.vue
@@ -42,6 +42,10 @@ export default {
       type: Number,
       default: 0
     },
+    closeDelay: {
+      type: Number,
+      default: 200
+    },
     title: String,
     disabled: Boolean,
     content: String,
@@ -163,7 +167,7 @@ export default {
       clearTimeout(this._timer);
       this._timer = setTimeout(() => {
         this.showPopper = false;
-      }, 200);
+      }, this.closeDelay);
     },
     handleDocumentClick(e) {
       let reference = this.reference || this.$refs.reference;


### PR DESCRIPTION
When using el-popover for multiple elements, move the mouse quickly over multiple elements
，the scene below appears, because the el-popover auto close after 200ms.

https://jsfiddle.net/yd4pu3zn/
![image](https://raw.githubusercontent.com/qinshenxue/public-images/master/ElemeFE-element-pull13398-2.gif)




Add and set the `close-delay` to 0 to avoid the problem of the above image.

https://jsfiddle.net/yd4pu3zn/1/

![image](https://user-images.githubusercontent.com/10354498/48452548-88e6f100-e7ea-11e8-9814-4ccd3d18f5c3.png)


![image](https://raw.githubusercontent.com/qinshenxue/public-images/master/ElemeFE-element-pull13398-1.gif)





|Attribute | Description | Type | Accepted Values | Default|
|-- | -- | -- | -- | --|
| close-delay | delay of disappearance when trigger is hover, in milliseconds| number| -- | 200 |





Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
