### PR TITLE
Upload: bind `xhr.upload.onprogress` event only when necessary

### DIFF
--- a/packages/upload/src/ajax.js
+++ b/packages/upload/src/ajax.js
@@ -36,7 +36,7 @@ export default function upload(option) {
   const xhr = new XMLHttpRequest();
   const action = option.action;
 
-  if (xhr.upload) {
+  if (xhr.upload && option.onProgress) {
     xhr.upload.onprogress = function progress(e) {
       if (e.total > 0) {
         e.percent = e.loaded / e.total * 100;

--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -285,7 +285,7 @@ export default {
         limit: this.limit,
         'on-exceed': this.onExceed,
         'on-start': this.handleStart,
-        'on-progress': this.handleProgress,
+        'on-progress': this.onProgress === noop ? null : this.handleProgress,
         'on-success': this.handleSuccess,
         'on-error': this.handleError,
         'on-preview': this.onPreview,

--- a/packages/upload/src/upload.vue
+++ b/packages/upload/src/upload.vue
@@ -141,9 +141,9 @@ export default {
         data: this.data,
         filename: this.name,
         action: this.action,
-        onProgress: e => {
+        onProgress: this.onProgress ? e => {
           this.onProgress(e, rawFile);
-        },
+        } : null,
         onSuccess: res => {
           this.onSuccess(res, rawFile);
           delete this.reqs[uid];


### PR DESCRIPTION
修改Upload组件，当绑定`on-progress`属性时才监听`xhr.upload.onprogress`，否则默认绑定此事件的话，会导致请求不是simple request，每次会发起options请求，是没有必要的。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
