### PR TITLE
menu: submenu component add blur event (#13913)

### DIFF
--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -273,7 +273,8 @@
             class={[`el-menu--${mode}`, popperClass]}
             on-mouseenter={this.handleMouseenter}
             on-mouseleave={this.handleMouseleave}
-            on-focus={this.handleMouseenter}>
+            on-focus={this.handleMouseenter}
+            on-blur={this.handleMouseleave}>
             <ul
               role="menu"
               class={['el-menu el-menu--popup', `el-menu--popup-${currentPlacement}`]}
@@ -315,6 +316,7 @@
           on-mouseenter={this.handleMouseenter}
           on-mouseleave={this.handleMouseleave}
           on-focus={this.handleMouseenter}
+          on-blur={this.handleMouseleave}
         >
           <div
             class="el-submenu__title"


### PR DESCRIPTION
menu组件的submenu子组件在focus时触发mouseenter的方法，但是并没有在blur时触发mouseleave的方法，导致出现Bug,详见Issues(#13913 )
