### PR TITLE
Menu: fix click el-submenu trigger childMenu pop again bug

### DIFF
--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -178,7 +178,8 @@
         }
         this.dispatch('ElMenu', 'submenu-click', this);
       },
-      handleMouseenter(event) {
+      handleMouseenter(event, showTimeout = this.showTimeout) {
+
         if (!('ActiveXObject' in window) && event.type === 'focus' && !event.relatedTarget) {
           return;
         }
@@ -194,7 +195,7 @@
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {
           this.rootMenu.openMenu(this.index, this.indexPath);
-        }, this.showTimeout);
+        }, showTimeout);
       },
       handleMouseleave() {
         const {rootMenu} = this;
@@ -274,9 +275,9 @@
             ref="menu"
             v-show={opened}
             class={[`el-menu--${mode}`, popperClass]}
-            on-mouseenter={this.handleMouseenter}
+            on-mouseenter={($event) => this.handleMouseenter($event, 100)}
             on-mouseleave={this.handleMouseleave}
-            on-focus={this.handleMouseenter}>
+            on-focus={($event) => this.handleMouseenter($event, 100)}>
             <ul
               role="menu"
               class={['el-menu el-menu--popup', `el-menu--popup-${currentPlacement}`]}


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.



The `showTimeout` duration of `popupMenu` does not need to be the same as `inlineMenu`.
If it
 set too long, it will cause the submenu pop again bug when you quickly click on the menu.

![submenu](https://user-images.githubusercontent.com/8121621/53163858-f5ebfd00-3609-11e9-9811-7cf42346e43e.gif)

To fix https://github.com/ElemeFE/element/issues/12512
