### PR TITLE
ElPopover: Close popper on deactivate to handle keep-alive properly

### DIFF
--- a/packages/popover/src/main.vue
+++ b/packages/popover/src/main.vue
@@ -129,6 +129,7 @@ export default {
 
   deactivated() {
     this.cleanup();
+    this.doClose();
   },
 
   methods: {


### PR DESCRIPTION
When using keep-alive with vue-router, if you have a hover popover on the button that takes you to a new route, if the popover is showing when you click the button, it remains visible even after the new page is shown, and the user has to move the pointer over the popover and then out again to make it go away.

Please see attached video:

[ElPopover.mp4.zip](https://github.com/ElemeFE/element/files/2806295/ElPopover.mp4.zip)

The fix for this is to call doClose() in the deactivated() method, to ensure the popover is not left open.

Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.
