### PR TITLE
Header: Remove default value for height property

### DIFF
--- a/packages/header/src/main.vue
+++ b/packages/header/src/main.vue
@@ -12,8 +12,7 @@
 
     props: {
       height: {
-        type: String,
-        default: '60px'
+        type: String
       }
     }
   };


### PR DESCRIPTION
Remove default value for the header component property. Since the default value keeps the inline CSS active, it requires an !important to be overwritten. 

This change keeps the functionality of the property untouched. It allows header with a variable height.

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.
