### PR TITLE
Docs: add missing description to Alert component

### DIFF
--- a/examples/docs/en-US/alert.md
+++ b/examples/docs/en-US/alert.md
@@ -233,6 +233,7 @@ Description includes a message with more detailed information.
 
 | Name | Description |
 |------|--------|
+| — | description |
 | title | content of the Alert title |
 
 ### Events

--- a/examples/docs/es/alert.md
+++ b/examples/docs/es/alert.md
@@ -235,6 +235,7 @@ Descripción incluye un mensaje con información más detallada.
 
 | Name | Description |
 |------|--------|
+| — | descripción |
 | title | El contenido del título de alerta. |
 
 ### Eventos

--- a/examples/docs/fr-FR/alert.md
+++ b/examples/docs/fr-FR/alert.md
@@ -233,6 +233,7 @@ Contient un message avec plus d'informations.
 
 | Nom | Description |
 |------|--------|
+| — | la description |
 | title | Le contenu du titre. |
 
 ### Évènements

--- a/examples/docs/zh-CN/alert.md
+++ b/examples/docs/zh-CN/alert.md
@@ -229,6 +229,7 @@ Alert 组件提供了两个不同的主题：`light`和`dark`。
 
 | Name | Description |
 |------|--------|
+| — | 描述 |
 | title | 标题的内容 |
 
 ### Events


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Was:
`<el-alert description="content" /> // content`
`<el-alert>content</el-alert> // content`
`<el-alert description="content props">content slots</el-alert> // -`

Now:
`<el-alert description="content" /> // content`
`<el-alert>content</el-alert> // content`
`<el-alert description="content props">content slots</el-alert> // content slots`

+removed extra v-if