### PR TITLE
Menu: fixed submenu hidden bug after adding popper-append-to-body

### DIFF
--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -208,6 +208,9 @@
         this.dispatch('ElSubmenu', 'mouse-leave-child');
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {
+          if (this.appendToBody) {
+            this.rootMenu.openedMenus = [];
+          }
           !this.mouseInChild && this.rootMenu.closeMenu(this.index);
         }, this.hideTimeout);
       },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

To Fixed https://github.com/ElemeFE/element/issues/13005
Relate problem https://github.com/PanJiaChen/vue-element-admin/issues/2004

The cause of the problem: When the `popper-append-to-body` property is added, `mouseLeave` event will only close the current submenu, and its parent menu will not be closed.
