### PR TITLE
DateTimePicker: add the selectableRange in pickerOptions

### DIFF
--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -30,7 +30,7 @@
             <span class="el-date-picker__editor-wrap" v-clickoutside="handleTimePickClose">
               <el-input
                 ref="input"
-                @focus="timePickerVisible = true"
+                @focus="getSelectRange"
                 :placeholder="t('el.datepicker.selectTime')"
                 :value="visibleTime"
                 size="small"
@@ -38,6 +38,7 @@
                 @change="handleVisibleTimeChange" />
               <time-picker
                 ref="timepicker"
+                :timePickerOptions="timePickerOptions"
                 :time-arrow-control="arrowControl"
                 @pick="handleTimePick"
                 :visible="timePickerVisible"
@@ -126,7 +127,7 @@
           type="text"
           class="el-picker-panel__link-btn"
           @click="changeToNow"
-          v-show="selectionMode !== 'dates'">
+          v-show="selectionMode !== 'dates' && selectableRange.length == 0">
           {{ t('el.datepicker.now') }}
         </el-button>
         <el-button
@@ -142,6 +143,7 @@
 </template>
 
 <script type="text/babel">
+/* eslint-disable */
   import {
     formatDate,
     parseDate,
@@ -158,7 +160,9 @@
     nextMonth,
     changeYearMonthAndClampDate,
     extractDateFormat,
-    extractTimeFormat
+    extractTimeFormat,
+    getTimeHMS,
+    checkIsinRange
   } from '../util';
   import Clickoutside from 'element-ui/src/utils/clickoutside';
   import Locale from 'element-ui/src/mixins/locale';
