### PR TITLE
TableBody: split render function into few smaller ones

### DIFF
--- a/packages/table-body/index.js
+++ b/packages/table-body/index.js
@@ -1,0 +1,3 @@
+import TableBody from '../table/src/table-body';
+
+export default TableBody;


### PR DESCRIPTION
Fix #14471

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

In this PR, I exported `TableBody` as public component and refactored its `render` function so that `TableBody` can be inherited and extended. This allows to create custom `Table` components with custom logic (e.g., for infinite loading). Example usage:

```js
import Table from 'element-ui/lib/table'
import TableBody from 'element-ui/lib/table-body'

const MyTableBody = {
  name: 'MyTableBody',
  extends: TableBody,
  methods: {
    renderBody(rows) {
       // custom body render implementation
      return this.$createElement('tbody', null, this.renderRows(rows))
    }
  }
}

export default {
  name: 'MyTable',
  extends: Table,
  components: {
     TableBody: MyTableBody
  }
}import MyTableBody from './MyTableBody.vue'

export default {
  name: 'MyTable',
  extends: Table,
  components: {
     TableBody: MyTableBody
  }
}
```