### PR TITLE
Menu: fix subMenu onfocus bug

### DIFF
--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -178,7 +178,10 @@
         }
         this.dispatch('ElMenu', 'submenu-click', this);
       },
-      handleMouseenter() {
+      handleMouseenter(event) {
+        if (!(!!window.ActiveXObject || 'ActiveXObject' in window) && event.type === 'focus' && !event.relatedTarget) {
+          return;
+        }
         const { rootMenu, disabled } = this;
         if (
           (rootMenu.menuTrigger === 'click' && rootMenu.mode === 'horizontal') ||

--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -275,7 +275,8 @@
             v-show={opened}
             class={[`el-menu--${mode}`, popperClass]}
             on-mouseenter={this.handleMouseenter}
-            on-mouseleave={this.handleMouseleave}>
+            on-mouseleave={this.handleMouseleave}
+            on-focus={this.handleMouseenter}>
             <ul
               role="menu"
               class={['el-menu el-menu--popup', `el-menu--popup-${currentPlacement}`]}
@@ -316,6 +317,7 @@
           aria-expanded={opened}
           on-mouseenter={this.handleMouseenter}
           on-mouseleave={this.handleMouseleave}
+          on-focus={this.handleMouseenter}
         >
           <div
             class="el-submenu__title"


### PR DESCRIPTION
menu添加onfocus事件会引起整个页面失去焦点又获得焦点时，使menu-item的子选项展开，影响用户体验
