### PR TITLE
Calendar : Fix i18n error

### DIFF
--- a/packages/calendar/src/date-table.vue
+++ b/packages/calendar/src/date-table.vue
@@ -2,7 +2,6 @@
 import fecha from 'element-ui/src/utils/date';
 import { range as rangeArr, getFirstDayOfMonth, getPrevMonthLastDays, getMonthDays, getI18nSettings, validateRangeInOneMonth } from 'element-ui/src/utils/date-util';
 
-const WEEK_DAYS = getI18nSettings().dayNames;
 export default {
   props: {
     selectedDay: String, // formated date yyyy-MM-dd
@@ -20,7 +19,13 @@ export default {
   },
 
   inject: ['elCalendar'],
-
+  
+  data() {
+    return {
+      WEEK_DAYS: getI18nSettings().dayNames;
+    }
+  },
+  
   methods: {
     toNestedArr(days) {
       return rangeArr(days.length / 7).map((_, index) => {
@@ -143,9 +148,9 @@ export default {
     weekDays() {
       const start = this.firstDayOfWeek;
       if (typeof start !== 'number' || start === 0) {
-        return WEEK_DAYS.slice();
+        return this.WEEK_DAYS.slice();
       } else {
-        return WEEK_DAYS.slice(start).concat(WEEK_DAYS.slice(0, start));
+        return this.WEEK_DAYS.slice(start).concat(this.WEEK_DAYS.slice(0, start));
       }
     }
   },


### PR DESCRIPTION
I moved variable `WEEK_DAYS` declaration in `root` to `data`.

In root declaration, `getI18nSettings()` couldn't get changed i18n settings.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
