### PR TITLE
Table: Add treeChildrenProp Attribute

### DIFF
--- a/examples/docs/zh-CN/table.md
+++ b/examples/docs/zh-CN/table.md
@@ -1282,11 +1282,13 @@
 ```html
 <template>
 <div>
-  <el-table
-    :data="tableData"
-    style="width: 100%;margin-bottom: 20px;"
-    border
-    row-key="id">
+    <el-table
+      :data="tableData"
+      style="width: 100%;margin-bottom: 20px;"
+      border
+      row-key="id"
+      tree-children-prop="customChildren"
+    >
     <el-table-column
       prop="date"
       label="日期"
@@ -1349,7 +1351,7 @@
           date: '2016-05-01',
           name: '王小虎',
           address: '上海市普陀区金沙江路 1519 弄',
-          children: [{
+          customChildren: [{
               id: 31,
               date: '2016-05-01',
               name: '王小虎',
@@ -1876,6 +1878,7 @@
 | summary-method | 自定义的合计计算方法 | Function({ columns, data }) | — | — |
 | span-method | 合并行或列的计算方法 | Function({ row, column, rowIndex, columnIndex }) | — | — |
 | select-on-indeterminate | 在多选表格中，当仅有部分行被选中时，点击表头的多选框时的行为。若为 true，则选中所有行；若为 false，则取消选择所有行 | Boolean | — | true |
+| tree-children-prop | 获得树形数据的子节点数据的属性名 | String | — | children |
 | indent      | 展示树形数据时，树节点的缩进 | Number | — | 16 |
 | lazy        | 是否懒加载子节点数据 | Boolean | — | — |
 | load        | 加载子节点数据的函数，lazy 为 true 时生效 | Function({ row, treeNode, resolve }) | — | — |


### PR DESCRIPTION
因为有时候后端给的数据子节点属性名不是children，或者有些正常表格数据，因为正好有个数组节点叫children，就会被误渲染成tree table。

所有增加的自定义获取tree data的子节点数组属性名的功能。

类似tree组件的props属性，可以自定义children。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
