### PR TITLE
Table: fix drag column

### DIFF
--- a/packages/table/src/table-layout.js
+++ b/packages/table/src/table-layout.js
@@ -188,6 +188,12 @@ class TableLayout {
     }
 
     const rightFixedColumns = this.store.states.rightFixedColumns;
+
+    if (flexColumns.length === 0 && rightFixedColumns.length > 0 && bodyMinWidth < bodyWidth) {
+      rightFixedColumns[0].realWidth = (rightFixedColumns[0].realWidth || rightFixedColumns[0].width) + bodyWidth - bodyMinWidth;
+      this.bodyWidth = bodyWidth;
+    }
+
     if (rightFixedColumns.length > 0) {
       let rightFixedWidth = 0;
       rightFixedColumns.forEach(function(column) {


### PR DESCRIPTION
对于配置了fixed="right"和border的table。在其它列宽都很小时（可能是默认设置，也可能是用户拖动），右侧固定列和左侧主体之间会出现空白
例如 #13220  
或 [https://jsfiddle.net/dhj9z8c3/1/](https://jsfiddle.net/dhj9z8c3/1/)  向左拖动省份列（超过100px就可以看到效果了）

此pr修复了该bug（在没有动态宽度列 且 配置了rightFixed 且 所有列宽小于bodyWidth 时，把多余的宽度给到最右侧的固定列）