### PR TITLE
TimePicker: Fix dafault to Jan 1st when user enter time manually (#15…

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -322,10 +322,10 @@
     var date;
     if (dateInfo.timezoneOffset != null) {
       dateInfo.minute = +(dateInfo.minute || 0) - +dateInfo.timezoneOffset;
-      date = new Date(Date.UTC(dateInfo.year || today.getFullYear(), dateInfo.month || 0, dateInfo.day || 1,
+      date = new Date(Date.UTC(dateInfo.year || today.getFullYear(), dateInfo.month || today.getMonth(), dateInfo.day || today.getDate(),
         dateInfo.hour || 0, dateInfo.minute || 0, dateInfo.second || 0, dateInfo.millisecond || 0));
     } else {
-      date = new Date(dateInfo.year || today.getFullYear(), dateInfo.month || 0, dateInfo.day || 1,
+      date = new Date(dateInfo.year || today.getFullYear(), dateInfo.month || today.getMonth(), dateInfo.day || today.getDate(),
         dateInfo.hour || 0, dateInfo.minute || 0, dateInfo.second || 0, dateInfo.millisecond || 0);
     }
     return date;


### PR DESCRIPTION
…180)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Using "today" as default value.
Close #15180 
