### PR TITLE
Table: fix background color of hovered rows in complex table

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -505,7 +505,7 @@
       &, &.el-table__row--striped {
         &, &.current-row {
           > td {
-            background-color: $--table-current-row-background-color;
+            background-color: $--table-row-hover-background-color;
           }
         }
       }


### PR DESCRIPTION
The normal table sets background color of hovered row by pseudo-class `:hover`, and the complex one sets by adding class `hover-row`. However, the background color of the hovered row of normal table and complex table is different.

Before(Please see the second row of normal table and the third row of complex table): 
![image](https://user-images.githubusercontent.com/13602053/57517929-7b01cb00-734a-11e9-860f-d54d1feaa866.png)
After(Please see the second row of normal table and the third row of complex table): 
![image](https://user-images.githubusercontent.com/13602053/57517951-87862380-734a-11e9-815c-1b64386493e6.png)
