### PR TITLE
Cascader: add funciton support for props.disabled

### DIFF
--- a/packages/cascader-panel/src/node.js
+++ b/packages/cascader-panel/src/node.js
@@ -40,9 +40,9 @@ export default class Node {
 
   get isDisabled() {
     const { data, parent, config } = this;
-    const disabledKey = config.disabled;
+    const isDisabled = typeof config.disabled === 'function' ? config.disabled(data) : data[config.disabled];
     const { checkStrictly } = config;
-    return data[disabledKey] ||
+    return isDisabled ||
       !checkStrictly && parent && parent.isDisabled;
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

Props.disabled accepts function(data) which returns a boolean value to indicate whether this option is disabled or not. data is the node value.

#16097

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
