### PR TITLE
Autocomplete: fix problem when input with Chinese input method and enabled select-when-unmatched

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -18,6 +18,8 @@
       @keydown.down.native.prevent="highlight(highlightedIndex + 1)"
       @keydown.enter.native="handleKeyEnter"
       @keydown.native.tab="close"
+      @compositionstart="handleCompositionStart"
+      @compositionend="handleCompositionEnd"
     >
       <template slot="prepend" v-if="$slots.prepend">
         <slot name="prepend"></slot>
@@ -138,7 +140,8 @@
         suggestions: [],
         loading: false,
         highlightedIndex: -1,
-        suggestionDisabled: false
+        suggestionDisabled: false,
+        isComposing: false
       };
     },
     computed: {
@@ -214,16 +217,24 @@
         this.activated = false;
       },
       handleKeyEnter(e) {
-        if (this.suggestionVisible && this.highlightedIndex >= 0 && this.highlightedIndex < this.suggestions.length) {
-          e.preventDefault();
-          this.select(this.suggestions[this.highlightedIndex]);
-        } else if (this.selectWhenUnmatched) {
-          this.$emit('select', {value: this.value});
-          this.$nextTick(_ => {
-            this.suggestions = [];
-            this.highlightedIndex = -1;
-          });
+        if (!this.isComposing) {
+          if (this.suggestionVisible && this.highlightedIndex >= 0 && this.highlightedIndex < this.suggestions.length) {
+            e.preventDefault();
+            this.select(this.suggestions[this.highlightedIndex]);
+          } else if (this.selectWhenUnmatched) {
+            this.$emit('select', {value: this.value});
+            this.$nextTick(_ => {
+              this.suggestions = [];
+              this.highlightedIndex = -1;
+            });
+          }
         }
+      },
+      handleCompositionStart() {
+        this.isComposing = true;
+      },
+      handleCompositionEnd() {
+        this.isComposing = false;
       },
       select(item) {
         this.$emit('input', item[this.valueKey]);

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -333,11 +333,13 @@
         this.focused = true;
         this.$emit('focus', event);
       },
-      handleCompositionStart() {
+      handleCompositionStart(event) {
         this.isComposing = true;
+        this.$emit('compositionstart', event);
       },
       handleCompositionEnd(event) {
         this.isComposing = false;
+        this.$emit('compositionend', event);
         this.handleInput(event);
       },
       handleInput(event) {


### PR DESCRIPTION
This PR fixes the problem when the Chinese input method is used with select-when-unmatched enabled. **Reproducible demo page: https://codepen.io/anon/pen/mYjKVP?editors=1111**

Expected behavior:
When input with the Chinese input method, the value won't be logged unless the user hits the Enter button after the compositionend event.

Actual behavior:
`handleKeyEnter` method doesn't check if we're still on composition and immediately logs the previous value before the compositionend event. If we want to get the actual value, we need to hit the Enter button one more time.

![image](https://user-images.githubusercontent.com/6451933/58492558-b9e5ac80-81a3-11e9-8d7a-3033b8bdf086.png)
