### PR TITLE
fixbug:#13968 tree 组件中的 checkbox按钮 在超过2层的情况下，次子级有disabled属性的情况下，无法操作的问题

### DIFF
--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -9,8 +9,10 @@ export const getChildState = node => {
     const n = node[i];
     if (n.checked !== true || n.indeterminate) {
       all = false;
-      if (!n.disabled) {
+      if (!n.disabled && n.childNodes.length === 0) {
         allWithoutDisable = false;
+      } else if (n.childNodes.length) {
+        allWithoutDisable = getChildState(n.childNodes).allWithoutDisable;
       }
     }
     if (n.checked !== false || n.indeterminate) {


### PR DESCRIPTION
在 getChildState 方法中需要检查遍历子元素是否有 disabled 的情况，仅根据当前子级是否有 disabled 会导致出现此问题。

fix: #13968