### PR TITLE
fix input issue when type is `textarea`

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -149,7 +149,10 @@
     },
     watch: {
       suggestionVisible(val) {
-        this.broadcast('ElAutocompleteSuggestions', 'visible', [val, this.$refs.input.$refs.input.offsetWidth]);
+        let input = this.$refs.input.$refs.input || this.$refs.input.$refs.textarea;
+        if (input) {
+          this.broadcast('ElAutocompleteSuggestions', 'visible', [val, input.offsetWidth]);
+        }
       }
     },
     methods: {
@@ -248,7 +251,8 @@
           suggestion.scrollTop -= highlightItem.scrollHeight;
         }
         this.highlightedIndex = index;
-        this.$el.querySelector('.el-input__inner').setAttribute('aria-activedescendant', `${this.id}-item-${this.highlightedIndex}`);
+        let $input = (this.$el.querySelector('.el-input__inner') || this.$el.querySelector('.el-textarea__inner'));
+        $input.setAttribute('aria-activedescendant', `${this.id}-item-${this.highlightedIndex}`);
       }
     },
     mounted() {
@@ -256,7 +260,7 @@
       this.$on('item-click', item => {
         this.select(item);
       });
-      let $input = this.$el.querySelector('.el-input__inner');
+      let $input = (this.$el.querySelector('.el-input__inner') || this.$el.querySelector('.el-textarea__inner'));
       $input.setAttribute('role', 'textbox');
       $input.setAttribute('aria-autocomplete', 'list');
       $input.setAttribute('aria-controls', 'id');

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -149,9 +149,9 @@
     },
     watch: {
       suggestionVisible(val) {
-        let input = this.$refs.input.$refs.input || this.$refs.input.$refs.textarea;
-        if (input) {
-          this.broadcast('ElAutocompleteSuggestions', 'visible', [val, input.offsetWidth]);
+        let $input = this.getInput();
+        if ($input) {
+          this.broadcast('ElAutocompleteSuggestions', 'visible', [val, $input.offsetWidth]);
         }
       }
     },
@@ -251,8 +251,11 @@
           suggestion.scrollTop -= highlightItem.scrollHeight;
         }
         this.highlightedIndex = index;
-        let $input = (this.$el.querySelector('.el-input__inner') || this.$el.querySelector('.el-textarea__inner'));
+        let $input = this.getInput();
         $input.setAttribute('aria-activedescendant', `${this.id}-item-${this.highlightedIndex}`);
+      },
+      getInput() {
+        return this.$refs.input.$refs.input || this.$refs.input.$refs.textarea;
       }
     },
     mounted() {
@@ -260,7 +263,7 @@
       this.$on('item-click', item => {
         this.select(item);
       });
-      let $input = (this.$el.querySelector('.el-input__inner') || this.$el.querySelector('.el-textarea__inner'));
+      let $input = this.getInput();
       $input.setAttribute('role', 'textbox');
       $input.setAttribute('aria-autocomplete', 'list');
       $input.setAttribute('aria-controls', 'id');

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -255,7 +255,7 @@
         $input.setAttribute('aria-activedescendant', `${this.id}-item-${this.highlightedIndex}`);
       },
       getInput() {
-        return this.$refs.input.$refs.input || this.$refs.input.$refs.textarea;
+        return this.$refs.input.getInput();
       }
     },
     mounted() {

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -286,7 +286,10 @@
 
         // set input's value, in case parent refuses the change
         // see: https://github.com/ElemeFE/element/issues/12850
-        this.$nextTick(() => { this.$refs.input.value = this.value; });
+        this.$nextTick(() => {
+          let input = this.$refs.input || this.$refs.textarea;
+          input.value = this.value;
+        });
       },
       handleChange(event) {
         this.$emit('change', event.target.value);

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -221,10 +221,10 @@
 
     methods: {
       focus() {
-        (this.$refs.input || this.$refs.textarea).focus();
+        this.getInput().focus();
       },
       blur() {
-        (this.$refs.input || this.$refs.textarea).blur();
+        this.getInput().blur();
       },
       getMigratingConfig() {
         return {
@@ -245,7 +245,7 @@
         }
       },
       select() {
-        (this.$refs.input || this.$refs.textarea).select();
+        this.getInput().select();
       },
       resizeTextarea() {
         if (this.$isServer) return;
@@ -287,7 +287,7 @@
         // set input's value, in case parent refuses the change
         // see: https://github.com/ElemeFE/element/issues/12850
         this.$nextTick(() => {
-          let input = this.$refs.input || this.$refs.textarea;
+          let input = this.getInput();
           input.value = this.value;
         });
       },
@@ -325,6 +325,9 @@
         this.$emit('input', '');
         this.$emit('change', '');
         this.$emit('clear');
+      },
+      getInput() {
+        return this.$refs.input || this.$refs.textarea;
       }
     },
 


### PR DESCRIPTION
close #13803 

also fix el-autocomplete when type is `textarea`

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
