### PR TITLE
Cascader: Correct type definitions of CascaderOption

### DIFF
--- a/types/cascader.d.ts
+++ b/types/cascader.d.ts
@@ -7,8 +7,8 @@ export type ExpandTrigger = 'click' | 'hover'
 export interface CascaderOption {
   label: string,
   value: any,
-  children: CascaderOption[],
-  disabled: boolean
+  children?: CascaderOption[],
+  disabled?: boolean
 }
 
 /** Cascader Component */


### PR DESCRIPTION
Allows `children` and `disabled` to be undefined

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
