### PR TITLE
fix highlighting control elements for Webkit touch

### DIFF
--- a/examples/assets/styles/common.css
+++ b/examples/assets/styles/common.css
@@ -5,6 +5,7 @@ html, body {
   font-family: 'Helvetica Neue',Helvetica,'PingFang SC','Hiragino Sans GB','Microsoft YaHei',SimSun,sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
 
   &.is-component {
     overflow: hidden;


### PR DESCRIPTION
![bug_touch](https://user-images.githubusercontent.com/24376817/54314931-f7e42300-45ed-11e9-8290-a0adbda0d3ad.png)
You can see the example of issue on picture above.
This tiny CSS fix for issue with highlighting all controll elements on touch screens in Webkit browsers.
