### PR TITLE
Tree: fix #15538 by adding more detect logic.

### DIFF
--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -1,6 +1,6 @@
 import objectAssign from 'element-ui/src/utils/merge';
 import { markNodeData, NODE_KEY } from './util';
-import { arrayContains } from 'element-ui/src/utils/util';
+import { arrayFindIndex } from 'element-ui/src/utils/util';
 
 export const getChildState = node => {
   let all = true;
@@ -437,7 +437,7 @@ export default class Node {
 
     newData.forEach((item, index) => {
       const key = item[NODE_KEY];
-      const isNodeExists = !!key && arrayContains(oldData, data => data[NODE_KEY] === key);
+      const isNodeExists = !!key && arrayFindIndex(oldData, data => data[NODE_KEY] === key) >= 0;
       if (isNodeExists) {
         newDataMap[key] = { index, data: item };
       } else {

--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -1,5 +1,6 @@
 import objectAssign from 'element-ui/src/utils/merge';
 import { markNodeData, NODE_KEY } from './util';
+import { arrayContains } from 'element-ui/src/utils/util';
 
 export const getChildState = node => {
   let all = true;
@@ -435,8 +436,10 @@ export default class Node {
     const newNodes = [];
 
     newData.forEach((item, index) => {
-      if (item[NODE_KEY]) {
-        newDataMap[item[NODE_KEY]] = { index, data: item };
+      const key = item[NODE_KEY];
+      const isNodeExists = !!key && arrayContains(oldData, data => data[NODE_KEY] === key);
+      if (isNodeExists) {
+        newDataMap[key] = { index, data: item };
       } else {
         newNodes.push({ index, data: item });
       }

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -97,6 +97,10 @@ export const arrayFindIndex = function(arr, pred) {
   return -1;
 };
 
+export const arrayContains = function(arr, pred) {
+  return arrayFindIndex(arr, pred) >= 0;
+};
+
 export const arrayFind = function(arr, pred) {
   const idx = arrayFindIndex(arr, pred);
   return idx !== -1 ? arr[idx] : undefined;

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -97,10 +97,6 @@ export const arrayFindIndex = function(arr, pred) {
   return -1;
 };
 
-export const arrayContains = function(arr, pred) {
-  return arrayFindIndex(arr, pred) >= 0;
-};
-
 export const arrayFind = function(arr, pred) {
   const idx = arrayFindIndex(arr, pred);
   return idx !== -1 ? arr[idx] : undefined;

--- a/test/unit/specs/tree.spec.js
+++ b/test/unit/specs/tree.spec.js
@@ -832,7 +832,7 @@ describe('Tree', () => {
     });
   });
 
-  it('update multi tree data', async () => {
+  it('update multi tree data', async() => {
     const vm = createVue({
       template: `
         <div>

--- a/test/unit/specs/tree.spec.js
+++ b/test/unit/specs/tree.spec.js
@@ -1,4 +1,4 @@
-import { createVue, destroyVM, waitImmediate } from '../util';
+import { createVue, destroyVM, waitImmediate, wait } from '../util';
 
 const DELAY = 10;
 
@@ -830,5 +830,64 @@ describe('Tree', () => {
       expect(label.textContent).to.equal('三级 1-1');
       done();
     });
+  });
+
+  it('update multi tree data', async () => {
+    const vm = createVue({
+      template: `
+        <div>
+          <el-tree ref="tree1" :data="data" node-key="id" :props="defaultProps"></el-tree>
+          <el-tree ref="tree2" :data="data" node-key="id" :props="defaultProps"></el-tree>
+        </div>
+        `,
+
+      data() {
+        return {
+          data: [{
+            id: 1,
+            label: '一级 1',
+            children: [{
+              id: 11,
+              label: '二级 1-1',
+              children: [{
+                id: 111,
+                label: '三级 1-1'
+              }]
+            }]
+          }, {
+            id: 2,
+            label: '一级 2',
+            children: [{
+              id: 21,
+              label: '二级 2-1'
+            }, {
+              id: 22,
+              label: '二级 2-2'
+            }]
+          }, {
+            id: 3,
+            label: '一级 3',
+            children: [{
+              id: 31,
+              label: '二级 3-1'
+            }, {
+              id: 32,
+              label: '二级 3-2'
+            }]
+          }],
+          defaultProps: {
+            children: 'children',
+            label: 'label'
+          }
+        };
+      }
+    }, true);
+    const nodeData = { label: '新增 1', id: 4 };
+    vm.data.push(nodeData);
+    await wait();
+    const tree1 = vm.$refs.tree1;
+    expect(tree1.getNode(4).data).to.equal(nodeData);
+    const tree2 = vm.$refs.tree2;
+    expect(tree2.getNode(4).data).to.equal(nodeData);
   });
 });


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Fix issue [#15538](https://github.com/ElemeFE/element/issues/15538).

原来逻辑只是判断数组对象有没有 `NODE_KEY` 属性，如果一个对象已经被第一颗树渲染过，在第二颗树的判断中就被认为已经存在，导致出现 #15538 的bug。

PR 中修改了数组项判断的逻辑，判断数组项是否在 `oldData` 数组中。
