### PR TITLE
Autocomplete: Add custom key

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -42,7 +42,7 @@
       :id="id">
       <li
         v-for="(item, index) in suggestions"
-        :key="index"
+        :key="customKey ? item[customKey] : index"
         :class="{'highlighted': highlightedIndex === index}"
         @click="select(item)"
         :id="`${id}-item-${index}`"
@@ -126,7 +126,8 @@
       popperAppendToBody: {
         type: Boolean,
         default: true
-      }
+      },
+      customKey: String,
     },
     data() {
       return {

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -127,7 +127,7 @@
         type: Boolean,
         default: true
       },
-      customKey: String,
+      customKey: String
     },
     data() {
       return {


### PR DESCRIPTION
Added custom key prop for `li` tag in autocomplete input. Index isn't a good key when data is dynamic and changes often. Vue would often lose track of the node and mix component state, resulting in unwanted behaviour. I propose a `customKey` prop that lets you specify the key yourself with a fallback to index when non is provided.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
