### PR TITLE
Pagination: 修正翻页组件同时设置page和totalPages时，当前页码可能显示不正确的情况。

### DIFF
--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -365,6 +365,7 @@ export default {
       immediate: true,
       handler(val) {
         this.internalPageSize = isNaN(val) ? 10 : val;
+        this.internalCurrentPage = this.getValidCurrentPage(this.currentPage);
       }
     },
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

我在使用分页组件时发现，有些时候（目前碰到的是在仅有三页时出现异常显示）请求完分页数据，设置currentPage和pageCount时，由于设置currentPage不能超过pageCount，导致显示异常（始终显示第一页）.通过pageCount变化时重算合法的internalCurrentPage可以解决此问题，无论先设置谁，最终都得到正确合法的internalCurrentPage.
