### PR TITLE
Fixes #16737 where the `window not defined` error causes SSR builds to fail

### DIFF
--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -66,7 +66,7 @@ const Mode = {
   }
 };
 
-const isFirefox = !!window.navigator.userAgent.match(/firefox/i);
+const isFirefox = typeof window !== 'undefined' && !!window.navigator.userAgent.match(/firefox/i);
 const mousewheelEventName = isFirefox ? 'DOMMouseScroll' : 'mousewheel';
 
 export default {


### PR DESCRIPTION
Fixes the issue #16737 by checking window existence before using it. See the issue for a test project showing the problem.

Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.
