### PR TITLE
Checkbox: Improve screen reader experience

### DIFF
--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -7,9 +7,6 @@
       { 'is-bordered': border },
       { 'is-checked': isChecked }
     ]"
-    role="checkbox"
-    :aria-checked="indeterminate ? 'mixed': isChecked"
-    :aria-disabled="isDisabled"
     :id="id"
   >
     <span class="el-checkbox__input"
@@ -19,14 +16,16 @@
         'is-indeterminate': indeterminate,
         'is-focus': focus
       }"
-       aria-checked="mixed"
+      :tabindex="indeterminate ? 0 : false"
+      :role="indeterminate ? checkbox : false"
+      :aria-checked="indeterminate ? 'mixed' : false"
     >
       <span class="el-checkbox__inner"></span>
       <input
         v-if="trueLabel || falseLabel"
         class="el-checkbox__original"
         type="checkbox"
-        aria-hidden="true"
+        :aria-hidden="indeterminate ? 'true' : 'false'"
         :name="name"
         :disabled="isDisabled"
         :true-value="trueLabel"
@@ -39,7 +38,7 @@
         v-else
         class="el-checkbox__original"
         type="checkbox"
-        aria-hidden="true"
+        :aria-hidden="indeterminate ? 'true' : 'false'"
         :disabled="isDisabled"
         :value="label"
         :name="name"


### PR DESCRIPTION
Checkbox labels are not read aloud by the popular NVDA screen reader. Rather than applying `aria-hidden` to the native checkbox elements it would be better to follow the [first rule of ARIA use](https://www.w3.org/TR/using-aria/#rule1) and rely on the native element. Simply removing all the aria attributes results in a much better experience. 

This PR does attempt to preserve the aria attributes for checkboxes in the indeterminate state, but it seems an `id` may be necessary to get that working. In other words, indeterminate checkboxes are no better or worse off with this PR.

Two videos show the screen reader experience [before](https://www.loom.com/share/294b09685e9a498380ba1bdbfdd14b5a) and [after](https://www.loom.com/share/346bc75bfc70428da2a785ae053b0900) this update.