### PR TITLE
[Docs]:  Fix minor spelling issue in en-US datepicker documentation

### DIFF
--- a/examples/docs/en-US/date-picker.md
+++ b/examples/docs/en-US/date-picker.md
@@ -530,4 +530,4 @@ When picking a date range, you can assign the time part for start date and end d
 ### Slots
 | Name    | Description |
 |---------|-------------|
-| range-separator  | costume range separator content |
+| range-separator  | custom range separator content |


### PR DESCRIPTION
MInor change that updates `costume` to `custom`.
