### PR TITLE
Repeat-click: use Date.now() instead of new Date()

### DIFF
--- a/src/directives/repeat-click.js
+++ b/src/directives/repeat-click.js
@@ -6,7 +6,7 @@ export default {
     let startTime;
     const handler = () => vnode.context[binding.expression].apply();
     const clear = () => {
-      if (new Date() - startTime < 100) {
+      if (Date.now() - startTime < 100) {
         handler();
       }
       clearInterval(interval);
@@ -15,7 +15,7 @@ export default {
 
     on(el, 'mousedown', (e) => {
       if (e.button !== 0) return;
-      startTime = new Date();
+      startTime = Date.now();
       once(document, 'mouseup', clear);
       clearInterval(interval);
       interval = setInterval(handler, 100);


### PR DESCRIPTION
Prevent creation of new Date object to get time in ms. see [performace test](https://jsperf.com/date-now-vs-new-date)