### PR TITLE
Table: fix that when the table is empty that the tips cannot in the middle and the scrollbars cannot be dragged.(#14148)

### DIFF
--- a/packages/table/src/table-layout.js
+++ b/packages/table/src/table-layout.js
@@ -90,8 +90,7 @@ class TableLayout {
     }
     this.fixedBodyHeight = this.scrollX ? this.bodyHeight - this.gutterWidth : this.bodyHeight;
 
-    const noData = !this.table.data || this.table.data.length === 0;
-    this.viewportHeight = this.scrollX ? tableHeight - (noData ? 0 : this.gutterWidth) : tableHeight;
+    this.viewportHeight = this.scrollX ? tableHeight - this.gutterWidth : tableHeight;
 
     this.updateScrollY();
     this.notifyObservers('scrollable');

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -48,13 +48,9 @@
       <div
         v-if="!data || data.length === 0"
         class="el-table__empty-block"
-        ref="emptyBlock"
         :style="{
           width: bodyWidth
         }">
-        <span class="el-table__empty-text">
-          <slot name="empty">{{ emptyText || t('el.table.emptyText') }}</slot>
-        </span>
       </div>
       <div
         v-if="$slots.append"
@@ -63,6 +59,11 @@
         <slot name="append"></slot>
       </div>
     </div>
+    
+    <span class="el-table__empty-text" v-if="!data || data.length === 0">
+      <slot name="empty">{{!data || data.length === 0}}{{ emptyText || t('el.table.emptyText') }}</slot>
+    </span>
+
     <div
       v-if="showSummary"
       v-show="data && data.length > 0"

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -61,7 +61,7 @@
     </div>
     
     <span class="el-table__empty-text" v-if="!data || data.length === 0">
-      <slot name="empty">{{!data || data.length === 0}}{{ emptyText || t('el.table.emptyText') }}</slot>
+      <slot name="empty">{{ emptyText || t('el.table.emptyText') }}</slot>
     </span>
 
     <div

--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -18,19 +18,13 @@
   // 数据为空
   @include e(empty-block) {
     min-height: 60px;
-    text-align: center;
-    width: 100%;
-    height: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
   }
 
   @include e(empty-text) {
-    // min-height doesn't work in IE10 and IE11 https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
-    // set empty text line height up to contrainer min-height as workaround.
-    line-height: 60px;
-    width: 50%;
+    position: absolute;
+    top: 50%;
+    text-align: center;
+    width: 100%;
     color: $--color-text-secondary;
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

- close #14148
