### PR TITLE
[CollapseTransition]:fix interrupted bug

### DIFF
--- a/src/transitions/collapse-transition.js
+++ b/src/transitions/collapse-transition.js
@@ -1,12 +1,19 @@
 import { addClass, removeClass } from 'element-ui/src/utils/dom';
 
+let isAfterLeave = true;
+
 class Transition {
   beforeEnter(el) {
     addClass(el, 'collapse-transition');
     if (!el.dataset) el.dataset = {};
-
-    el.dataset.oldPaddingTop = el.style.paddingTop;
-    el.dataset.oldPaddingBottom = el.style.paddingBottom;
+  
+    if (isAfterLeave) {
+      el.dataset.oldPaddingTop = el.style.paddingTop;
+      el.dataset.oldPaddingBottom = el.style.paddingBottom;
+    } else {
+      el.style.paddingTop = el.dataset.oldPaddingTop;
+      el.style.paddingBottom = el.dataset.oldPaddingBottom;
+    }
 
     el.style.height = '0';
     el.style.paddingTop = 0;
@@ -14,6 +21,7 @@ class Transition {
   }
 
   enter(el) {
+    isAfterLeave = false;
     el.dataset.oldOverflow = el.style.overflow;
     if (el.scrollHeight !== 0) {
       el.style.height = el.scrollHeight + 'px';
@@ -52,6 +60,93 @@ class Transition {
       el.style.height = 0;
       el.style.paddingTop = 0;
       el.style.paddingBottom = 0;
+      isAfterLeave = true;
+    }
+  }
+
+  afterLeave(el) {
+    removeClass(el, 'collapse-transition');
+    el.style.height = '';
+    el.style.overflow = el.dataset.oldOverflow;
+    el.style.paddingTop = el.dataset.oldPaddingTop;
+    el.style.paddingBottom = el.dataset.oldPaddingBottom;
+  }
+}
+
+export default {
+  name: 'ElCollapseTransition',
+  functional: true,
+  render(h, { children }) {
+    const data = {
+      on: new Transition()
+    };
+
+    return h('transition', data, children);
+  }
+};
+import { addClass, removeClass } from 'element-ui/src/utils/dom';
+
+let isAfterLeave = true;
+
+class Transition {
+  beforeEnter(el) {
+    addClass(el, 'collapse-transition');
+    if (!el.dataset) el.dataset = {};
+  
+    if (isAfterLeave) {
+      el.dataset.oldPaddingTop = el.style.paddingTop;
+      el.dataset.oldPaddingBottom = el.style.paddingBottom;
+    } else {
+      el.style.paddingTop = el.dataset.oldPaddingTop;
+      el.style.paddingBottom = el.dataset.oldPaddingBottom;
+    }
+
+    el.style.height = '0';
+    el.style.paddingTop = 0;
+    el.style.paddingBottom = 0;
+  }
+
+  enter(el) {
+    isAfterLeave = false;
+    el.dataset.oldOverflow = el.style.overflow;
+    if (el.scrollHeight !== 0) {
+      el.style.height = el.scrollHeight + 'px';
+      el.style.paddingTop = el.dataset.oldPaddingTop;
+      el.style.paddingBottom = el.dataset.oldPaddingBottom;
+    } else {
+      el.style.height = '';
+      el.style.paddingTop = el.dataset.oldPaddingTop;
+      el.style.paddingBottom = el.dataset.oldPaddingBottom;
+    }
+
+    el.style.overflow = 'hidden';
+  }
+
+  afterEnter(el) {
+    // for safari: remove class then reset height is necessary
+    removeClass(el, 'collapse-transition');
+    el.style.height = '';
+    el.style.overflow = el.dataset.oldOverflow;
+  }
+
+  beforeLeave(el) {
+    if (!el.dataset) el.dataset = {};
+    el.dataset.oldPaddingTop = el.style.paddingTop;
+    el.dataset.oldPaddingBottom = el.style.paddingBottom;
+    el.dataset.oldOverflow = el.style.overflow;
+
+    el.style.height = el.scrollHeight + 'px';
+    el.style.overflow = 'hidden';
+  }
+
+  leave(el) {
+    if (el.scrollHeight !== 0) {
+      // for safari: add class after set height, or it will jump to zero height suddenly, weired
+      addClass(el, 'collapse-transition');
+      el.style.height = 0;
+      el.style.paddingTop = 0;
+      el.style.paddingBottom = 0;
+      isAfterLeave = true;
     }
   }
 


### PR DESCRIPTION
CollapseTransition在触发leave钩子但未触发afterLeave钩子时打断重新触发beforeEnter钩子，而导致paddingTop,paddingBottom最终被设为0.
When the CollapseTransition is  interrupted after the leave hook and before the afterLeave hook for re-trigger the beforeEnter hook,  paddingTop and paddingBottom would be set to 0 filnally.

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
