### PR TITLE
Select: Prevent browser autocomplete

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -43,7 +43,7 @@
       </transition-group>
 
       <input
-        type="text"
+        :type="inputType"
         class="el-select__input"
         :class="[selectSize ? `is-${ selectSize }` : '']"
         :disabled="selectDisabled"
@@ -70,7 +70,7 @@
     <el-input
       ref="reference"
       v-model="selectedLabel"
-      type="text"
+      :type="inputType"
       :placeholder="currentPlaceholder"
       :name="name"
       :id="id"
@@ -176,6 +176,10 @@
     computed: {
       _elFormItemSize() {
         return (this.elFormItem || {}).elFormItemSize;
+      },
+
+      inputType() {
+        return this.autocomplete === 'off' ? 'search' : 'text';
       },
 
       readonly() {

--- a/test/unit/specs/select.spec.js
+++ b/test/unit/specs/select.spec.js
@@ -3,7 +3,7 @@ import Select from 'packages/select';
 
 describe('Select', () => {
   const getSelectVm = (configs = {}, options) => {
-    ['multiple', 'clearable', 'filterable', 'allowCreate', 'remote', 'collapseTags', 'automaticDropdown'].forEach(config => {
+    ['multiple', 'clearable', 'filterable', 'allowCreate', 'remote', 'collapseTags', 'automaticDropdown', 'autocomplete'].forEach(config => {
       configs[config] = configs[config] || false;
     });
     configs.multipleLimit = configs.multipleLimit || 0;
@@ -37,6 +37,7 @@ describe('Select', () => {
             ref="select"
             v-model="value"
             :multiple="multiple"
+            :autocomplete="autocomplete"
             :multiple-limit="multipleLimit"
             :popper-class="popperClass"
             :clearable="clearable"
@@ -289,6 +290,15 @@ describe('Select', () => {
       expect(iconClear).to.exist;
       iconClear.click();
       expect(vm.value).to.equal('');
+      done();
+    }, 100);
+  });
+
+  it('autocomplete off', done => {
+    vm = getSelectVm({ autocomplete: 'off' });
+    setTimeout(() => {
+      const input = vm.$el.querySelector('.el-input input');
+      expect(input.type).to.equal('search');
       done();
     }, 100);
   });


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

This PR aims to remove browser autocomplete when `autocomplete="off"` by adding `type="search"` to the select input.

[MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#Values) states that having only `autocomplete="off"` is not enough to prevent browser autocomplete. Inputs of `type="search"` usually turn off this behaviour