### PR TITLE
Table: fix empty text vertical alignment issue on IE10+

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -27,6 +27,7 @@
   }
 
   @include e(empty-text) {
+    line-height: 60px;
     width: 50%;
     color: $--color-text-secondary;
   }

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -27,6 +27,8 @@
   }
 
   @include e(empty-text) {
+    // min-height doesn't work in IE10 and IE11 https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
+    // set empty text line height up to contrainer min-height as workaround.
     line-height: 60px;
     width: 50%;
     color: $--color-text-secondary;


### PR DESCRIPTION
Fix the table empty text vertical alignment issue(pushed top of empty container).
Please refer to attached screenshot:
![el-table-empty-text-vertical-align-issue.png](https://i.loli.net/2018/12/02/5c02b5e2c5915.png)

Thank you!

**Environment**
- Windows 10
- Internet Explorer 10+