### PR TITLE
[message-box] 修复callback的逻辑错误

### DIFF
--- a/examples/docs/zh-CN/message-box.md
+++ b/examples/docs/zh-CN/message-box.md
@@ -301,7 +301,7 @@ import { MessageBox } from 'element-ui';
 | type | 消息类型，用于显示图标 | string | success / info / warning / error | — |
 | iconClass | 自定义图标的类名，会覆盖 `type` | string | — | — |
 | customClass | MessageBox 的自定义类名 | string | — | — |
-| callback | 若不使用 Promise，可以使用此参数指定 MessageBox 关闭后的回调 | function(action, instance)，action 的值为'confirm', 'cancel'或'close', instance 为 MessageBox 实例，可以通过它访问实例上的属性和方法 | — | — |
+| callback | 若不使用 Promise，可以使用此参数指定 MessageBox 关闭后的回调 | function(action, instance)，action 的值为'confirm', 'cancel'或'close', instance 为 MessageBox 实例，可以通过它访问实例上的属性和方法，若 showInput 为 true , callback 的第一个参数则是用户输入的值 inputValue ，第二和第三个参数则为action 和 instance  | — | — |
 | showClose | MessageBox 是否显示右上角关闭按钮 | boolean | — | true |
 | beforeClose | MessageBox 关闭前的回调，会暂停实例的关闭 | function(action, instance, done)，action 的值为'confirm', 'cancel'或'close'；instance 为 MessageBox 实例，可以通过它访问实例上的属性和方法；done 用于关闭 MessageBox 实例 | — | — |
 | distinguishCancelAndClose | 是否将取消（点击取消按钮）与关闭（点击关闭按钮或遮罩层、按下 ESC 键）进行区分 | boolean | — | false |

--- a/packages/message-box/src/main.js
+++ b/packages/message-box/src/main.js
@@ -48,9 +48,9 @@ const defaultCallback = action => {
     let callback = currentMsg.callback;
     if (typeof callback === 'function') {
       if (instance.showInput) {
-        callback(instance.inputValue, action);
+        callback(instance.inputValue, action, instance);
       } else {
-        callback(action);
+        callback(action, instance);
       }
     }
     if (currentMsg.resolve) {
@@ -87,7 +87,7 @@ const showNextMsg = () => {
 
       let options = currentMsg.options;
       for (let prop in options) {
-        if (options.hasOwnProperty(prop)) {
+        if (options.hasOwnProperty(prop) && prop !== 'callback') {
           instance[prop] = options[prop];
         }
       }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
在[message-box]组件的main.js的91行代码中，实例的callback会被options的callback替换，导致callback的执行逻辑出错，当options.callback为一个函数时，永远无法执行defaultCallback方法，导致options.showInput为true的时候，callback中的参数无法直接取到 inputValue 值（只能在 instance 中取，不科学）