### PR TITLE
Input: fix show-word-count style in el-form

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -98,6 +98,7 @@
 
     .el-input__count-inner {
       background: $--color-white;
+      line-height: initial;
       display: inline-block;
       padding: 0 5px;
     }


### PR DESCRIPTION

**when el-form being set size attribute like medium\etc. and then the style of el-input's show-word-limit is sad.**

![捕获](https://user-images.githubusercontent.com/11309921/56940046-a01e5e80-6b3e-11e9-8169-d93b096ad5fc.PNG)

repair:

![image](https://user-images.githubusercontent.com/11309921/56940095-e4116380-6b3e-11e9-94d0-4f19749a2c92.png)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
