### PR TITLE
Dialog: fix body not render when invisible.

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -25,7 +25,7 @@
             <i class="el-dialog__close el-icon el-icon-close"></i>
           </button>
         </div>
-        <div class="el-dialog__body" ><slot></slot></div>
+        <div class="el-dialog__body"><slot></slot></div>
         <div class="el-dialog__footer" v-if="$slots.footer">
           <slot name="footer"></slot>
         </div>

--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -25,7 +25,7 @@
             <i class="el-dialog__close el-icon el-icon-close"></i>
           </button>
         </div>
-        <div class="el-dialog__body" v-if="rendered"><slot></slot></div>
+        <div class="el-dialog__body" ><slot></slot></div>
         <div class="el-dialog__footer" v-if="$slots.footer">
           <slot name="footer"></slot>
         </div>
@@ -183,7 +183,6 @@
 
     mounted() {
       if (this.visible) {
-        this.rendered = true;
         this.open();
         if (this.appendToBody) {
           document.body.appendChild(this.$el);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

 Reproduction Link
---
https://codepen.io/a631807682/pen/zgwwvL?editors=1011

Steps to reproduce
---
1. open dialog
2. see the console

What is Expected?
---
footer ref is exist but body ref is not exist when dialog invisible.

What is actually happening?
---
footer and body ref is exist.