### PR TITLE
Icon: Adding font-display to @font-face declaration

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -104,6 +104,7 @@ $--fill-base: $--color-white !default;
 /* Typography
 -------------------------- */
 $--font-path: 'fonts' !default;
+$--font-display: 'auto' !default;
 /// fontSize|1|Font Size|0
 $--font-size-extra-large: 20px !default;
 /// fontSize|1|Font Size|0

--- a/packages/theme-chalk/src/icon.scss
+++ b/packages/theme-chalk/src/icon.scss
@@ -5,7 +5,8 @@
   src: url('#{$--font-path}/element-icons.woff') format('woff'), /* chrome, firefox */
        url('#{$--font-path}/element-icons.ttf') format('truetype'); /* chrome, firefox, opera, Safari, Android, iOS 4.2+*/
   font-weight: normal;
-  font-style: normal
+  font-display: $--font-display;
+  font-style: normal;
 }
 
 [class^="el-icon-"], [class*=" el-icon-"] {


### PR DESCRIPTION
Currently, I'm working on optimizing our website to boost its performance
By running Chrome Lighthouse audits, the results warn me about this web font not having a [`font-display`](https://developers.google.com/web/updates/2016/02/font-display) property set
I've solved this problem by declaring the font face with the new property added

I think it can be useful to add this declaration to improve performance of the webfont loading and rendering

Reference:
https://github.com/FortAwesome/Font-Awesome/issues/14387#issuecomment-454062536
https://github.com/FortAwesome/Font-Awesome/blob/master/scss/_variables.scss#L6
https://github.com/FortAwesome/Font-Awesome/blob/master/scss/solid.scss#L11

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
