### PR TITLE
TimePicker: Fix text selection for 12-hour format

### DIFF
--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -207,12 +207,13 @@
       },
 
       emitSelectRange(type) {
+        var hoursLen = this.amPmMode && (this.date.getHours() % 12) !== 0 && (this.date.getHours() % 12) < 10 ? 1 : 2;
         if (type === 'hours') {
-          this.$emit('select-range', 0, 2);
+          this.$emit('select-range', 0, hoursLen);
         } else if (type === 'minutes') {
-          this.$emit('select-range', 3, 5);
+          this.$emit('select-range', 3 - (2 - hoursLen), 5 - (2 - hoursLen));
         } else if (type === 'seconds') {
-          this.$emit('select-range', 6, 8);
+          this.$emit('select-range', 6 - (2 - hoursLen), 8 - (2 - hoursLen));
         }
         this.currentScrollbar = type;
       },

--- a/packages/date-picker/src/panel/time.vue
+++ b/packages/date-picker/src/panel/time.vue
@@ -170,7 +170,8 @@
       },
 
       changeSelectionRange(step) {
-        const list = [0, 3].concat(this.showSeconds ? [6] : []);
+        var hoursLen = this.amPmMode && (this.date.getHours() % 12) !== 0 && (this.date.getHours() % 12) < 10 ? 1 : 2;
+        const list = [0, (3 - (2 - hoursLen))].concat(this.showSeconds ? [(6 - (2 - hoursLen))] : []);
         const mapping = ['hours', 'minutes'].concat(this.showSeconds ? ['seconds'] : []);
         const index = list.indexOf(this.selectionRange[0]);
         const next = (index + step + list.length) % list.length;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.

When using a 12-hour format, the selected characters in the time spinner are off by 1 when the hour is less than 10. This fixes the problem by determining the length that the selection should be for the hour part, based on the AM/PM mode and the hour value, and adjusts every part based on that value. This fixes issue #16865 - [Bug Report] Time picker selected text is off by 1 when 12-hour format is used
