### PR TITLE
chore: Display dev server info by default

### DIFF
--- a/build/webpack.demo.js
+++ b/build/webpack.demo.js
@@ -33,8 +33,7 @@ const webpackConfig = {
   devServer: {
     host: '0.0.0.0',
     port: 8085,
-    publicPath: '/',
-    noInfo: true
+    publicPath: '/'
   },
   performance: {
     hints: false


### PR DESCRIPTION
恢复成升级 webopack 之前的 `Project is running at http://0.0.0.0:8085/` 提示

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
