### PR TITLE
[Dialog]: 添加visible到props

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -49,6 +49,12 @@
         type: String,
         default: ''
       },
+    
+      visible: {
+        sync: true,
+        required: true,
+        type: Boolean
+      },
 
       modal: {
         type: Boolean,


### PR DESCRIPTION
添加visible到props
添加必填属性
添加sync修饰词支持

visible没有添加到props中，且不是必填项
visible的.sync可以在props中直接设定
以上导致使用高阶函数时，visible没有被正确传递