### PR TITLE
Add maximum width to fit small screens (#15980)

### DIFF
--- a/packages/theme-chalk/src/date-picker/date-range-picker.scss
+++ b/packages/theme-chalk/src/date-picker/date-range-picker.scss
@@ -2,6 +2,8 @@
 
 @include b(date-range-picker) {
   width: 646px;
+  max-width: 100vw;
+  overflow: auto;
 
   &.has-sidebar {
     width: 756px;


### PR DESCRIPTION
I need to use the date selection component in development, but I can't finish viewing it under the small screen. It is recommended to add the following controls to the el-date-picker component style:

.el-date-range-picker {
   max-width: 100vw;
   overflow: auto;
}

- Closes #15980