### PR TITLE
Dropdown: fix split-button caret default color

### DIFF
--- a/packages/theme-chalk/src/dropdown.scss
+++ b/packages/theme-chalk/src/dropdown.scss
@@ -35,6 +35,10 @@
       background: mix(white, transparent, 50%);
     }
 
+    &.el-button--default::before {
+      background: mix($--button-default-border-color, transparent, 50%);
+    }
+
     &:hover {
       &::before {
         top: 0;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Before fix, the caret of split-button dropdown default type is white background, and the caret is invisible.

After fix, I add a `mix($--button-default-border-color, transparent, 50%)`  (`rgba(220, 223, 230, 0.5)`)  background to default type split-button dropdown, so that the caret is obvious and match the whole style.  

修复前，default类型的分离按钮样式 dropdown 看不到分隔符，因为其颜色是和背景近似的半透明白色。
修复后，给上述类型的 dropdown 分隔符添加了和整体风格一致的 `mix($--button-default-border-color, transparent, 50%)` 颜色，以便于能看到这个分隔符。

CodePen Demo: 
https://codepen.io/JuniorTour/pen/RmqYLy?editors=1100#0

![image](https://user-images.githubusercontent.com/14243906/58928292-77fccd80-8784-11e9-996b-19ba9ff2c52a.png)

