### PR TITLE
ElCollapse: fix: display error when there are multiple lines of text

### DIFF
--- a/packages/theme-chalk/src/collapse.scss
+++ b/packages/theme-chalk/src/collapse.scss
@@ -10,8 +10,7 @@
   @include e(header) {
     display: flex;
     align-items: center;
-    height: $--collapse-header-height;
-    line-height: $--collapse-header-height;
+    min-height: $--collapse-header-height;
     background-color: $--collapse-header-fill;
     color: $--collapse-header-color;
     cursor: pointer;


### PR DESCRIPTION
check [https://jsfiddle.net/y4m3p5zn/](https://jsfiddle.net/y4m3p5zn/).

ElCollapse's title display error when there are multiple lines of text
当标题很长时，甚至占用几行，显示就会有问题。见上面的链接。
