### PR TITLE
fixbug: #14074 Menu Component Repair: If the defaultIndex value does …

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -139,7 +139,12 @@
       }
     },
     watch: {
-      defaultActive: 'updateActiveIndex',
+      defaultActive(value){
+        if(!this.items[value]){
+          this.activeIndex = null
+        }
+        this.updateActiveIndex(value)
+      },
 
       defaultOpeneds(value) {
         if (!this.collapse) {


### PR DESCRIPTION
修复 menu 组件当修改的 defaultIndex 值不存在时, activeIndex 应该为null

fix: #14074