### PR TITLE
Card: Add border-width scss var, allowing disabling of card borders.

### DIFF
--- a/packages/theme-chalk/src/card.scss
+++ b/packages/theme-chalk/src/card.scss
@@ -3,7 +3,7 @@
 
 @include b(card) {
   border-radius: $--card-border-radius;
-  border: 1px solid $--card-border-color;
+  border: $--card-border-width solid $--card-border-color;
   background-color: $--color-white;
   overflow: hidden;
   color: $--color-text-primary;
@@ -22,7 +22,7 @@
 
   @include e(header) {
     padding: #{$--card-padding - 2 $--card-padding};
-    border-bottom: 1px solid $--card-border-color;
+    border-bottom: $--card-border-width solid $--card-border-color;
     box-sizing: border-box;
   }
 

--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -571,6 +571,7 @@ $--badge-size: 18px !default;
 /* Card
 --------------------------*/
 $--card-border-color: $--border-color-lighter !default;
+$--card-border-width: 1px !default;
 $--card-border-radius: 4px !default;
 $--card-padding: 20px !default;
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

------

Defining `$--card-border-width` scss var.  This is defaulted to 1px as before, but means we can now change or crucially disable card borders via extending element scss
