### PR TITLE
DatePicker: fix reference when type changed

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -97,7 +97,7 @@ const NewPopper = {
   },
   methods: Popper.methods,
   data() {
-    return merge({ visibleArrow: true }, Popper.data);
+    return merge({ visibleArrow: true, referenceElm: null }, Popper.data);
   },
   beforeDestroy: Popper.beforeDestroy
 };
@@ -436,14 +436,9 @@ export default {
       return this.type.indexOf('range') > -1;
     },
 
-    reference() {
-      const reference = this.$refs.reference;
-      return reference.$el || reference;
-    },
-
     refInput() {
-      if (this.reference) {
-        return [].slice.call(this.reference.querySelectorAll('input'));
+      if (this.referenceElm) {
+        return [].slice.call(this.referenceElm.querySelectorAll('input'));
       }
       return [];
     },
@@ -809,7 +804,7 @@ export default {
       this.picker.defaultTime = this.defaultTime;
       this.picker.popperClass = this.popperClass;
       this.popperElm = this.picker.$el;
-      this.picker.width = this.reference.getBoundingClientRect().width;
+      this.picker.width = this.referenceElm.getBoundingClientRect().width;
       this.picker.showTime = this.type === 'datetime' || this.type === 'datetimerange';
       this.picker.selectionMode = this.selectionMode;
       this.picker.unlinkPanels = this.unlinkPanels;
@@ -906,7 +901,19 @@ export default {
       } else {
         return true;
       }
+    },
+
+    updateRef() {
+      this.referenceElm = this.$refs.reference.$el || this.$refs.reference
     }
+  },
+
+  mounted() {
+    this.updateRef();
+  },
+
+  updated() {
+    this.updateRef();    
   }
 };
 </script>


### PR DESCRIPTION
1. reference是计算属性，在type变化时，不能响应$refs的变化
2. vue-popper会缓存referenceElm的值，即使reference响应了变化，popper依旧会使用上一次的referenceElm进行定位

jsfiddle: [popper位置异常](https://jsfiddle.net/n3t907av/4/)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
