### PR TITLE
Tree 组件的类型定义为泛类型

### DIFF
--- a/types/element-ui.d.ts
+++ b/types/element-ui.d.ts
@@ -67,7 +67,7 @@ import { ElTimePicker } from './time-picker'
 import { ElTimeSelect } from './time-select'
 import { ElTooltip } from './tooltip'
 import { ElTransfer } from './transfer'
-import { ElTree } from './tree'
+import { ElTree, TreeData } from './tree'
 import { ElUpload } from './upload'
 import { ElLink } from './link'
 import { ElDivider } from './divider'
@@ -305,7 +305,7 @@ export class Tooltip extends ElTooltip {}
 export class Transfer extends ElTransfer {}
 
 /** Tree Component */
-export class Tree extends ElTree {}
+export class Tree<K = any, D = TreeData> extends ElTree<K, D> {}
 
 /** Upload Component */
 export class Upload extends ElUpload {}

--- a/types/tree.d.ts
+++ b/types/tree.d.ts
@@ -45,7 +45,7 @@ export interface TreeStore<K, D> {
 }
 
 /** Tree Component */
-export declare class ElTree<K = any, D = TreeData> extends ElementUIComponent {
+export declare class ElTree<K, D extends TreeData> extends ElementUIComponent {
   /** TreeStore */
   store: TreeStore<K, D>;
 


### PR DESCRIPTION
### Senario
现在有一个场景, 就是当我需要写
```typescript
import { Tree } from 'element-ui';
/**/
(this.$refs.tree as Tree).getCheckedNodes().map(node => {
  // 对 node 操作
  console.log(node.somethingElse); // 这里会报 node 类型里不存在 somethingElse 属性的错误
});
```
根据 `Tree.getCheckedNodes` 的函数签名
```typescript
getCheckedNodes(leafOnly?: boolean, includeHalfChecked?: boolean): D[];
```
上文的的 `node` 是由 ElTree 的默认泛类型 `TreeData` 
```typescript
interface TreeData {
  id?: any;
  label?: string;
  disabled?: boolean;
  isLeaf?: boolean;
  children?: TreeData[];
}
```
而在实际的需求中, `TreeData` 的结构往往不一定和默认定义的一直, 这样就会导致一个问题, 如果要跳过这个地方就需要强行使用 `node as any` 来把 node 转换成一个任意类型, 失去了本来的意义.
### Change based on requirement
此处的改动就是将 `element-ui.d.ts` 暴露出去的 `Tree` 类型从普通的类型定义改为了泛类型定义, Tree 类型可以接受两个类型参数 `<K, D extends TreeData>`, 用来修饰这两个类型, 从而使得上面的代码可以用这种写法
```typescript
import { Tree } from 'element-ui';
/**/
(this.$refs.tree as Tree<any, CustomizedType>).getCheckedNodes().map(node => {
  // 对 node 操作
  console.log(node.somethingElse);
});
```

### Commit Message
- Make Tree type generic, in case of customized tree data user would pass into.

- 让 Tree 类型变为泛类型, 用来保证当用户自定义的类型没办法被传入 Tree 组件中

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
