### PR TITLE
Upload: abort upload when `before-upload` return `Promise<false>`

### DIFF
--- a/examples/docs/en-US/upload.md
+++ b/examples/docs/en-US/upload.md
@@ -358,7 +358,7 @@ on-success | hook function when uploaded successfully | function(response, file,
 on-error | hook function when some errors occurs | function(err, file, fileList) | — | —
 on-progress | hook function when some progress occurs | function(event, file, fileList) | — | — |
 on-change | hook function when select file or upload file success or upload file fail | function(file, fileList) | — | — |
-before-upload | hook function before uploading with the file to be uploaded as its parameter. If `false` is returned or a `Promise` is returned and then is rejected, uploading will be aborted | function(file) | — | —
+before-upload | hook function before uploading with the file to be uploaded as its parameter. If `false` or a `Promise` resolves with `false` or a `Promise` rejected is returned, uploading will be aborted | function(file) | — | —
 before-remove | hook function before removing a file with the file and file list as its parameters. If `false` is returned or a `Promise` is returned and then is rejected, removing will be aborted. | function(file, fileList) | — | — |
 thumbnail-mode | whether thumbnail is displayed | boolean | — | false
 file-list | default uploaded files, e.g. [{name: 'food.jpg', url: 'https://xxx.cdn.com/xxx.jpg'}] | array | — | []

--- a/examples/docs/zh-CN/upload.md
+++ b/examples/docs/zh-CN/upload.md
@@ -367,7 +367,7 @@
 | on-error | 文件上传失败时的钩子 | function(err, file, fileList) | — | — |
 | on-progress | 文件上传时的钩子 | function(event, file, fileList) | — | — |
 | on-change | 文件状态改变时的钩子，添加文件、上传成功和上传失败时都会被调用 | function(file, fileList) | — | — |
-| before-upload | 上传文件之前的钩子，参数为上传的文件，若返回 false 或者返回 Promise 且被 reject，则停止上传。 | function(file) | — | — |
+| before-upload | 上传文件之前的钩子，参数为上传的文件，若返回 false 或者 Promise&lt;false&gt; 或者 rejected Promise，则停止上传。 | function(file) | — | — |
 | before-remove | 删除文件之前的钩子，参数为上传的文件和文件列表，若返回 false 或者返回 Promise 且被 reject，则停止删除。| function(file, fileList) | — | — |
 | list-type | 文件列表的类型 | string | text/picture/picture-card | text |
 | auto-upload | 是否在选取文件后立即进行上传 | boolean | — | true |

--- a/packages/upload/src/upload.vue
+++ b/packages/upload/src/upload.vue
@@ -93,7 +93,9 @@ export default {
         before.then(processedFile => {
           const fileType = Object.prototype.toString.call(processedFile);
 
-          if (fileType === '[object File]' || fileType === '[object Blob]') {
+          if (processedFile === false) {
+            this.onRemove(null, rawFile);
+          } else if (fileType === '[object File]' || fileType === '[object Blob]') {
             if (fileType === '[object Blob]') {
               processedFile = new File([processedFile], rawFile.name, {
                 type: rawFile.type

--- a/test/unit/specs/upload.spec.js
+++ b/test/unit/specs/upload.spec.js
@@ -263,6 +263,23 @@ describe('Upload', () => {
         requests[0].respond(200, {}, `${files[0].name}`);
       }, 100);
     });
+    it('beforeUpload return promise<false>', done => {
+      const spy = sinon.spy();
+      handlers.beforeRemove = (file) => {
+        expect(spy.calledOnce).to.equal(true);
+        expect(uploader.uploadFiles.length).to.equal(1);
+        done();
+      };
+      const file = new Blob([JSON.stringify({}, null, 2)], {
+        type: 'application/json'
+      });
+      const files = [file];
+      handlers.beforeUpload = (file) => {
+        spy();
+        return Promise.resolve(false);
+      };
+      uploader.$refs['upload-inner'].handleChange({ target: { files }});
+    });
     it('beforeRemove return rejected promise', done => {
       const spy = sinon.spy();
       handlers.beforeRemove = (file) => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.


this PR changes `Upload` behavior `before-upload`, when `before-upload` return `Promise&lt;false&gt` will abort upload

fixes #15939

**Notice: This PR has Breaking changes**

TODO:

docs except `zh-CN` and `en-US` are not updated
