### PR TITLE
Submenu: fix prop append-to-body . #16289

### DIFF
--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -196,8 +196,12 @@
         this.timeout = setTimeout(() => {
           this.rootMenu.openMenu(this.index, this.indexPath);
         }, showTimeout);
+
+        if (this.appendToBody) {
+          this.$parent.$el.dispatchEvent(new MouseEvent('mouseenter'));
+        }
       },
-      handleMouseleave() {
+      handleMouseleave(deepDispatch = false) {
         const {rootMenu} = this;
         if (
           (rootMenu.menuTrigger === 'click' && rootMenu.mode === 'horizontal') ||
@@ -208,11 +212,14 @@
         this.dispatch('ElSubmenu', 'mouse-leave-child');
         clearTimeout(this.timeout);
         this.timeout = setTimeout(() => {
-          if (this.appendToBody) {
-            this.rootMenu.openedMenus = [];
-          }
           !this.mouseInChild && this.rootMenu.closeMenu(this.index);
         }, this.hideTimeout);
+
+        if (this.appendToBody && deepDispatch) {
+          if (this.$parent.$options.name === 'ElSubmenu') {
+            this.$parent.handleMouseleave(true);
+          }
+        }
       },
       handleTitleMouseenter() {
         if (this.mode === 'horizontal' && !this.rootMenu.backgroundColor) return;
@@ -279,7 +286,7 @@
             v-show={opened}
             class={[`el-menu--${mode}`, popperClass]}
             on-mouseenter={($event) => this.handleMouseenter($event, 100)}
-            on-mouseleave={this.handleMouseleave}
+            on-mouseleave={() => this.handleMouseleave(true)}
             on-focus={($event) => this.handleMouseenter($event, 100)}>
             <ul
               role="menu"
@@ -320,7 +327,7 @@
           aria-haspopup="true"
           aria-expanded={opened}
           on-mouseenter={this.handleMouseenter}
-          on-mouseleave={this.handleMouseleave}
+          on-mouseleave={() => this.handleMouseleave(false)}
           on-focus={this.handleMouseenter}
         >
           <div


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Issue
----
#16289 #16329

Description
---
1. `append-to-body` prop will append dom in body that they will lose relationship between parent and child event. So it should fix this relationship not just clear `openedMenus` when leave in child. 
2. `submenu` component leave have two situation, one is leave to `transition` component, it should emit parent `submenu` leave event to clear the `openedMenus`, other is leave to title warp component that just need to leave itself.

Description-CN
---
1.  `append-to-body`属性会让`dom`从`document.body`创建，意味此属性的多个`submenu`的事件（`mouseleave`和`mouseenter`）触发不存在父子关系。因此需要在`append-to-body`的时候修复这种关系而不能直接清空。
2.  `mouseleave`事件修复存在两种清空，一种是离开右侧弹出内容的部分，这部分需要触发父级的`mouseleave`事件递归清空。一种是离开title所包裹的部分，这时候只需要关闭其本身的菜单。



