### PR TITLE
chore: import version from package.json

### DIFF
--- a/build/webpack.conf.js
+++ b/build/webpack.conf.js
@@ -35,7 +35,7 @@ module.exports = {
           output: {
             comments: false
           }
-        },
+        }
       })
     ]
   },

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ import Timeline from '../packages/timeline/index.js';
 import TimelineItem from '../packages/timeline-item/index.js';
 import locale from 'element-ui/src/locale';
 import CollapseTransition from 'element-ui/src/transitions/collapse-transition';
+import { version } from '../package.json';
 
 const components = [
   Pagination,
@@ -176,7 +177,7 @@ if (typeof window !== 'undefined' && window.Vue) {
 }
 
 export default {
-  version: '2.5.4',
+  version,
   locale: locale.use,
   i18n: locale.i18n,
   install,


### PR DESCRIPTION
- Synchronize version from `package.json` instead of updating manually.

- Changed in `build/webpack.conf.js` because of eslint problem.

P.S. Why not trying `git hooks` before commit?