### PR TITLE
fix: 🐛 (input) use event's isComposing && v-model default behavior

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -28,9 +28,8 @@
         :disabled="inputDisabled"
         :readonly="readonly"
         :autocomplete="autoComplete || autocomplete"
+        :value="value"
         ref="input"
-        @compositionstart="handleCompositionStart"
-        @compositionend="handleCompositionEnd"
         @input="handleInput"
         @focus="handleFocus"
         @blur="handleBlur"
@@ -80,8 +79,6 @@
       v-else
       :tabindex="tabindex"
       class="el-textarea__inner"
-      @compositionstart="handleCompositionStart"
-      @compositionend="handleCompositionEnd"
       @input="handleInput"
       ref="textarea"
       v-bind="$attrs"
@@ -89,6 +86,7 @@
       :readonly="readonly"
       :autocomplete="autoComplete || autocomplete"
       :style="textareaStyle"
+      :value="value"
       @focus="handleFocus"
       @blur="handleBlur"
       @change="handleChange"
@@ -126,7 +124,6 @@
         textareaCalcStyle: {},
         hovering: false,
         focused: false,
-        isComposing: false,
         passwordVisible: false
       };
     },
@@ -227,12 +224,6 @@
         if (this.validateEvent) {
           this.dispatch('ElFormItem', 'el.form.change', [val]);
         }
-      },
-      // native input value is set explicitly
-      // do not use v-model / :value in template
-      // see: https://github.com/ElemeFE/element/issues/14521
-      nativeInputValue() {
-        this.setNativeInputValue();
       }
     },
 
@@ -279,37 +270,15 @@
 
         this.textareaCalcStyle = calcTextareaHeight(this.$refs.textarea, minRows, maxRows);
       },
-      setNativeInputValue() {
-        const input = this.getInput();
-        if (!input) return;
-        if (input.value === this.nativeInputValue) return;
-        input.value = this.nativeInputValue;
-      },
       handleFocus(event) {
         this.focused = true;
         this.$emit('focus', event);
       },
-      handleCompositionStart() {
-        this.isComposing = true;
-      },
-      handleCompositionEnd(event) {
-        this.isComposing = false;
-        this.handleInput(event);
-      },
       handleInput(event) {
         // should not emit input during composition
         // see: https://github.com/ElemeFE/element/issues/10516
-        if (this.isComposing) return;
-
-        // hack for https://github.com/ElemeFE/element/issues/8548
-        // should remove the following line when we don't support IE
-        if (event.target.value === this.nativeInputValue) return;
-
+        if (event.isComposing) return;
         this.$emit('input', event.target.value);
-
-        // ensure native input value is controlled
-        // see: https://github.com/ElemeFE/element/issues/12850
-        this.$nextTick(this.setNativeInputValue);
       },
       handleChange(event) {
         this.$emit('change', event.target.value);
@@ -360,7 +329,6 @@
     },
 
     mounted() {
-      this.setNativeInputValue();
       this.resizeTextarea();
       this.updateIconOffset();
     },

--- a/test/unit/specs/input.spec.js
+++ b/test/unit/specs/input.spec.js
@@ -340,7 +340,7 @@ describe('Input', () => {
             ref="input"
             placeholder="请输入内容"
             clearable
-            :value="input">
+            v-model="input">
           </el-input>
         `,
         data() {
@@ -349,25 +349,18 @@ describe('Input', () => {
           };
         }
       }, true);
-      const spy = sinon.spy();
-      vm.$refs.input.$on('input', spy);
       const nativeInput = vm.$refs.input.$el.querySelector('input');
       nativeInput.value = '1';
       triggerEvent(nativeInput, 'compositionstart');
-      triggerEvent(nativeInput, 'input');
+      triggerEvent(nativeInput, 'change');
       await waitImmediate();
       nativeInput.value = '2';
-      triggerEvent(nativeInput, 'compositionupdate');
-      triggerEvent(nativeInput, 'input');
+      triggerEvent(nativeInput, 'change');
       await waitImmediate();
       triggerEvent(nativeInput, 'compositionend');
       await waitImmediate();
-      // input event does not fire during composition
-      expect(spy.calledOnce).to.be.true;
-      // native input value is controlled
-      expect(vm.input).to.equal('a');
-      expect(nativeInput.value).to.equal('a');
-
+      // model not change while isCompositing
+      expect(vm._data.input).equal('a');
     });
   });
 


### PR DESCRIPTION
use event's isComposing && v-model default behavior

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
https://github.com/ElemeFE/element/pull/14402
https://github.com/ElemeFE/element/issues/14330
https://github.com/ElemeFE/element/issues/14779