### PR TITLE
Divider: Avoid user-written styles lost

### DIFF
--- a/packages/divider/src/main.js
+++ b/packages/divider/src/main.js
@@ -25,7 +25,7 @@ export default {
     const $slots = context.slots();
     const { direction, contentPosition } = context.props;
     return (
-      <div class={['el-divider', `el-divider--${direction}`]}>
+      <div class={['el-divider', `el-divider--${direction}`]} {...context.data}>
         {
           $slots.default && direction !== 'vertical'
             ? <div class={['el-divider__text', `is-${contentPosition}`]}>{$slots.default}</div>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you are merging your commits to `dev` branch.
* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Add some descriptions and refer relative issues for you PR.

---
Avoid user-written styles lost

in this case
``` vue
<el-divider style="margin: 0 20px" class="divider"></el-divider>
```