@@ -175,6 +179,12 @@
     directives: { Clickoutside },
 
     watch: {
+      selectableRange(val) {
+        console.log(val)
+        if (!val || val.length === 0) return;
+        this.resetDateWhileNeedselectable()
+      },
+
       showTime(val) {
         /* istanbul ignore if */
         if (!val) return;
@@ -218,6 +228,54 @@
     },
 
     methods: {
+      // 如果传入参数有对时分秒进行限制的，在时间改动时要考虑填充对应限制时间
+      // 我需要对比如若设置的时间小于了或者大于了限制时间，就对其赋值
+      // 由于在选定日期时会默认给当天的0点，而selectablerange可能会动态修改，需要watch跟踪seletablerange
+      // 还有手动修改时间和年月日的Input也要控制
+      resetDateWhileNeedselectable() {
+        debugger
+        if (this.selectableRange && this.selectableRange.length > 0) {
+          // 传递的是string类型，如12:00:00 - 18:00:00
+          // 若超出可选范围则修正为最小限制时间
+          let h = this.date.getHours()
+          let m = this.date.getMinutes()
+          let s = this.date.getSeconds()
+          let time1, time2, time3, time4, type
+          if (this.selectableRange.length === 1) {
+            time1 = getTimeHMS(this.selectableRange[0][0])
+            time2 = getTimeHMS(this.selectableRange[0][1])
+            type = 1
+          } else if (this.selectableRange.length === 2) {
+            // 传递的是Array
+            time1 = getTimeHMS(this.selectableRange[0][0])
+            time2 = getTimeHMS(this.selectableRange[0][1])
+            time3 = getTimeHMS(this.selectableRange[1][0])
+            time4 = getTimeHMS(this.selectableRange[1][1])
+            type = 2
+          }
+          if (type === 1) {
+            // 限制的最小时间，如果选中的时间比限制范围还低就只能取限制范围最小值，
+            if (!checkIsinRange(time1,time2,{h,m,s})) {
+              this.date.setHours(time1.h)
+              this.date.setMinutes(time1.m)
+              this.date.setSeconds(time1.s)
+              this.emit(this.date, this.showTime);
+            }
+          } else if (type === 2) {
+            if (!checkIsinRange(time1,time2,{h,m,s}) && !checkIsinRange(time3,time4,{h,m,s})) {
+              this.date.setHours(time1.h)
+              this.date.setMinutes(time1.m)
+              this.date.setSeconds(time1.s)
+              this.emit(this.date, this.showTime);
+            }
+          }
+        }
+      },
+      // change Time's SelectRange if focus
+      getSelectRange() {
+        this.timePickerVisible = true;
+        this.timePickerOptions = this.selectableRange || [];
+      },
       proxyTimePickerDataProperties() {
         const format = timeFormat => {this.$refs.timepicker.format = timeFormat;};
         const value = value => {this.$refs.timepicker.value = value;};
@@ -332,10 +390,12 @@
       },
 
       handleDatePick(value) {
+        // debugger
         if (this.selectionMode === 'day') {
           this.date = this.value
             ? modifyDate(this.value, value.getFullYear(), value.getMonth(), value.getDate())
             : modifyWithTimeString(value, this.defaultTime);
+          this.resetDateWhileNeedselectable()
           this.emit(this.date, this.showTime);
         } else if (this.selectionMode === 'week') {
           this.emit(value.date);
@@ -445,6 +505,8 @@
       },
 
       handleVisibleTimeChange(value) {
+        console.log(value)
+        debugger
         const time = parseDate(value, this.timeFormat);
         if (time) {
           this.date = modifyDate(time, this.year, this.month, this.monthDate);
@@ -456,6 +518,7 @@
       },
 
       handleVisibleDateChange(value) {
+        debugger
         const date = parseDate(value, this.dateFormat);
         if (date) {
           if (typeof this.disabledDate === 'function' && this.disabledDate(date)) {
@@ -465,6 +528,7 @@
           this.userInputDate = null;
           this.resetView();
           this.emit(this.date, true);
+          this.resetDateWhileNeedselectable()
         }
       },
 
@@ -500,13 +564,15 @@
         visible: false,
         currentView: 'date',
         disabledDate: '',
+        selectableRange: '',
         firstDayOfWeek: 7,
         showWeekNumber: false,
         timePickerVisible: false,
         format: '',
         arrowControl: false,
         userInputDate: null,
-        userInputTime: null
+        userInputTime: null,
+        timePickerOptions: [] // use this options for time's selectablerange
       };
     },
 

--- a/packages/date-picker/src/panel/time.vue
+++ b/packages/date-picker/src/panel/time.vue
@@ -44,10 +44,19 @@
 
     props: {
       visible: Boolean,
-      timeArrowControl: Boolean
+      timeArrowControl: Boolean,
+      timePickerOptions: Array
     },
 
     watch: {
+      // selectableRange changed while this components get another timePickerOptions
+      timePickerOptions(val) {
+        if (val.length > 0) {
+          this.selectableRange = this.timePickerOptions;
+        } else {
+          this.selectableRange = [];
+        }
+      },
       visible(val) {
         if (val) {
           this.oldValue = this.value;

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -864,7 +864,6 @@ export default {
       };
       updateOptions();
       this.unwatchPickerOptions = this.$watch('pickerOptions', () => updateOptions(), { deep: true });
-
       this.$el.appendChild(this.picker.$el);
       this.picker.resetView && this.picker.resetView();
 

--- a/packages/date-picker/src/util/index.js
+++ b/packages/date-picker/src/util/index.js
@@ -219,6 +219,23 @@ export const limitTimeRange = function(date, ranges, format = 'HH:mm:ss') {
   );
 };
 
+export const getTimeHMS = function(date) {
+  return { h: date.getHours(), m: date.getMinutes(), s: date.getSeconds() };
+};
+/* eslint-disable */
+// eg range = 12:00:00 - 15:00:00 ,check date is in range
+export const checkIsinRange = function(rangeDate1, rangeDate2, date) {
+  debugger
+  let time1 = new Date(`2000-01-01 ${rangeDate1.h}:${rangeDate1.m}:${rangeDate1.s}`).getTime();
+  let time2 = new Date(`2000-01-01 ${rangeDate2.h}:${rangeDate2.m}:${rangeDate2.s}`).getTime();
+  let time = new Date(`2000-01-01 ${date.h}:${date.m}:${date.s}`).getTime();
+  if (time >= time1 && time <= time2) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
 export const timeWithinRange = function(date, selectableRange, format) {
   const limitedDate = limitTimeRange(date, selectableRange, format);
   return limitedDate.getTime() === date.getTime();

--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ if (typeof window !== 'undefined' && window.Vue) {
 }
 
 module.exports = {
-  version: '2.4.11',
+  version: '2.4.23',
   locale: locale.use,
   i18n: locale.i18n,
   install,

--- a/src/index.js
+++ b/src/index.js
@@ -172,7 +172,7 @@ if (typeof window !== 'undefined' && window.Vue) {
 }
 
 module.exports = {
-  version: '2.4.23',
+  version: '2.4.11',
   locale: locale.use,
   i18n: locale.i18n,
   install,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

feat:补充datetimepicker中的selectableRange功能 #11148 #8912 #8979
 - 目的：目前datetimepicker组件不支持selectableRange传递，time-picker中是实际存在的，由于项目中要求需要设置一个1小时后的闹钟功能希望能为大家做点贡献。

 - 实现逻辑：动态修改selectableRange时向time-picker传递

 - 遇到的问题：点击日期，手动修改input会默认设置0时，导致越过selectableRange的限制

 - 解决办法：watch监听selectableRange随时矫正this.date为限制时间的最小值，以上都建立在selectableRange存在的条件下

 - 在线测试环境：
    - selectableRange为单区间时https://jsfiddle.net/eeeeeeason/dqnhatps/8/
    - selectableRange为多区间时https://jsfiddle.net/eeeeeeason/dqnhatps/5/

 - 大佬说要写单元测试，我真不会写。。。刚刚学习开发

 - 第一次填...不会填，期间学到很多东西，感谢各位一直的默默奉献，@wacky6给了我一些指导才能解决问题，有误的地方请指正，我会继续无私奉献！！！！！。谢谢