### PR TITLE
Cascader: fix cascade selector show wrong value  (#16377)

### DIFF
--- a/packages/cascader-panel/src/store.js
+++ b/packages/cascader-panel/src/store.js
@@ -52,12 +52,23 @@ export default class Store {
 
   getNodeByValue(value) {
     if (value) {
-      value = Array.isArray(value) ? value[value.length - 1] : value;
+      const curValue = Array.isArray(value) ? value : [value];
+      const fullValue = curValue.slice(0).reverse().join('');
       const nodes = this.getFlattedNodes(false, !this.config.lazy)
-        .filter(node => node.value === value);
+        .filter(node => fullValue === this.getFullValue(node));
+
       return nodes && nodes.length ? nodes[0] : null;
     }
     return null;
   }
 
+  getFullValue(node) {
+    let fullValue = '';
+
+    for (let item = node; item; item = item.parent) {
+      fullValue += item.value || '';
+    }
+
+    return fullValue;
+  }
 }

--- a/packages/cascader-panel/src/store.js
+++ b/packages/cascader-panel/src/store.js
@@ -52,10 +52,17 @@ export default class Store {
 
   getNodeByValue(value) {
     if (value) {
-      const curValue = Array.isArray(value) ? value : [value];
-      const fullValue = curValue.slice(0).reverse().join('');
       const nodes = this.getFlattedNodes(false, !this.config.lazy)
-        .filter(node => fullValue === this.getFullValue(node));
+        .filter(node => {
+          // leaf node value can not locate the path
+          // find node by diff full value when value is array
+          if (Array.isArray(value)) {
+            const fullValue = value.slice(0).reverse().join('');
+            return fullValue === this.getFullValue(node);
+          }
+
+          return node.value === value;
+        });
 
       return nodes && nodes.length ? nodes[0] : null;
     }

--- a/test/unit/specs/cascader.spec.js
+++ b/test/unit/specs/cascader.spec.js
@@ -405,4 +405,106 @@ describe('Cascader', () => {
     await wait(300);
     expect(body.querySelector('.el-cascader__suggestion-item').textContent).to.equal('Zhejiang / Hangzhou / West Lake');
   });
+
+  it('options with same leaf value', async() => {
+    const sameValueOptions = [{
+      value: 'zhinan',
+      label: '指南',
+      children: [{
+        value: 'shejiyuanze',
+        label: '设计原则',
+        children: [{
+          value: 'yizhi',
+          label: '一致',
+          children: [
+            {
+              value: 'child01',
+              label: 'child01',
+              children: null
+            },
+            {
+              value: 'child02',
+              label: 'child02',
+              children: null
+            }
+          ]
+        }, {
+          value: 'fankui',
+          label: '反馈',
+          children: [
+            {
+              value: 'child01',
+              label: 'child01',
+              children: null
+            },
+            {
+              value: 'child02',
+              label: 'child02',
+              children: null
+            }
+          ]
+        }]
+      }]
+    }, {
+      value: '第二',
+      label: '第二',
+      children: [{
+        value: '211',
+        label: '第二1',
+        children: [{
+          value: '2221',
+          label: '一致2',
+          children: [
+            {
+              value: 'child01',
+              label: 'child01',
+              children: null
+            },
+            {
+              value: 'child02',
+              label: 'child02',
+              children: null
+            }
+          ]
+        }, {
+          value: '2222',
+          label: '反馈2',
+          children: [
+            {
+              value: 'child01',
+              label: 'child01',
+              children: null
+            },
+            {
+              value: 'child02',
+              label: 'child02',
+              children: null
+            }
+          ]
+        }]
+      }]
+    }];
+    vm = createVue({
+      template: `
+        <el-cascader
+          v-model="value"
+          :options="options"
+        ></el-cascader>
+      `,
+      data() {
+        return {
+          value: [],
+          options: sameValueOptions
+        };
+      }
+    }, true);
+
+    vm.value = ['zhinan', 'shejiyuanze', 'yizhi', 'child01'];
+    await waitImmediate();
+    expect(vm.$el.querySelector('input').value).to.equal('指南 / 设计原则 / 一致 / child01');
+
+    vm.value = ['第二', '211', '2221', 'child01'];
+    await waitImmediate();
+    expect(vm.$el.querySelector('input').value).to.equal('第二 / 第二1 / 一致2 / child01');
+  });
 });


### PR DESCRIPTION
问题：
        当两个路径的叶子节点的 value 一样的时候，cascader 输入框内展示的值错误。

修复前：
        根据叶子节点的 value 值计算 cascader 输入框内展示的值

修复后：
        根据整个 path 的 value 值计算 cascader 输入框内展示的值

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
