### PR TITLE
Table: Fix sort-change behaviour when sort condition is null (#15010)

### DIFF
--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -501,8 +501,6 @@ export default {
 
       if (!order) {
         sortOrder = column.order = null;
-        states.sortingColumn = null;
-        sortProp = null;
       } else {
         sortOrder = column.order = order;
       }


### PR DESCRIPTION
As explained in #15010 this fixes the behavior of `sort-change` events on Tables.
Is expected to a handler of this particular event to track all the changes of the sorting condition to a column.

See the issue for more details.
