### PR TITLE
Select: change the order of events option click emit before input blur.

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -1,6 +1,7 @@
 <template>
   <li
     @mouseenter="hoverItem"
+    @mousedown.prevent
     @click.stop="selectOptionClick"
     class="el-select-dropdown__item"
     v-show="visible"

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -580,13 +580,13 @@
       },
 
       handleBlur(event) {
-        setTimeout(() => {
+        this.$nextTick(() => {
           if (this.isSilentBlur) {
             this.isSilentBlur = false;
           } else {
             this.$emit('blur', event);
           }
-        }, 50);
+        });
         this.softFocus = false;
       },
 
@@ -851,7 +851,10 @@
         this.handleQueryChange(e.target.value);
       });
 
-      this.$on('handleOptionClick', this.handleOptionSelect);
+      this.$on('handleOptionClick', (option, byClick) => {
+        this.handleOptionSelect(option, byClick);
+        this.handleBlur();
+      });
       this.$on('setSelected', this.setSelected);
     },
 

--- a/test/unit/specs/select.spec.js
+++ b/test/unit/specs/select.spec.js
@@ -689,11 +689,11 @@ describe('Select', () => {
     vm.$el.querySelector('input').focus();
     vm.$el.querySelector('input').blur();
 
-    setTimeout(_ => {
+    vm.$nextTick(_ => {
       expect(spyFocus.calledOnce).to.be.true;
       expect(spyBlur.calledOnce).to.be.true;
       done();
-    }, 100);
+    });
   });
 
   it('should return focus to input inside select after option select', done => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

* related #16877
* related #10810

desc
---
1. default order of events is that
   > option mousedown 
input blur 
option mouseup
option click

   so if task finish in 50ms what `handleBlur` timout setting, blur event is expected.

2. this edit is  to contrl the order of events by `mousedown.prevent` that trigger `handleOptionSelect` and then execute `handleBlur`
