### PR TITLE
Input: Fix Korean composition event

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -31,6 +31,7 @@
         :autocomplete="autoComplete || autocomplete"
         ref="input"
         @compositionstart="handleCompositionStart"
+        @compositionupdate="handleCompositionUpdate"
         @compositionend="handleCompositionEnd"
         @input="handleInput"
         @focus="handleFocus"
@@ -87,6 +88,7 @@
       :tabindex="tabindex"
       class="el-textarea__inner"
       @compositionstart="handleCompositionStart"
+      @compositionupdate="handleCompositionUpdate"
       @compositionend="handleCompositionEnd"
       @input="handleInput"
       ref="textarea"
@@ -109,6 +111,7 @@
   import Migrating from 'element-ui/src/mixins/migrating';
   import calcTextareaHeight from './calcTextareaHeight';
   import merge from 'element-ui/src/utils/merge';
+  import {isKorean} from 'element-ui/src/utils/shared';
 
   export default {
     name: 'ElInput',
@@ -336,9 +339,16 @@
       handleCompositionStart() {
         this.isComposing = true;
       },
+      handleCompositionUpdate(event) {
+        const text = event.target.value;
+        const lastCharacter = text[text.length - 1] || '';
+        this.isComposing = !isKorean(lastCharacter);
+      },
       handleCompositionEnd(event) {
-        this.isComposing = false;
-        this.handleInput(event);
+        if (this.isComposing) {
+          this.isComposing = false;
+          this.handleInput(event);
+        }
       },
       handleInput(event) {
         // should not emit input during composition


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

fix: #11665 

There is a code to handle Korean inputs in [select.vue](https://github.com/ElemeFE/element/blob/bc407e57c43ef51fa4b01411e42fcf96a146c32a/packages/select/src/select.vue#L443), but it was missing in input.vue. 

- before this commit (tested with IE11, windows 10)

I typed '안녕하세요' (in qwerty, 'dkssudgktpdy')

![image](https://drive.google.com/uc?export=view&id=1OHh28NREol-vMHZ19FSFftJZxBet95I_)

- after this commit (tested with IE11, windows 10)

![image](https://drive.google.com/uc?export=view&id=1oNO4iCJpJBsgMBZcHjjzwSr6pxIEGjfW)

```
<template>
  <div>
    <el-input v-model="input"></el-input>
    <div v-for="log in logs">
      {{ log }}
    </div>
  </div>
</template>

<script>
  export default {
    data() {
      return {
        input: '',
        logs: []
      };
    },
    watch: {
      input (newValue, oldValue) {
        this.logs.push(newValue)
      }
    },
  };
</script>
```