### PR TITLE
form: Uniform promise and callback validate return values

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -102,8 +102,8 @@
         // if no callback, return promise
         if (typeof callback !== 'function' && window.Promise) {
           promise = new window.Promise((resolve, reject) => {
-            callback = function(valid) {
-              valid ? resolve(valid) : reject(valid);
+            callback = function(valid, invalidFields) {
+              valid ? resolve(valid) : reject({valid, invalidFields});
             };
           });
         }

--- a/test/unit/specs/form.spec.js
+++ b/test/unit/specs/form.spec.js
@@ -884,8 +884,11 @@ describe('Form', () => {
           };
         }
       }, true);
-      vm.$refs.form.validate().catch(validFailed => {
-        expect(validFailed).to.false;
+      vm.$refs.form.validate().catch(({valid, invalidFields}) => {
+        expect(valid).to.false;
+        expect(invalidFields.name).to.exist;
+        expect(invalidFields.name).to.have.lengthOf(1);
+        expect(invalidFields.name[0].message).to.equal('长度至少为5');
         done();
       });
     });


### PR DESCRIPTION
form 使用 validate 校验返回 promise 的时候，如果校验不通过，`reject`并没有带上不通过的信息，和使用`callback`时有不一致的返回值。

由 [async-validator](https://www.npmjs.com/package/async-validator#usage) 的文档可见，当 promise reject 的时候同样会带上 `invalidateFields`。


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
