### PR TITLE
message-box:增加$promt提交内容组件inputValidator函数对远程验证的支持

### DIFF
--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -206,22 +206,29 @@
           }
           const inputValidator = this.inputValidator;
           if (typeof inputValidator === 'function') {
-            const validateResult = inputValidator(this.inputValue);
-            if (validateResult === false) {
-              this.editorErrorMessage = this.inputErrorMessage || t('el.messagebox.error');
-              addClass(this.getInputElement(), 'invalid');
-              return false;
-            }
-            if (typeof validateResult === 'string') {
-              this.editorErrorMessage = validateResult;
-              addClass(this.getInputElement(), 'invalid');
-              return false;
-            }
+            Promise.resolve(
+              inputValidator(this.inputValue)
+            ).then(validateResult=>{
+              if (validateResult === false) {
+                this.editorErrorMessage = this.inputErrorMessage || t('el.messagebox.error');
+                addClass(this.getInputElement(), 'invalid');
+                return false;
+              }
+              if (typeof validateResult === 'string') {
+                this.editorErrorMessage = validateResult;
+                addClass(this.getInputElement(), 'invalid');
+                return false;
+              }
+              this.editorErrorMessage = '';
+              removeClass(this.getInputElement(), 'invalid');
+              return true;
+            })
           }
+        }else{
+          this.editorErrorMessage = '';
+          removeClass(this.getInputElement(), 'invalid');
+          return true;
         }
-        this.editorErrorMessage = '';
-        removeClass(this.getInputElement(), 'invalid');
-        return true;
       },
       getFirstFocus() {
         const btn = this.$el.querySelector('.el-message-box__btns .el-button');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35484325/57760987-2df96c80-772f-11e9-9216-73ff4ce30c4e.png)

message-box上的$promt使用inputValidator函数时增加远程的请求验证方式
