### PR TITLE
InputNumber:fix uncontrolled when use v-bind (#14369)

### DIFF
--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -130,13 +130,13 @@
     },
     computed: {
       minDisabled() {
-        return this._decrease(this.value, this.step) < this.min;
+        return this._decrease(this.currentValue, this.step) < this.min;
       },
       maxDisabled() {
-        return this._increase(this.value, this.step) > this.max;
+        return this._increase(this.currentValue, this.step) > this.max;
       },
       numPrecision() {
-        const { value, step, getPrecision, precision } = this;
+        const { currentValue, step, getPrecision, precision } = this;
         const stepPrecision = getPrecision(step);
         if (precision !== undefined) {
           if (stepPrecision > precision) {
@@ -144,7 +144,7 @@
           }
           return precision;
         } else {
-          return Math.max(getPrecision(value), stepPrecision);
+          return Math.max(getPrecision(currentValue), stepPrecision);
         }
       },
       controlsAtRight() {
@@ -202,13 +202,13 @@
       },
       increase() {
         if (this.inputNumberDisabled || this.maxDisabled) return;
-        const value = this.value || 0;
+        const value = this.currentValue || 0;
         const newVal = this._increase(value, this.step);
         this.setCurrentValue(newVal);
       },
       decrease() {
         if (this.inputNumberDisabled || this.minDisabled) return;
-        const value = this.value || 0;
+        const value = this.currentValue || 0;
         const newVal = this._decrease(value, this.step);
         this.setCurrentValue(newVal);
       },


### PR DESCRIPTION
Closes #14369
因为使用`v-bind`绑定的值为单向绑定，组件无法改变父组件的`value`值
将计算依赖的父组件的`value`值修改为当前组件的`currentValue`
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
