### PR TITLE
Update select.vue

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -563,6 +563,7 @@
       },
 
       handleFocus(event) {
+        this.resetHoverIndex();
         if (!this.softFocus) {
           if (this.automaticDropdown || this.filterable) {
             this.visible = true;


### PR DESCRIPTION
在某种特殊使用场景下，需要重置下hoverIndex以使用户直接在filter输入框回车的时候选中的是上次选过的（selected）而不应该是index＝-1的条目，因为default-first-option属性会令filter框在focus的时候总是hoverIndex=-1
该场景为：某个table单元格，点击变为可编辑，自动下拉选择，并有filter功能，选择完毕后单元格变为不可编辑，显示内容为选中的条目文字。如果回头修改，用户点击单元格后，期望直接回车选中上次的条目，而不是第一个。本场景里其实，选择完成后还有后续弹窗处理逻辑。
此种场景也许是第一次暴露，加一行代码，就解决了，逻辑更加严谨了。

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
