### PR TITLE
Table: fix column dislocation after update(#16667)

### DIFF
--- a/packages/theme-chalk/src/table.scss
+++ b/packages/theme-chalk/src/table.scss
@@ -403,6 +403,10 @@
   @include e((header-wrapper, footer-wrapper)) {
     overflow: hidden;
 
+    & th {
+      width: 80px;
+    }
+
     & tbody td {
       background-color: $--table-row-hover-background-color;
       color: $--table-font-color;


### PR DESCRIPTION
close #16667 

动态插入column的时候，执行了`table.debouncedUpdateLayout`，`debouncedUpdateLayout`是防抖函数，50ms 延迟，DOM更新，插入新单元格。

抖动的原因是新的单元格插入时没设置宽度，表格本身自适应(不太确定这个说法是否准确)，增加了单元格的高度，column更新宽度之后又恢复正常了。`layout.updateElsHeight`里面拿到的`headerHeight`刚好是单元格被撑高的那个时候的高度。

![1](https://user-images.githubusercontent.com/18650703/62001839-f09c5c80-b12b-11e9-81cd-112d4a2833d1.png)

在`layout.updateElsHeight` 添加多一个延迟为0的`setTimeout`更新来`headerHeight/bodyHeight`也可以达到效果，但会回流，所以选择了用css设置初始宽度的方法。

这里是效果 https://codepen.io/icecoffee/pen/aeBQPY

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
