### PR TITLE
input: add is-uncontrolled attribute

### DIFF
--- a/examples/docs/en-US/input.md
+++ b/examples/docs/en-US/input.md
@@ -143,6 +143,13 @@
   }
 </style>
 
+:::warning
+**v-model modifiers are discouraged.**\
+`is-uncontrolled` attribute must be set to use v-model modifiers. This will put Input into uncontrolled mode. Otherwise, it always shows Vue data model's value.
+
+Please note that support for v-model modifiers may be removed in future versions.
+:::
+
 ## Input
 
 Input data using mouse or keyboard.

--- a/examples/docs/es/input.md
+++ b/examples/docs/es/input.md
@@ -47,7 +47,7 @@
       querySearchAsync(queryString, cb) {
         var links = this.links;
         var results = queryString ? links.filter(this.createStateFilter(queryString)) : links;
-    
+
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {
           cb(results);
@@ -112,11 +112,11 @@
         font-size: 14px;
         color: #8492a6;
       }
-    
+
       .el-col:not(:last-child) {
         border-right: 1px solid rgba(224,230,237,0.50);
       }
-    
+
       .el-autocomplete {
         text-align: left;
       }
@@ -141,6 +141,13 @@
     }
   }
 </style>
+
+:::warning
+**v-model modifiers are discouraged.**\
+`is-uncontrolled` attribute must be set to use v-model modifiers. This will put Input into uncontrolled mode. Otherwise, it always shows Vue data model's value.
+
+Please note that support for v-model modifiers may be removed in future versions.
+:::
 
 ## Input
 

--- a/examples/docs/fr-FR/input.md
+++ b/examples/docs/fr-FR/input.md
@@ -143,6 +143,13 @@
   }
 </style>
 
+:::warning
+**v-model modifiers are discouraged.**\
+`is-uncontrolled` attribute must be set to use v-model modifiers. This will put Input into uncontrolled mode. Otherwise, it always shows Vue data model's value.
+
+Please note that support for v-model modifiers may be removed in future versions.
+:::
+
 ## Input
 
 Le champs d'input de base.

--- a/examples/docs/zh-CN/input.md
+++ b/examples/docs/zh-CN/input.md
@@ -180,6 +180,13 @@
   }
 </style>
 
+:::warning
+**不建议使用 v-model 修饰符**。\
+如需使用，必须指定 `is-uncontrolled` 属性。这会让组件处于非受控状态，否则组件总会显示 Vue 数据模型的值。
+
+请注意，将来版本可能会移除对修饰符支持。
+:::
+
 ## Input 输入框
 
 通过鼠标或键盘输入字符
@@ -868,6 +875,7 @@ export default {
 | hide-loading | 是否隐藏远程加载时的加载图标 | boolean | — | false |
 | popper-append-to-body | 是否将下拉列表插入至 body 元素。在下拉列表的定位出现问题时，可将该属性设置为 false | boolean | - | true |
 | highlight-first-item | 是否默认突出显示远程搜索建议中的第一项 | boolean | — | false |
+| is-uncontrolled | 让组件处于非受控模式 | boolean | - | false |
 
 ### Autocomplete Slots
 | name | 说明 |

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -169,7 +169,11 @@
         type: Boolean,
         default: false
       },
-      tabindex: String
+      tabindex: String,
+      isUncontrolled: {
+        type: Boolean,
+        default: false
+      }
     },
 
     computed: {
@@ -284,15 +288,22 @@
 
         this.$emit('input', event.target.value);
 
-        // set input's value, in case parent refuses the change
+        // component state is controlled by `value` prop,
+        // unless user explicitly requires it to be uncontrolled
         // see: https://github.com/ElemeFE/element/issues/12850
-        this.$nextTick(() => {
-          let input = this.getInput();
-          input.value = this.value;
-        });
+        // TODO: remove `isUncontrolled` in next major version
+        if (!this.isUncontrolled) {
+          this.$nextTick(() => { this.getInput().value = this.value; });
+        }
       },
       handleChange(event) {
         this.$emit('change', event.target.value);
+
+        // escape hatch for v-model modifier, to simulate native input's behavior
+        // TODO: remove `isUncontrolled` in next major version
+        if (this.isUncontrolled) {
+          this.$nextTick(() => { this.getInput().value = this.value; });
+        }
       },
       calcIconOffset(place) {
         let elList = [].slice.call(this.$el.querySelectorAll(`.el-input__${place}`) || []);


### PR DESCRIPTION
* 增加属性，允许 2.5.0 前部分社区用法能工作。https://github.com/ElemeFE/element/issues/14315 https://github.com/ElemeFE/element/issues/14330
* 文档增加注意事项

**下一个大版本应当移除这个功能。所有输入类组件应当完全受控。不处理input事件就不会有DOM变化。**

严格来说，`is-uncontrolled`把组件放到半受控状态。在 `change` 事件时依然会从 Vue/JS 模型刷新 DOM，让 el-input 使用 modifier 的行为更接近原生 input。

---

* 使用 v-model.number， v-model.trim：加上 is-uncontrolled 属性。
* 不处理 input 事件，但处理 change 事件：加上 is-uncontrolled 属性，并在change事件中同步设置Vue/JS模型的值。如使用blur事件，改为 change 事件，参考 https://github.com/ElemeFE/element/issues/14225 。
* v-model.lazy 原先就不支持，现在依然不支持。

---

发 2.5 的 patch 也可以。

不同受控 + modifier的行为： https://jsfiddle.net/qskuba8x/2/