### PR TITLE
input-number: remove unnecessary parseFloat

### DIFF
--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -174,7 +174,7 @@
     methods: {
       toPrecision(num, precision) {
         if (precision === undefined) precision = this.numPrecision;
-        return parseFloat(parseFloat(Number(num).toFixed(precision)));
+        return parseFloat(Number(num).toFixed(precision));
       },
       getPrecision(value) {
         if (value === undefined) return 0;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

#### JsFiddle Demo for difference: [https://jsfiddle.net/4dpbhs5z/5/](https://jsfiddle.net/4dpbhs5z/5/)

There is nothing different between two parseFloat and one parseFloat.

![image](https://user-images.githubusercontent.com/14243906/51518470-fc475780-1e58-11e9-96af-6ce898c85ba9.png)


