### PR TITLE
Tabs: fix maxOffset bug

### DIFF
--- a/packages/tabs/src/tab-nav.vue
+++ b/packages/tabs/src/tab-nav.vue
@@ -87,7 +87,7 @@
         const navScroll = this.$refs.navScroll;
         const activeTabBounding = activeTab.getBoundingClientRect();
         const navScrollBounding = navScroll.getBoundingClientRect();
-        const maxOffset = nav.offsetWidth - navScrollBounding.width;
+        const maxOffset = ['top', 'bottom'].indexOf(this.rootTabs.tabPosition) !== -1 ? nav.offsetWidth - navScrollBounding.width : nav.offsetHeight - navScrollBounding.height;
         const currentOffset = this.navOffset;
         let newOffset = currentOffset;
 


### PR DESCRIPTION
当tab-position值为left或right,点击下一页中的tabs项时总会滚动到第一页，推断可能是因为maxOffset = nav.offsetWidth - navScrollBounding.width导致，缺少判断