### PR TITLE
InputNumber: add type and readonly props (native input attrs)

### DIFF
--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -35,6 +35,7 @@
       :max="max"
       :min="min"
       :type="type"
+      :readonly="readonly"
       :name="name"
       :label="label"
       @keydown.up.native.prevent="increase"
@@ -87,6 +88,7 @@
       },
       value: {},
       disabled: Boolean,
+      readonly: Boolean,
       size: String,
       controls: {
         type: Boolean,

--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -34,6 +34,7 @@
       :size="inputNumberSize"
       :max="max"
       :min="min"
+      :type="type"
       :name="name"
       :label="label"
       @keydown.up.native.prevent="increase"
@@ -94,6 +95,10 @@
       controlsPosition: {
         type: String,
         default: ''
+      },
+      type: {
+        type: String,
+        default: 'text'
       },
       name: String,
       label: String,


### PR DESCRIPTION
New `type` property to edit native input type attribute, so the user may be able to change the default type (text) to tel (and maybe number, but it would change the default design).
Imho it's important to give better experience on mobile, showing the number keyboard on focus instead of default keyboard.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
