### PR TITLE
Input: Add "required" attribute

### DIFF
--- a/examples/docs/en-US/date-picker.md
+++ b/examples/docs/en-US/date-picker.md
@@ -436,6 +436,7 @@ When picking a date range, you can assign the time part for start date and end d
 | value / v-model | binding value | date(DatePicker) / array(DateRangePicker) | — | — |
 | readonly | whether DatePicker is read only | boolean | — | false |
 | disabled | whether DatePicker is disabled | boolean | — | false |
+| required | whether DatePicker is required | boolean | — | false |
 | size | size of Input | string | large/small/mini | — |
 | editable | whether the input is editable | boolean | — | true |
 | clearable | whether to show clear button | boolean | — | true |

--- a/examples/docs/en-US/datetime-picker.md
+++ b/examples/docs/en-US/datetime-picker.md
@@ -193,6 +193,7 @@ DateTimePicker is derived from DatePicker and TimePicker. For a more detailed ex
 | value / v-model | binding value | date(DateTimePicker) / array(DateTimeRangePicker) | — | — |
 | readonly | whether DatePicker is read only | boolean | — | false |
 | disabled | whether DatePicker is disabled | boolean | — | false |
+| required | whether DatePicker is disabled | required | — | false |
 | editable | whether the input is editable | boolean | — | true |
 | clearable | whether to show clear button | boolean | — | true |
 |size | size of Input | string | large/small/mini | — |

--- a/examples/docs/en-US/datetime-picker.md
+++ b/examples/docs/en-US/datetime-picker.md
@@ -193,7 +193,7 @@ DateTimePicker is derived from DatePicker and TimePicker. For a more detailed ex
 | value / v-model | binding value | date(DateTimePicker) / array(DateTimeRangePicker) | — | — |
 | readonly | whether DatePicker is read only | boolean | — | false |
 | disabled | whether DatePicker is disabled | boolean | — | false |
-| required | whether DatePicker is disabled | required | — | false |
+| required | whether DatePicker is disabled | boolean | — | false |
 | editable | whether the input is editable | boolean | — | true |
 | clearable | whether to show clear button | boolean | — | true |
 |size | size of Input | string | large/small/mini | — |

--- a/examples/docs/en-US/input-number.md
+++ b/examples/docs/en-US/input-number.md
@@ -47,6 +47,27 @@ Input numerical values with a customizable range.
 ```
 :::
 
+### Required
+
+:::demo Make the Input required with the `required` attribute.
+
+```html
+</el-input>
+<template>
+  <el-input-number v-model="num" required></el-input-number>
+</template>
+<script>
+export default {
+  data() {
+    return {
+      input: ''
+    }
+  }
+}
+</script>
+```
+:::
+
 ### Steps
 
 Allows you to define incremental steps.

--- a/examples/docs/en-US/input.md
+++ b/examples/docs/en-US/input.md
@@ -53,6 +53,29 @@ export default {
 ```
 :::
 
+### Required
+
+:::demo Make the Input required with the `required` attribute.
+
+```html
+<el-input
+  placeholder="Please input"
+  v-model="input"
+  required>
+</el-input>
+
+<script>
+export default {
+  data() {
+    return {
+      input: ''
+    }
+  }
+}
+</script>
+```
+:::
+
 ### Clearable
 
 :::demo Make the Input clearable with the `clearable` attribute.

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -18,6 +18,7 @@
     @mouseenter.native="handleMouseEnter"
     @mouseleave.native="showClose = false"
     :validateEvent="false"
+    :required="required"
     ref="reference">
     <i slot="prefix"
       class="el-input__icon"
@@ -54,6 +55,7 @@
       :disabled="pickerDisabled"
       v-bind="firstInputId"
       :readonly="!editable || readonly"
+      :required="required"
       :name="name && name[0]"
       @input="handleStartInput"
       @change="handleStartChange"
@@ -69,6 +71,7 @@
       :disabled="pickerDisabled"
       v-bind="secondInputId"
       :readonly="!editable || readonly"
+      :required="required"
       :name="name && name[1]"
       @input="handleEndInput"
       @change="handleEndChange"
@@ -97,7 +100,8 @@ const NewPopper = {
     appendToBody: Popper.props.appendToBody,
     offset: Popper.props.offset,
     boundariesPadding: Popper.props.boundariesPadding,
-    arrowOffset: Popper.props.arrowOffset
+    arrowOffset: Popper.props.arrowOffset,
+    required: Boolean
   },
   methods: Popper.methods,
   data() {

--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -36,6 +36,7 @@
       :min="min"
       :name="name"
       :label="label"
+      :required="required"
       @keydown.up.native.prevent="increase"
       @keydown.down.native.prevent="decrease"
       @blur="handleBlur"
@@ -86,6 +87,7 @@
       },
       value: {},
       disabled: Boolean,
+      required: Boolean,
       size: String,
       controls: {
         type: Boolean,

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -29,6 +29,7 @@
         :disabled="inputDisabled"
         :readonly="readonly"
         :autocomplete="autoComplete || autocomplete"
+        :required="required"
         ref="input"
         @compositionstart="handleCompositionStart"
         @compositionend="handleCompositionEnd"
@@ -94,6 +95,7 @@
       :disabled="inputDisabled"
       :readonly="readonly"
       :autocomplete="autoComplete || autocomplete"
+      :required="required"
       :style="textareaStyle"
       @focus="handleFocus"
       @blur="handleBlur"
@@ -145,6 +147,7 @@
       form: String,
       disabled: Boolean,
       readonly: Boolean,
+      required: Boolean,
       type: {
         type: String,
         default: 'text'


### PR DESCRIPTION
Added 'required' attribute to picker.vue, input.vue, and input-number.vue to bubble down to the root input element so the validityState API can be used to validate these fields have values present.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
