### PR TITLE
Select: fix multiple and filterable props can not click the arrow to…

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -95,7 +95,7 @@
         <slot name="prefix"></slot>
       </template>
       <template slot="suffix">
-        <i v-show="!showClose" :class="['el-select__caret', 'el-input__icon', 'el-icon-' + iconClass]"></i>
+        <i v-show="!showClose" :class="['el-select__caret', 'el-input__icon', 'el-icon-' + iconClass]" @click="!(filterable && remote) && setSoftFocus"></i>
         <i v-if="showClose" class="el-select__caret el-input__icon el-icon-circle-close" @click="handleClearClick"></i>
       </template>
     </el-input>
@@ -701,6 +701,9 @@
 
       setSoftFocus() {
         this.softFocus = true;
+        if (this.menuVisibleOnFocus) {
+          this.menuVisibleOnFocus = false;
+        }
         const input = this.$refs.input || this.$refs.reference;
         if (input) {
           input.focus();


### PR DESCRIPTION
… toggle the collapse (#15229)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

`menuVisibleOnFocus`是为了含有`automaticDropdown`属性的单选组件避免同时触发 handleFocus 和 toggleMenu 导致点击下拉不成功，`multiple`组件不需要`menuVisibleOnFocus`属性判断

