### PR TITLE
Tree: Empty-text tips are different from tables

### DIFF
--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -22,7 +22,7 @@
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
-    color: mix($--color-primary, rgb(158, 68, 0), 50%);
+    color: $--color-text-secondary;
   }
 
   @include e(drop-indicator) {


### PR DESCRIPTION
There is a `color` difference between the tree and the table empty-text.And I think use `$--color-text-secondary` is  more sense.

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
