### PR TITLE
Table: clearSort support custom sort method(#13873)

### DIFF
--- a/packages/table/src/util.js
+++ b/packages/table/src/util.js
@@ -18,7 +18,7 @@ const isObject = function(obj) {
 };
 
 export const orderBy = function(array, sortKey, reverse, sortMethod, sortBy) {
-  if (!sortKey && !sortMethod && (!sortBy || Array.isArray(sortBy) && !sortBy.length)) {
+  if (!sortKey && (!sortBy || Array.isArray(sortBy) && !sortBy.length)) {
     return array;
   }
   if (typeof reverse === 'string') {


### PR DESCRIPTION
fix #13873.
While table-column has a custom sort method, clearSort() doesn’t assign state._data(the original table data)  to states.data, so I updated the if condition.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
