### PR TITLE
修复监听事件为0时，如果再次添加事件无法监听问题

### DIFF
--- a/src/utils/resize-event.js
+++ b/src/utils/resize-event.js
@@ -31,5 +31,6 @@ export const removeResizeListener = function(element, fn) {
   element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
   if (!element.__resizeListeners__.length) {
     element.__ro__.disconnect();
+    element.__resizeListeners__ = null;
   }
 };


### PR DESCRIPTION
在组件中 如果移除最后一个事件时，原来的element.__resizeListeners__将成为一个空数组[]，后续如果再次添加事件时，不会触发observe方法，element.__resizeListeners_里面的事件将不再执行。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
