### PR TITLE
Loading: fix Loading.directive bug in TypeScript

### DIFF
--- a/types/loading.d.ts
+++ b/types/loading.d.ts
@@ -1,4 +1,4 @@
-import Vue, { VNodeDirective } from 'vue'
+import Vue, { VNodeDirective, PluginObject } from 'vue'
 
 /** Options used in Loading service */
 export interface LoadingServiceOptions {
@@ -51,7 +51,7 @@ export interface ElLoading {
   /** If you do not have a specific DOM node to attach the Loading directive, or if you simply prefer not to use Loading as a directive, you can call this service with some configs to open a Loading instance. */
   service (options: LoadingServiceOptions): ElLoadingComponent
 
-  directive: object
+  directive: PluginObject<object>
 }
 
 declare module 'vue/types/vue' {


### PR DESCRIPTION
* In TypeScript, Vue.use(Loading.directive) will show "Argument of type 'object' is not assignable to parameter of type 'PluginObject<any> | PluginFunction<any>'"

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
