### PR TITLE
Table: make toggleAllSelection method an instance method(#14075)

### DIFF
--- a/packages/table/src/table-store.js
+++ b/packages/table/src/table-store.js
@@ -112,6 +112,35 @@ const TableStore = function(table, initialState = {}) {
     selectOnIndeterminate: false
   };
 
+  this._toggleAllSelection = debounce(10, function(states) {
+    const data = states.data || [];
+    if (data.length === 0) return;
+    const selection = this.states.selection;
+    // when only some rows are selected (but not all), select or deselect all of them
+    // depending on the value of selectOnIndeterminate
+    const value = states.selectOnIndeterminate
+      ? !states.isAllSelected
+      : !(states.isAllSelected || selection.length);
+    let selectionChanged = false;
+    data.forEach((item, index) => {
+      if (states.selectable) {
+        if (states.selectable.call(null, item, index) && toggleRowSelection(states, item, value)) {
+          selectionChanged = true;
+        }
+      } else {
+        if (toggleRowSelection(states, item, value)) {
+          selectionChanged = true;
+        }
+      }
+    });
+    const table = this.table;
+    if (selectionChanged) {
+      table.$emit('selection-change', selection ? selection.slice() : []);
+    }
+    table.$emit('select-all', selection);
+    states.isAllSelected = value;
+  });
+
   for (let prop in initialState) {
     if (initialState.hasOwnProperty(prop) && this.states.hasOwnProperty(prop)) {
       this.states[prop] = initialState[prop];
@@ -347,36 +376,9 @@ TableStore.prototype.mutations = {
     this.updateAllSelected();
   },
 
-  toggleAllSelection: debounce(10, function(states) {
-    const data = states.data || [];
-    if (data.length === 0) return;
-    const selection = this.states.selection;
-    // when only some rows are selected (but not all), select or deselect all of them
-    // depending on the value of selectOnIndeterminate
-    const value = states.selectOnIndeterminate
-      ? !states.isAllSelected
-      : !(states.isAllSelected || selection.length);
-    let selectionChanged = false;
-
-    data.forEach((item, index) => {
-      if (states.selectable) {
-        if (states.selectable.call(null, item, index) && toggleRowSelection(states, item, value)) {
-          selectionChanged = true;
-        }
-      } else {
-        if (toggleRowSelection(states, item, value)) {
-          selectionChanged = true;
-        }
-      }
-    });
-
-    const table = this.table;
-    if (selectionChanged) {
-      table.$emit('selection-change', selection ? selection.slice() : []);
-    }
-    table.$emit('select-all', selection);
-    states.isAllSelected = value;
-  })
+  toggleAllSelection(state) {
+    this._toggleAllSelection(state);
+  }
 };
 
 const doFlattenColumns = (columns) => {


### PR DESCRIPTION
fix #14075 .
All instances of TableStore share the same toggleAllSelection method in TableStore.prototype.mutations.Since the toggleAllSelection method is a debounce function which create a closure, all TableStore's instances share the same Lexical scope while they call the toggleAllSelection method. The time interval between two tables call `toggleAllSelection` is less than the debouncing delay(10), so the first call doesn't work.

This commit make the actual toggleAllSelection method an instance method.


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
