### PR TITLE
Build: Fix UMD bundle error used in node env

### DIFF
--- a/build/webpack.conf.js
+++ b/build/webpack.conf.js
@@ -18,7 +18,8 @@ module.exports = {
     libraryTarget: 'umd',
     libraryExport: 'default',
     library: 'ELEMENT',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   resolve: {
     extensions: ['.js', '.vue', '.json'],


### PR DESCRIPTION
Webpack UMD modules are broken currently: [webpack/webpack#6525](https://github.com/webpack/webpack/issues/6525)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
