### PR TITLE
fix: drawer when content is too much

### DIFF
--- a/packages/theme-chalk/src/drawer.scss
+++ b/packages/theme-chalk/src/drawer.scss
@@ -163,6 +163,7 @@ $directions: rtl, ltr, ttb, btt;
     height: 100%;
     top: 0;
     bottom: 0;
+    overflow-y: auto;
   }
 
   &.ttb, &.btt {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
### Issues
https://github.com/ElemeFE/element/issues/16896

修复：
当 drawer 内容过多时，无法展示的问题
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
