### PR TITLE
Autocomplete: prop to highlight first item

### DIFF
--- a/examples/components/search.vue
+++ b/examples/components/search.vue
@@ -36,81 +36,81 @@
 </template>
 
 <style>
-.algolia-search {
-  width: 450px !important;
+  .algolia-search {
+    width: 450px !important;
+  
+    &.is-empty {
+      .el-autocomplete-suggestion__list {
+        padding-bottom: 0;
+      }
+    }
 
-  &.is-empty {
     .el-autocomplete-suggestion__list {
-      padding-bottom: 0;
+      position: static !important;
+      padding-bottom: 28px;
     }
-  }
 
-  .el-autocomplete-suggestion__list {
-    position: static !important;
-    padding-bottom: 28px;
-  }
-
-  li {
-    border-bottom: solid 1px #ebebeb;
-
-    &:last-child {
-      border-bottom: none;
+    li {
+      border-bottom: solid 1px #ebebeb;
+      
+      &:last-child {
+         border-bottom: none;
+       }
     }
-  }
-
-  .algolia-highlight {
-    color: #409eff;
-    font-weight: bold;
-  }
-
-  .algolia-search-title {
-    font-size: 14px;
-    margin: 6px 0;
-    line-height: 1.8;
-  }
-
-  .algolia-search-separator {
-    padding: 0 6px;
-  }
-
-  .algolia-search-content {
-    font-size: 12px;
-    margin: 6px 0;
-    line-height: 2.4;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .algolia-search-link {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    padding-right: 20px;
-    background-color: #e4e7ed;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    box-sizing: border-box;
-    text-align: right;
-
-    &:hover {
+    
+    .algolia-highlight {
+      color: #409EFF;
+      font-weight: bold;
+    }
+    
+    .algolia-search-title {
+      font-size: 14px;
+      margin: 6px 0;
+      line-height: 1.8;
+    }
+    
+    .algolia-search-separator {
+      padding: 0 6px;
+    }
+    
+    .algolia-search-content {
+      font-size: 12px;
+      margin: 6px 0;
+      line-height: 2.4;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    
+    .algolia-search-link {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      padding-right: 20px;
       background-color: #e4e7ed;
-    }
+      border-bottom-left-radius: 4px;
+      border-bottom-right-radius: 4px;
+      box-sizing: border-box;
+      text-align: right;
 
-    img {
-      display: inline-block;
-      height: 17px;
-      margin-top: 10px;
+      &:hover {
+         background-color: #e4e7ed;
+       }
+    
+      img {
+        display: inline-block;
+        height: 17px;
+        margin-top: 10px;
+      }
+    }
+  
+    .algolia-search-empty {
+      margin: 5px 0;
+      text-align: center;
+      color: #999;
     }
   }
-
-  .algolia-search-empty {
-    margin: 5px 0;
-    text-align: center;
-    color: #999;
-  }
-}
 </style>
 
 <script>

--- a/examples/components/search.vue
+++ b/examples/components/search.vue
@@ -6,7 +6,8 @@
     :fetch-suggestions="querySearch"
     :placeholder="placeholder"
     :trigger-on-focus="false"
-    @select="handleSelect">
+    @select="handleSelect"
+    highlight-first-item>
     <template slot-scope="props">
       <p class="algolia-search-title" v-if="props.item.title">
         <span v-html="props.item.highlightedCompo"></span>

--- a/examples/components/search.vue
+++ b/examples/components/search.vue
@@ -35,81 +35,81 @@
 </template>
 
 <style>
-  .algolia-search {
-    width: 450px !important;
-  
-    &.is-empty {
-      .el-autocomplete-suggestion__list {
-        padding-bottom: 0;
-      }
-    }
+.algolia-search {
+  width: 450px !important;
 
+  &.is-empty {
     .el-autocomplete-suggestion__list {
-      position: static !important;
-      padding-bottom: 28px;
-    }
-
-    li {
-      border-bottom: solid 1px #ebebeb;
-      
-      &:last-child {
-         border-bottom: none;
-       }
-    }
-    
-    .algolia-highlight {
-      color: #409EFF;
-      font-weight: bold;
-    }
-    
-    .algolia-search-title {
-      font-size: 14px;
-      margin: 6px 0;
-      line-height: 1.8;
-    }
-    
-    .algolia-search-separator {
-      padding: 0 6px;
-    }
-    
-    .algolia-search-content {
-      font-size: 12px;
-      margin: 6px 0;
-      line-height: 2.4;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    
-    .algolia-search-link {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      padding-right: 20px;
-      background-color: #e4e7ed;
-      border-bottom-left-radius: 4px;
-      border-bottom-right-radius: 4px;
-      box-sizing: border-box;
-      text-align: right;
-
-      &:hover {
-         background-color: #e4e7ed;
-       }
-    
-      img {
-        display: inline-block;
-        height: 17px;
-        margin-top: 10px;
-      }
-    }
-  
-    .algolia-search-empty {
-      margin: 5px 0;
-      text-align: center;
-      color: #999;
+      padding-bottom: 0;
     }
   }
+
+  .el-autocomplete-suggestion__list {
+    position: static !important;
+    padding-bottom: 28px;
+  }
+
+  li {
+    border-bottom: solid 1px #ebebeb;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+
+  .algolia-highlight {
+    color: #409eff;
+    font-weight: bold;
+  }
+
+  .algolia-search-title {
+    font-size: 14px;
+    margin: 6px 0;
+    line-height: 1.8;
+  }
+
+  .algolia-search-separator {
+    padding: 0 6px;
+  }
+
+  .algolia-search-content {
+    font-size: 12px;
+    margin: 6px 0;
+    line-height: 2.4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .algolia-search-link {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    padding-right: 20px;
+    background-color: #e4e7ed;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    box-sizing: border-box;
+    text-align: right;
+
+    &:hover {
+      background-color: #e4e7ed;
+    }
+
+    img {
+      display: inline-block;
+      height: 17px;
+      margin-top: 10px;
+    }
+  }
+
+  .algolia-search-empty {
+    margin: 5px 0;
+    text-align: center;
+    color: #999;
+  }
+}
 </style>
 
 <script>

--- a/examples/docs/en-US/input.md
+++ b/examples/docs/en-US/input.md
@@ -716,6 +716,7 @@ Attribute | Description | Type | Options | Default
 | suffix-icon | suffix icon class | string | — | — |
 | hide-loading | whether to hide the loading icon in remote search | boolean | — | false |
 | popper-append-to-body | whether to append the dropdown to body. If the positioning of the dropdown is wrong, you can try to set this prop to false | boolean | - | true |
+| highlight-first-item | whether to highlight first item in remote search suggestions by default | boolean | — | false |
 
 ### Autocomplete Slots
 

--- a/examples/docs/es/input.md
+++ b/examples/docs/es/input.md
@@ -705,6 +705,7 @@ Búsqueda de datos desde el servidor.
 | hide-loading          | si se debe ocultar el icono de loading en la búsqueda remota                                                                                       | boolean                         | —                                                              | false        |
 | popper-append-to-body | si añadir el desplegable al cuerpo. Si la posición del menú desplegable es incorrecta, puede intentar establecer este prop a false                 | boolean                         | -                                                              | true         |
 | validate-event        | si se debe lanzar la validación de formulario                                                                                                                 | boolean                         | -                                                   | true         |
+| highlight-first-item | si se debe resaltar el primer elemento en las sugerencias de búsqueda remota de forma predeterminada                 | boolean                         | -                                                              | false         |
 
 ### Autocomplete Slots
 

--- a/examples/docs/zh-CN/input.md
+++ b/examples/docs/zh-CN/input.md
@@ -867,6 +867,7 @@ export default {
 | suffix-icon | 输入框尾部图标 | string | — | — |
 | hide-loading | 是否隐藏远程加载时的加载图标 | boolean | — | false |
 | popper-append-to-body | 是否将下拉列表插入至 body 元素。在下拉列表的定位出现问题时，可将该属性设置为 false | boolean | - | true |
+| highlight-first-item | 是否默认突出显示远程搜索建议中的第一项 | boolean | — | false |
 
 ### Autocomplete Slots
 | name | 说明 |

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -137,7 +137,7 @@
         activated: false,
         suggestions: [],
         loading: false,
-        highlightedIndex: this.getHighlightedItem(),
+        highlightedIndex: this.getHighlightedIndex(),
         suggestionDisabled: false
       };
     },
@@ -229,7 +229,7 @@
         this.$emit('select', item);
         this.$nextTick(_ => {
           this.suggestions = [];
-          this.highlightedIndex = this.getHighlightedItem();
+          this.highlightedIndex = this.getHighlightedIndex();
         });
       },
       highlight(index) {
@@ -261,7 +261,7 @@
       getInput() {
         return this.$refs.input.getInput();
       },
-      getHighlightedItem() {
+      getHighlightedIndex() {
         return this.highlightFirstItem ? 0 : -1;
       }
     },

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -137,7 +137,7 @@
         activated: false,
         suggestions: [],
         loading: false,
-        highlightedIndex: this.highlightFirstItem ? 0 : -1,
+        highlightedIndex: this.getHighlightedItem(),
         suggestionDisabled: false
       };
     },
@@ -229,7 +229,7 @@
         this.$emit('select', item);
         this.$nextTick(_ => {
           this.suggestions = [];
-          this.highlightedIndex = -1;
+          this.highlightedIndex = this.getHighlightedItem();
         });
       },
       highlight(index) {
@@ -260,6 +260,9 @@
       },
       getInput() {
         return this.$refs.input.getInput();
+      },
+      getHighlightedItem() {
+        return this.highlightFirstItem ? 0 : -1;
       }
     },
     mounted() {

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -126,6 +126,10 @@
       popperAppendToBody: {
         type: Boolean,
         default: true
+      },
+      highlightFirstItem: {
+        type: Boolean,
+        default: false
       }
     },
     data() {
@@ -133,7 +137,7 @@
         activated: false,
         suggestions: [],
         loading: false,
-        highlightedIndex: -1,
+        highlightedIndex: this.highlightFirstItem ? 0 : -1,
         suggestionDisabled: false
       };
     },

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -137,7 +137,7 @@
         activated: false,
         suggestions: [],
         loading: false,
-        highlightedIndex: this.getHighlightedIndex(),
+        highlightedIndex: -1,
         suggestionDisabled: false
       };
     },
@@ -180,6 +180,7 @@
           }
           if (Array.isArray(suggestions)) {
             this.suggestions = suggestions;
+            this.highlightedIndex = this.highlightFirstItem ? 0 : -1;
           } else {
             console.error('[Element Error][Autocomplete]autocomplete suggestions must be an array');
           }
@@ -229,7 +230,7 @@
         this.$emit('select', item);
         this.$nextTick(_ => {
           this.suggestions = [];
-          this.highlightedIndex = this.getHighlightedIndex();
+          this.highlightedIndex = -1;
         });
       },
       highlight(index) {
@@ -260,9 +261,6 @@
       },
       getInput() {
         return this.$refs.input.getInput();
-      },
-      getHighlightedIndex() {
-        return this.highlightFirstItem ? 0 : -1;
       }
     },
     mounted() {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.


This PR adds a prop to enable a user to have the first item highlighted by default when using remote search.

I have also applied this to the Algolia search component in the header for quick demoing, and because I feel this is a speedier approach for people navigating the docs. Could be removed though.

This addresses/ fixes this issue
https://github.com/ElemeFE/element/issues/14270