### PR TITLE
Calendar: remove useless map on date-table

### DIFF
--- a/packages/calendar/src/date-table.vue
+++ b/packages/calendar/src/date-table.vue
@@ -122,14 +122,8 @@ export default {
         let firstDay = getFirstDayOfMonth(date);
         firstDay = firstDay === 0 ? 7 : firstDay;
         const firstDayOfWeek = typeof this.firstDayOfWeek === 'number' ? this.firstDayOfWeek : 1;
-        const prevMonthDays = getPrevMonthLastDays(date, firstDay - firstDayOfWeek).map(day => ({
-          text: day,
-          type: 'prev'
-        }));
-        const currentMonthDays = getMonthDays(date).map(day => ({
-          text: day,
-          type: 'current'
-        }));
+        const prevMonthDays = getPrevMonthLastDays(date, firstDay - firstDayOfWeek);
+        const currentMonthDays = getMonthDays(date);
         days = [...prevMonthDays, ...currentMonthDays];
         const nextMonthDays = rangeArr(42 - days.length).map((_, index) => ({
           text: index + 1,

--- a/src/utils/date-util.js
+++ b/src/utils/date-util.js
@@ -137,13 +137,13 @@ export const getPrevMonthLastDays = (date, amount) => {
   const temp = new Date(date.getTime());
   temp.setDate(0);
   const lastDay = temp.getDate();
-  return range(amount).map((_, index) => lastDay - (amount - index - 1));
+  return range(amount).map((_, index) => ({text: lastDay - (amount - index - 1), type: 'prev'}));
 };
 
 export const getMonthDays = (date) => {
   const temp = new Date(date.getFullYear(), date.getMonth() + 1, 0);
   const days = temp.getDate();
-  return range(days).map((_, index) => index + 1);
+  return range(days).map((_, index) => ({text: index + 1, type: 'current'}));
 };
 
 function setRangeData(arr, start, end, value) {


### PR DESCRIPTION
I removed useless map of `prevMonthDays` and `currentMonthDays` on `date-table.vue`.
Simpler and better optimization.