### PR TITLE
doc: input-number, fix missing num9 declaration

### DIFF
--- a/examples/docs/en-US/input-number.md
+++ b/examples/docs/en-US/input-number.md
@@ -9,7 +9,8 @@
         num5: 1,
         num6: 1,
         num7: 1,
-        num8: 1
+        num8: 1,
+        num9: 1
       }
     },
     methods: {

--- a/examples/docs/es/input-number.md
+++ b/examples/docs/es/input-number.md
@@ -9,7 +9,8 @@
         num5: 1,
         num6: 1,
         num7: 1,
-        num8: 1
+        num8: 1,
+        num9: 1
       }
     },
     methods: {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9319556/48689144-3dcf4280-ec1d-11e8-8626-bc379a893897.png)

https://github.com/ElemeFE/element/pull/11281 的时候 英文 和 西语 的文档没加上 `num9`

这么久竟然没有国际友人发现这个bug。。。