### PR TITLE
Table: fix fixed column attribute style malformed bug

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -131,7 +131,9 @@
 
     &.is-hidden {
       > * {
-        visibility: hidden;
+          // visibility: hidden;
+          pointer-events:none;
+          opacity: 0;
       }
     }
   }

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -131,8 +131,6 @@
 
     &.is-hidden {
       > * {
-          // visibility: hidden;
-          pointer-events:none;
           opacity: 0;
       }
     }


### PR DESCRIPTION
我在`<el-table-column> `首列中添加fixed属性，并在其他列使用css将超出三行的文字隐藏，但此时fixed列样式出现异常，如图：

![error](https://user-images.githubusercontent.com/35052357/49442136-86812100-f803-11e8-8edd-8122d719dcbd.jpg)

做如下修改此问题解决；