### PR TITLE
Table: move `hoverRow` from table-store to table-body (#13643)

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -201,7 +201,8 @@ export default {
 
   data() {
     return {
-      tooltipContent: ''
+      tooltipContent: '',
+      hoverRow: null
     };
   },
 
@@ -273,7 +274,7 @@ export default {
         classes.push('current-row');
       }
 
-      if (rowIndex === this.store.states.hoverRow) {
+      if (rowIndex === this.hoverRow) {
         classes.push('hover-row');
       }
 
@@ -381,11 +382,11 @@ export default {
     },
 
     handleMouseEnter(index) {
-      this.store.commit('setHoverRow', index);
+      this.hoverRow = index;
     },
 
     handleMouseLeave() {
-      this.store.commit('setHoverRow', null);
+      this.hoverRow = null;
     },
 
     handleContextMenu(event, row) {

--- a/packages/table/src/table-store.js
+++ b/packages/table/src/table-store.js
@@ -138,7 +138,6 @@ const TableStore = function(table, initialState = {}) {
     reserveSelection: false,
     selectable: null,
     currentRow: null,
-    hoverRow: null,
     filters: {},
     expandRows: [],
     defaultExpandAll: false,
@@ -374,10 +373,6 @@ TableStore.prototype.mutations = {
       this.updateColumns(); // hack for dynamics remove column
       this.scheduleLayout();
     }
-  },
-
-  setHoverRow(states, row) {
-    states.hoverRow = row;
   },
 
   setCurrentRow(states, row) {

--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -111,6 +111,7 @@
         fixedBodyHeight]">
         <table-body
           fixed="left"
+          ref="tableBody"
           :store="store"
           :stripe="stripe"
           :highlight="highlightCurrentRow"
@@ -385,7 +386,7 @@
       },
 
       handleMouseLeave() {
-        this.store.commit('setHoverRow', null);
+        this.$refs.tableBody.hoverRow = null;
         if (this.hoverState) this.hoverState = null;
       },
 


### PR DESCRIPTION
for #13643 
将hoverRow属性从table-store中移到了table-body内。

原因分析：store会被传入到所有子组件内的，当hoverRow变化时，因为子组件props改变，必定引起组件重绘。将hoverRow从store中移除后，当鼠标移动时渲染效率大幅提高。

测试demo：http://jsfiddle.net/HarlanLuo/sghtvxbf/3/ 包含1000行数据和两个fixed列的相对复杂表格

修改前，每次渲染用时1s以上：
![屏幕快照 2019-03-27 下午11 27 37](https://user-images.githubusercontent.com/948001/55091455-d144e280-50eb-11e9-811b-08a7ded60cd8.png)
修改后，每次渲染约0.5s，效率提升近半：
![屏幕快照 2019-03-27 下午11 53 08](https://user-images.githubusercontent.com/948001/55091488-e02b9500-50eb-11e9-82ef-c2564a21452c.png)
