### PR TITLE
Utils: fix menu-item error event handler (#13106)

### DIFF
--- a/src/utils/menu/aria-menuitem.js
+++ b/src/utils/menu/aria-menuitem.js
@@ -20,6 +20,10 @@ MenuItem.prototype.addListeners = function() {
   const keys = Utils.keys;
   this.domNode.addEventListener('keydown', event => {
     let prevDef = false;
+
+    // fix issue https://github.com/ElemeFE/element/issues/13106
+    if (event.target.tagName === 'INPUT') return;
+
     switch (event.keyCode) {
       case keys.down:
         Utils.triggerEvent(event.currentTarget, 'mouseenter');


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

menu 组件 mode=“horizontal” 时，menu-item 中 input 触发 keydown 事件被错误的处理导致的 Bug。