### PR TITLE
TimePicker: Set the selection range after scrolling up or down

### DIFF
--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -283,6 +283,7 @@
 
         this.modifyDateField(label, now);
         this.adjustSpinner(label, now);
+        this.$nextTick(() => this.emitSelectRange(this.currentScrollbar));
       },
       amPm(hour) {
         let shouldShowAmPm = this.amPmMode.toLowerCase() === 'a';


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.

After scrolling up or down in the time picker's text box, the selected text is lost and the cursor goes to the end of the input (though scrolling continues to work). This fixes the problem by calling `emitSelectRange` at the end of the `scrollDown` method.

`this.$nextTick(() => this.emitSelectRange(this.currentScrollbar));`

Fixes #16866 - [Bug Report] Time picker doesn't visually select the part being edited via directional keys
