### PR TITLE
Slider: fix max too large the browser crash bug

### DIFF
--- a/packages/slider/src/main.vue
+++ b/packages/slider/src/main.vue
@@ -45,13 +45,14 @@
         ref="button2"
         v-if="range">
       </slider-button>
-      <div
-        class="el-slider__stop"
-        v-for="(item, key) in stops"
-        :key="key"
-        :style="vertical ? { 'bottom': item + '%' } : { 'left': item + '%' }"
-        v-if="showStops">
-      </div>
+      <template v-if="showStops">
+        <div
+          class="el-slider__stop"
+          v-for="(item, key) in stops"
+          :key="key"
+          :style="vertical ? { 'bottom': item + '%' } : { 'left': item + '%' }">
+        </div>
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
if the value of max is too much like 10000000 the browser will crash because html has too much line `<!---->` (if the value of `v-if` is false , will leave `<!---->`, because of `v-for`, there are too much `<!---->`) , let max to outer will reduce the number of `<!---->` to 1

- closes #14132
