### PR TITLE
Cascader: add disabled-select-on-hover prop to disabled select on hover

### DIFF
--- a/examples/docs/en-US/cascader.md
+++ b/examples/docs/en-US/cascader.md
@@ -1400,6 +1400,7 @@ Search and select options with a keyword.
 | filterable  | whether the options can be searched | boolean | — | — |
 | debounce | debounce delay when typing filter keyword, in milliseconds | number | — | 300 |
 | change-on-select | whether selecting an option of any level is permitted | boolean | — | false |
+| disabled-select-on-hover | Disable hover trigger menu-item selection, with `change-on-select="true"` (by default hover menu-item will trigger select) | boolean | true / false | false |
 | size  | size of Input | string | medium / small / mini | — |
 | before-filter | hook function before filtering with the value to be filtered as its parameter. If `false` is returned or a `Promise` is returned and then is rejected, filtering will be aborted | function(value) | — | — |
 

--- a/examples/docs/zh-CN/cascader.md
+++ b/examples/docs/zh-CN/cascader.md
@@ -1400,6 +1400,7 @@
 | filterable | 是否可搜索选项 | boolean | — | — |
 | debounce | 搜索关键词输入的去抖延迟，毫秒 | number | — | 300 |
 | change-on-select | 是否允许选择任意一级的选项 | boolean | — | false |
+| disabled-select-on-hover | 禁用hover触发menu-item的选中，配合`change-on-select="true"`使用（默认情况下hover menu-item会触发select） | boolean | true / false | false |
 | size | 尺寸 | string | medium / small / mini | — |
 | before-filter | 筛选之前的钩子，参数为输入的值，若返回 false 或者返回 Promise 且被 reject，则停止筛选 | function(value) | — | — |
 

--- a/packages/cascader/src/main.vue
+++ b/packages/cascader/src/main.vue
@@ -170,6 +170,10 @@ export default {
     hoverThreshold: {
       type: Number,
       default: 500
+    },
+    disabledSelectOnHover: {
+      type: Boolean,
+      default: false
     }
   },
 
@@ -266,6 +270,7 @@ export default {
       this.menu.hoverThreshold = this.hoverThreshold;
       this.popperElm = this.menu.$el;
       this.menu.$refs.menus[0].setAttribute('id', `cascader-menu-${this.id}`);
+      this.menu.disabledSelectOnHover = this.disabledSelectOnHover;
       this.menu.$on('pick', this.handlePick);
       this.menu.$on('activeItemChange', this.handleActiveItemChange);
       this.menu.$on('menuLeave', this.doDestroy);

--- a/packages/cascader/src/menu.vue
+++ b/packages/cascader/src/menu.vue
@@ -40,6 +40,7 @@
         value: [],
         expandTrigger: 'click',
         changeOnSelect: false,
+        disabledHoverSelect: false,
         popperClass: '',
         hoverTimer: 0,
         clicking: false,
@@ -118,7 +119,7 @@
         const len = this.activeOptions.length;
         this.activeValue.splice(menuIndex, len, item.value);
         this.activeOptions.splice(menuIndex + 1, len, item.children);
-        if (this.changeOnSelect) {
+        if (this.changeOnSelect && !this.disabledSelectOnHover) {
           this.$emit('pick', this.activeValue.slice(), false);
         } else {
           this.$emit('activeItemChange', this.activeValue);
@@ -242,6 +243,10 @@
               if (triggerEvent === 'mouseenter' && this.changeOnSelect) {
                 events.on.click = () => {
                   if (this.activeValue.indexOf(item.value) !== -1) {
+                    if (this.disabledSelectOnHover) {
+                      this.select(item, menuIndex);
+                      this.$nextTick(() => this.scrollMenu(this.$refs.menus[menuIndex]));
+                    }
                     this.$emit('closeInside', true);
                   }
                 };


### PR DESCRIPTION
添加`disabled-select-on-hover`，在设置`change-on-select="true"`和`expand-trigger="hover"`后，你发现hover在任意选项上就会将数据添加到input中，当然这也是一种需求。但是也有click触发而不是hover触发数据添加到input上的需求。

* [ x ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ x ] Make sure you are merging your commits to `dev` branch.
* [ x ] Add some descriptions and refer relative issues for you PR.
