### PR TITLE
Select: added multiprefix named slot for tags

### DIFF
--- a/examples/docs/en-US/select.md
+++ b/examples/docs/en-US/select.md
@@ -252,7 +252,7 @@ The `item` property of the slot data scope holds data regarding the selected ite
 
 ```html
 <template>
-  <el-select v-model="value" placeholder="Select">
+  <el-select v-model="value" multiple :collapse-tags="false" placeholder="Select">
     <template v-slot:multiprefix="selected">
       {{ selected.item.label.substring(0, 1) }}
     </template>

--- a/examples/docs/en-US/select.md
+++ b/examples/docs/en-US/select.md
@@ -242,7 +242,61 @@ Multiple select uses tags to display selected options.
 ```
 :::
 
-### Custom template
+### Custom template for multiple tags prefix
+
+You can customize the HTML template for selected values tag prefixes.
+
+The `item` property of the slot data scope holds data regarding the selected item.
+
+:::demo Insert customized HTML template into the `multiprefix` slot of `el-select`.
+
+```html
+<template>
+  <el-select v-model="value" placeholder="Select">
+    <template v-slot:multiprefix="selected">
+      {{ selected.item.label.substring(0, 1) }}
+    </template>
+    <el-option
+      v-for="item in cities"
+      :key="item.value"
+      :label="item.label"
+      :value="item.value">
+    </el-option>
+  </el-select>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        cities: [{
+          value: 'Beijing',
+          label: 'Beijing'
+        }, {
+          value: 'Shanghai',
+          label: 'Shanghai'
+        }, {
+          value: 'Nanjing',
+          label: 'Nanjing'
+        }, {
+          value: 'Chengdu',
+          label: 'Chengdu'
+        }, {
+          value: 'Shenzhen',
+          label: 'Shenzhen'
+        }, {
+          value: 'Guangzhou',
+          label: 'Guangzhou'
+        }],
+        value: ''
+      }
+    }
+  }
+</script>
+```
+:::
+
+### Custom template for options
 
 You can customize HTML templates for options.
 
@@ -569,6 +623,7 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 |---------|-------------|
 |    —    | Option component list |
 | prefix  | content as Select prefix |
+| multiprefix | in multiple mode, with no collapse, content that will be prefixed to each tag for selected values |
 | empty  | content when there is no options |
 
 ### Option Group Attributes

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -19,14 +19,14 @@
           disable-transitions>
           <span class="el-select__tags-text">{{ selected[0].currentLabel }}</span>
         </el-tag>
-        <el-tag
-          v-if="selected.length > 1"
-          :closable="false"
-          :size="collapseTagSize"
-          type="info"
-          disable-transitions>
-          <span class="el-select__tags-text">+ {{ selected.length - 1 }}</span>
-        </el-tag>
+          <el-tag
+            v-if="selected.length > 1"
+            :closable="false"
+            :size="collapseTagSize"
+            type="info"
+            disable-transitions>
+            <span class="el-select__tags-text">+ {{ selected.length - 1 }}</span>
+          </el-tag>
       </span>
       <transition-group @after-leave="resetInputHeight" v-if="!collapseTags">
         <el-tag
@@ -38,6 +38,7 @@
           type="info"
           @close="deleteTag($event, item)"
           disable-transitions>
+          <slot name="multiprefix" v-bind:item="item"></slot>
           <span class="el-select__tags-text">{{ item.currentLabel }}</span>
         </el-tag>
       </transition-group>

--- a/test/unit/specs/select.spec.js
+++ b/test/unit/specs/select.spec.js
@@ -362,7 +362,9 @@ describe('Select', () => {
       template: `
         <div>
           <el-select v-model="value" multiple filterable :collapse-tags="false">
-            <template v-slot:multiprefix="selected"><div class="a-multiprefix">{{ selected.item.value }}</div></template>
+            <template v-slot:multiprefix="selected">
+              <div class="a-multiprefix">{{ selected.item.value }}</div>
+            </template>
             <el-option
               v-for="item in options"
               :label="item.label"
@@ -390,14 +392,14 @@ describe('Select', () => {
       }
     }, true);
     expect(vm.value.length).to.equal(2);
-    setTimeout(() => {
+    vm.$nextTick(() => {
       const qsResult = vm.$el.querySelectorAll('.a-multiprefix');
       expect(qsResult.length).to.equal(2);
       const tags = Object.values(qsResult);
       expect(tags.some(tag => tag.innerText === '1'));
       expect(tags.some(tag => tag.innerText === '2'));
       done();
-    }, 50);
+    });
   });
 
   it('custom el-option template', () => {

--- a/test/unit/specs/select.spec.js
+++ b/test/unit/specs/select.spec.js
@@ -357,6 +357,49 @@ describe('Select', () => {
     expect(vm.$el.querySelector('.el-input__icon').classList.contains('el-icon-search')).to.be.true;
   });
 
+  it('prefixed selected tags', done => {
+    vm = createVue({
+      template: `
+        <div>
+          <el-select v-model="value" multiple filterable :collapse-tags="false">
+            <template v-slot:multiprefix="selected"><div class="a-multiprefix">{{ selected.item.value }}</div></template>
+            <el-option
+              v-for="item in options"
+              :label="item.label"
+              :key="item.value"
+              :value="item.value">
+            </el-option>
+          </el-select>
+        </div>
+      `,
+
+      data() {
+        return {
+          options: [{
+            value: '1',
+            label: 'label1'
+          }, {
+            value: '2',
+            label: 'label2'
+          }, {
+            value: '3',
+            label: 'label3'
+          }],
+          value: [ '1', '2' ]
+        };
+      }
+    }, true);
+    expect(vm.value.length).to.equal(2);
+    setTimeout(() => {
+      const qsResult = vm.$el.querySelectorAll('.a-multiprefix');
+      expect(qsResult.length).to.equal(2);
+      const tags = Object.values(qsResult);
+      expect(tags.some(tag => tag.innerText === '1'));
+      expect(tags.some(tag => tag.innerText === '2'));
+      done();
+    }, 50);
+  });
+
   it('custom el-option template', () => {
     vm = createVue({
       template: `


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Related issue is #15127 

Also added a simple test, and an example in the docs.

The idea was to implement a template, similar to how the "prefix" template already works.

This will allow devs to inject a template inside the resulting el-tag elements while the el-select is has:
multiple: true
collapseTags: false

No need to implement for non-multiple, since in that case we have "prefix"
For collapseTags: true it has not been implemented since binding a data structure gets a little weirder (the first item would receive a single item, the second item an array... handling tags prefix when collapseTags is on probably requires two more named templated: "multiprefix-collapsed-first" and "multiprefix-collapsed-group"
