### PR TITLE
Table: equal behaviour for height and max-height

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -507,9 +507,7 @@
           };
         } else if (this.maxHeight) {
           return {
-            'max-height': (this.showHeader
-              ? this.maxHeight - this.layout.headerHeight - this.layout.footerHeight
-              : this.maxHeight - this.layout.footerHeight) + 'px'
+            'max-height': this.layout.bodyHeight ? this.layout.bodyHeight + 'px' : ''
           };
         }
         return {};


### PR DESCRIPTION
Closes #13751.

This PR is an attempt to close the referenced issue since I'm not sure if it breaks something...

Since the `max-height` is calculated [this way](https://github.com/ElemeFE/element/blob/dev/packages/table/src/table.vue#L510), if you specify it with a unit other than `px` (an integer), it doesn't calculate properly, therefore, doesn't show the scrollbar.

I looked into _why_ it's calculated like that and couldn't figured out, so I tried to replace it with the same calculation used for `height` and it worked as expected. Even [this example](http://element.eleme.io/#/en-US/component/table#fluid-height-table-with-fixed-header-and-columns), created in the [PR that originated the `max-height` feature](https://github.com/ElemeFE/element/pull/1674), just worked as before.

I checked the documentation after changing the calculation and all the examples are working as before, so it seems to me that the change doesn't break anything, but please review it carefully since I'm not aware of all the edge cases covered by the current calculation.