### PR TITLE
Slider:fix click slidebar tootip's arrow not in center

### DIFF
--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -955,9 +955,15 @@
      */
     function getOuterSizes(element) {
         // NOTE: 1 DOM access here
-        var _display = element.style.display, _visibility = element.style.visibility;
+        var _display = element.style.display, _visibility = element.style.visibility,
+            _parentDisplay = element.parentNode.style.display, _parentVisibility = element.parentNode.style.visibility,
+            parentElement = element.parentNode;
         element.style.display = 'block'; element.style.visibility = 'hidden';
-        var calcWidthToForceRepaint = element.offsetWidth;
+        // solve arrow offset problem
+        if(element.getAttribute('x-arrow') !== null) {
+            // element is arrowElement
+            parentElement.style.display = 'block';parentElement.style.visibility = 'hidden';
+        }
 
         // original method
         var styles = root.getComputedStyle(element);
@@ -967,6 +973,7 @@
 
         // reset element styles
         element.style.display = _display; element.style.visibility = _visibility;
+        parentElement.style.display = _parentDisplay;parentElement.style.visibility = _parentVisibility;
         return result;
     }
 

--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -956,12 +956,14 @@
     function getOuterSizes(element) {
         // NOTE: 1 DOM access here
         var _display = element.style.display, _visibility = element.style.visibility,
-            _parentDisplay = element.parentNode.style.display, _parentVisibility = element.parentNode.style.visibility,
+            _parentDisplay, _parentVisibility,
             parentElement = element.parentNode;
         element.style.display = 'block'; element.style.visibility = 'hidden';
         // solve arrow offset problem
         if(element.getAttribute('x-arrow') !== null) {
             // element is arrowElement
+            _parentDisplay = element.parentNode.style.display;
+            _parentVisibility = element.parentNode.style.visibility;
             parentElement.style.display = 'block';parentElement.style.visibility = 'hidden';
         }
 
@@ -973,7 +975,9 @@
 
         // reset element styles
         element.style.display = _display; element.style.visibility = _visibility;
-        parentElement.style.display = _parentDisplay;parentElement.style.visibility = _parentVisibility;
+        if(element.getAttribute('x-arrow') !== null) {
+            parentElement.style.display = _parentDisplay;parentElement.style.visibility = _parentVisibility;
+        }
         return result;
     }
 


### PR DESCRIPTION
http://element-cn.eleme.io/#/zh-CN/component/slider 点击滑动槽上的点，弹出的tooltip箭头是不居中的，本次提交修复此问题
