### PR TITLE
DatePicker: add current month & current year highlight style

### DIFF
--- a/packages/theme-chalk/src/date-picker/month-table.scss
+++ b/packages/theme-chalk/src/date-picker/month-table.scss
@@ -10,6 +10,13 @@
     padding: 20px 3px;
     cursor: pointer;
 
+    &.today {
+      .cell {
+        color: $--color-primary;
+        font-weight: bold;
+      }
+    }
+
     &.disabled .cell {
       background-color: $--background-color-base;
       cursor: not-allowed;

--- a/packages/theme-chalk/src/date-picker/year-table.scss
+++ b/packages/theme-chalk/src/date-picker/year-table.scss
@@ -14,6 +14,13 @@
     padding: 20px 3px;
     cursor: pointer;
 
+    &.today {
+      .cell {
+        color: $--color-primary;
+        font-weight: bold;
+      }
+    }
+
     &.disabled .cell {
       background-color: $--background-color-base;
       cursor: not-allowed;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

When `el-date-picker` type is `month` or `year`,  current month or this year has not to highlight. The pull request could be fixed
