### PR TITLE
Table: fix current-update event bug (#16670)

### DIFF
--- a/packages/table/src/store/current.js
+++ b/packages/table/src/store/current.js
@@ -41,6 +41,10 @@ export default {
       const data = states.data || [];
       const oldCurrentRow = states.currentRow;
 
+      if (!currentRow || currentRow instanceof MouseEvent) {
+        currentRow = null;
+      }
+
       if (currentRow) {
         this.restoreCurrentRowKey();
         states.currentRow = currentRow;
@@ -62,6 +66,11 @@ export default {
           }
         } else if (_currentRowKey) {
           this.setCurrentRowByKey(_currentRowKey);
+        } else {
+          states.currentRow = currentRow;
+          if (states.currentRow !== oldCurrentRow) {
+            table.$emit('current-change', null, oldCurrentRow);
+          }
         }
       }
     }


### PR DESCRIPTION
close #16670 

在最后添加了处理对参数是`undefined`的处理。

把`MouseEvent`当成`null`处理是因为绑定如`@click="setCurrent"`的情况，重复点击时也会重复触发`current-change`，实际上并没有选中行改变，复现链接https://codepen.io/icecoffee/pen/EqNMyW?editors=1111

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
