### PR TITLE
Form: custom messages for form validator

### DIFF
--- a/packages/form/src/form-item.vue
+++ b/packages/form/src/form-item.vue
@@ -39,6 +39,7 @@
   import emitter from 'element-ui/src/mixins/emitter';
   import objectAssign from 'element-ui/src/utils/merge';
   import { noop, getPropByPath } from 'element-ui/src/utils/util';
+  import validatorMessages from './validatorMessages';
 
   export default {
     name: 'ElFormItem',
@@ -190,6 +191,7 @@
         descriptor[this.prop] = rules;
 
         const validator = new AsyncValidator(descriptor);
+        validator.messages(validatorMessages.fetch());
         const model = {};
 
         model[this.prop] = this.fieldValue;

--- a/packages/form/src/validatorMessages.js
+++ b/packages/form/src/validatorMessages.js
@@ -1,0 +1,10 @@
+let messages;
+
+export default {
+  fetch() {
+    return messages;
+  },
+  set(replacement) {
+    messages = replacement;
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ import Breadcrumb from '../packages/breadcrumb/index.js';
 import BreadcrumbItem from '../packages/breadcrumb-item/index.js';
 import Form from '../packages/form/index.js';
 import FormItem from '../packages/form-item/index.js';
+import validatorMessages from '../packages/form/src/validatorMessages';
 import Tabs from '../packages/tabs/index.js';
 import TabPane from '../packages/tab-pane/index.js';
 import Tag from '../packages/tag/index.js';
@@ -144,6 +145,7 @@ const components = [
 const install = function(Vue, opts = {}) {
   locale.use(opts.locale);
   locale.i18n(opts.i18n);
+  validatorMessages.set(opts.validatorMessages);
 
   components.forEach(component => {
     Vue.component(component.name, component);


### PR DESCRIPTION
Set custom error messages globally for Element UI forms:
```javascript
const messages =  {required: 'Please enter %s'}
Vue.use(Element, {validatorMessages: messages)
```

I18n compatible error messages can be achived with messages like this:

```javascript
import { t } from 'element-ui/src/locale';
const fieldLabel = field => t(`fields.${field}`) || field;

const message = (field, errorType, op = {}) => {
  let options = {...op, f: fieldLabel(field)};
  let ret = t(`errors.${field}.${errorType}`, options);
  if (ret) return ret;

  return t(`errors.${errorType}`, options);
};
export default {
  default(field) {
    return message(field, 'default');
  },
  required(field) {
    return message(field, 'required');
  }
}
```