### PR TITLE
TimePicker: Add support for toggling AM/PM

### DIFF
--- a/examples/docs/en-US/time-picker.md
+++ b/examples/docs/en-US/time-picker.md
@@ -169,6 +169,7 @@ Can pick an arbitrary time range.
 | name | same as `name` in native input | string | — | — |
 | prefix-icon | Custom prefix icon class | string | — | el-icon-time |
 | clear-icon | Custom clear icon class | string | — | el-icon-circle-close |
+| toggle-am-pm | whether an AM/PM selector should be rendered, only works with `<el-time-picker>` when the format includes AM/PM, and is best used in conjunction with `arrow-control` | boolean | — | false |
 
 ### Time Select Options
 | Attribute      | Description          | Type      | Accepted Values       | Default  |

--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -15,7 +15,7 @@
           v-for="(disabled, hour) in hoursList"
           class="el-time-spinner__item"
           :key="hour"
-          :class="{ 'active': hour === hours, 'disabled': disabled }">{{ ('0' + (amPmMode ? (hour % 12 || 12) : hour )).slice(-2) }}{{ getAmPm(hour, { prefix: ' ' }) }}</li>
+          :class="{ 'active': hour === hours, 'disabled': disabled }">{{ ('0' + (twelveHourClock ? (hour % 12 || 12) : hour )).slice(-2) }}{{ getAmPm(hour, { prefix: ' ' }) }}</li>
       </el-scrollbar>
       <el-scrollbar
         @mouseenter.native="emitSelectRange('minutes')"
@@ -79,7 +79,7 @@
             class="el-time-spinner__item"
             :class="{ 'active': hour === hours, 'disabled': hoursList[hour] }"
             v-for="(hour, key) in arrowHourList"
-            :key="key">{{ hour === undefined ? '' : ('0' + (amPmMode ? (hour % 12 || 12) : hour )).slice(-2) + (showAmPm ? '' : getAmPm(hour, { prefix: ' ' })) }}</li>
+            :key="key">{{ hour === undefined ? '' : ('0' + (twelveHourClock ? (hour % 12 || 12) : hour )).slice(-2) + (showAmPm ? '' : getAmPm(hour, { prefix: ' ' })) }}</li>
         </ul>
       </div>
       <div
@@ -161,6 +161,7 @@
         type: String,
         default: '' // 'a': am/pm; 'A': AM/PM
       },
+      twelveHourClock: Boolean,
       zeroPadHour: Boolean
     },
 
@@ -268,7 +269,7 @@
       },
 
       emitSelectRange(type) {
-        const hoursLen = !this.zeroPadHour && (this.date.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const hoursLen = !this.zeroPadHour && (this.twelveHourClock ? (this.date.getHours() % 12 || 12) : this.date.getHours()) < 10 ? 1 : 2;
         const secondsOffset = this.showSeconds ? 3 : 0;
         if (type === 'hours') {
           this.$emit('select-range', 0, hoursLen);

--- a/packages/date-picker/src/basic/time-spinner.vue
+++ b/packages/date-picker/src/basic/time-spinner.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="el-time-spinner" :class="{ 'has-seconds': showSeconds }">
+  <div class="el-time-spinner" :class="{ 'has-seconds': showSeconds, 'has-am-pm': showAmPm }">
     <template v-if="!arrowControl">
       <el-scrollbar
         @mouseenter.native="emitSelectRange('hours')"
@@ -15,7 +15,7 @@
           v-for="(disabled, hour) in hoursList"
           class="el-time-spinner__item"
           :key="hour"
-          :class="{ 'active': hour === hours, 'disabled': disabled }">{{ ('0' + (amPmMode ? (hour % 12 || 12) : hour )).slice(-2) }}{{ amPm(hour) }}</li>
+          :class="{ 'active': hour === hours, 'disabled': disabled }">{{ ('0' + (amPmMode ? (hour % 12 || 12) : hour )).slice(-2) }}{{ getAmPm(hour, { prefix: ' ' }) }}</li>
       </el-scrollbar>
       <el-scrollbar
         @mouseenter.native="emitSelectRange('minutes')"
@@ -50,6 +50,23 @@
           :class="{ 'active': key === seconds }"
           :key="key">{{ ('0' + key).slice(-2) }}</li>
       </el-scrollbar>
+      <el-scrollbar
+        v-show="showAmPm"
+        @mouseenter.native="emitSelectRange('amPm')"
+        @mousemove.native="adjustCurrentSpinner('amPm')"
+        class="el-time-spinner__wrapper"
+        wrap-style="max-height: inherit;"
+        view-class="el-time-spinner__list"
+        noresize
+        tag="ul"
+        ref="amPm">
+        <li
+          @click="handleClick('amPm', { value: key, disabled: false })"
+          v-for="(value, key) in amPmList"
+          class="el-time-spinner__item"
+          :class="{ 'active': key === amPm }"
+          :key="key">{{ key ? getAmPm(12) : getAmPm(0) }}</li>
+      </el-scrollbar>
     </template>
     <template v-if="arrowControl">
       <div
@@ -62,7 +79,7 @@
             class="el-time-spinner__item"
             :class="{ 'active': hour === hours, 'disabled': hoursList[hour] }"
             v-for="(hour, key) in arrowHourList"
-            :key="key">{{ hour === undefined ? '' : ('0' + (amPmMode ? (hour % 12 || 12) : hour )).slice(-2) + amPm(hour) }}</li>
+            :key="key">{{ hour === undefined ? '' : ('0' + (amPmMode ? (hour % 12 || 12) : hour )).slice(-2) + (showAmPm ? '' : getAmPm(hour, { prefix: ' ' })) }}</li>
         </ul>
       </div>
       <div
@@ -96,6 +113,22 @@
           </li>
         </ul>
       </div>
+      <div
+        @mouseenter="emitSelectRange('amPm')"
+        class="el-time-spinner__wrapper is-arrow"
+        v-if="showAmPm">
+        <i v-repeat-click="decrease" class="el-time-spinner__arrow el-icon-arrow-up"></i>
+        <i v-repeat-click="increase" class="el-time-spinner__arrow el-icon-arrow-down"></i>
+        <ul class="el-time-spinner__list" ref="amPm">
+          <li
+            v-for="(amOrPm, key) in arrowAmPmList"
+            class="el-time-spinner__item"
+            :class="{ 'active': amOrPm === amPm }"
+            :key="key">
+            {{ amOrPm === undefined ? '' : (amOrPm ? getAmPm(12) : getAmPm(0)) }}
+          </li>
+        </ul>
+      </div>
     </template>
   </div>
 </template>
@@ -119,11 +152,16 @@
         type: Boolean,
         default: true
       },
+      showAmPm: {
+        type: Boolean,
+        default: false
+      },
       arrowControl: Boolean,
       amPmMode: {
         type: String,
         default: '' // 'a': am/pm; 'A': AM/PM
-      }
+      },
+      zeroPadHour: Boolean
     },
 
     computed: {
@@ -136,18 +174,27 @@
       seconds() {
         return this.date.getSeconds();
       },
+      amPm() {
+        return this.date.getHours() >= 12 ? 1 : 0;
+      },
       hoursList() {
         return getRangeHours(this.selectableRange);
       },
       minutesList() {
         return getRangeMinutes(this.selectableRange, this.hours);
       },
+      amPmList() {
+        return [0, 1];
+      },
       arrowHourList() {
         const hours = this.hours;
+        // Only show 12 hours if toggling AM/PM
+        const minHour = this.showAmPm ? (this.amPm ? 12 : 0) : 0;
+        const maxHour = this.showAmPm ? (this.amPm ? 23 : 11) : 23;
         return [
-          hours > 0 ? hours - 1 : undefined,
+          hours > minHour ? hours - 1 : undefined,
           hours,
-          hours < 23 ? hours + 1 : undefined
+          hours < maxHour ? hours + 1 : undefined
         ];
       },
       arrowMinuteList() {
@@ -165,6 +212,19 @@
           seconds,
           seconds < 59 ? seconds + 1 : undefined
         ];
+      },
+      arrowAmPmList() {
+        var list = this.amPmMode ? [0, 1] : [];
+        // Since there are only two options for AM/PM, prepend or append
+        // a blank option depending on what is currently selected
+        if (list.length) {
+          if (this.amPm) {
+            list.push(undefined);
+          } else {
+            list.splice(0, 0, undefined);
+          }
+        }
+        return list;
       }
     },
 
@@ -195,6 +255,7 @@
           case 'hours': this.$emit('change', modifyTime(this.date, value, this.minutes, this.seconds)); break;
           case 'minutes': this.$emit('change', modifyTime(this.date, this.hours, value, this.seconds)); break;
           case 'seconds': this.$emit('change', modifyTime(this.date, this.hours, this.minutes, value)); break;
+          case 'amPm': this.$emit('change', modifyTime(this.date, this.hours % 12 + (value ? 12 : 0), this.minutes, this.seconds)); break;
         }
       },
 
@@ -207,12 +268,16 @@
       },
 
       emitSelectRange(type) {
+        const hoursLen = !this.zeroPadHour && (this.date.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const secondsOffset = this.showSeconds ? 3 : 0;
         if (type === 'hours') {
-          this.$emit('select-range', 0, 2);
+          this.$emit('select-range', 0, hoursLen);
         } else if (type === 'minutes') {
-          this.$emit('select-range', 3, 5);
+          this.$emit('select-range', 3 - (2 - hoursLen), 5 - (2 - hoursLen));
         } else if (type === 'seconds') {
-          this.$emit('select-range', 6, 8);
+          this.$emit('select-range', 6 - (2 - hoursLen), 8 - (2 - hoursLen));
+        } else if (type === 'amPm') {
+          this.$emit('select-range', 6 + secondsOffset - (2 - hoursLen), 8 + secondsOffset - (2 - hoursLen));
         }
         this.currentScrollbar = type;
       },
@@ -228,6 +293,7 @@
         bindFuntion('hours');
         bindFuntion('minutes');
         bindFuntion('seconds');
+        bindFuntion('amPm');
       },
 
       handleScroll(type) {
@@ -242,6 +308,7 @@
         this.adjustSpinner('hours', this.hours);
         this.adjustSpinner('minutes', this.minutes);
         this.adjustSpinner('seconds', this.seconds);
+        this.adjustSpinner('amPm', this.amPm);
       },
 
       adjustCurrentSpinner(type) {
@@ -261,11 +328,25 @@
           this.emitSelectRange('hours');
         }
 
-        const label = this.currentScrollbar;
+        var label = this.currentScrollbar;
         const hoursList = this.hoursList;
         let now = this[label];
 
-        if (this.currentScrollbar === 'hours') {
+        if (label === 'amPm') {
+          if (now === 0) {
+            step = 12;
+            label = 'hours';
+            now = this.hours;
+          } else if (now === 1) {
+            step = -12;
+            label = 'hours';
+            now = this.hours;
+          } else {
+            return;
+          }
+        }
+
+        if (label === 'hours') {
           let total = Math.abs(step);
           step = step > 0 ? 1 : -1;
           let length = hoursList.length;
@@ -283,14 +364,16 @@
 
         this.modifyDateField(label, now);
         this.adjustSpinner(label, now);
+        this.$nextTick(() => this.emitSelectRange(this.currentScrollbar));
       },
-      amPm(hour) {
+      getAmPm(hour, options) {
+        const prefix = options && typeof options.prefix === 'string' ? options.prefix : '';
         let shouldShowAmPm = this.amPmMode.toLowerCase() === 'a';
         if (!shouldShowAmPm) return '';
         let isCapital = this.amPmMode === 'A';
-        let content = (hour < 12) ? ' am' : ' pm';
+        let content = (hour < 12) ? 'am' : 'pm';
         if (isCapital) content = content.toUpperCase();
-        return content;
+        return prefix + content;
       },
       typeItemHeight(type) {
         return this.$refs[type].$el.querySelector('li').offsetHeight;

--- a/packages/date-picker/src/panel/time-range.vue
+++ b/packages/date-picker/src/panel/time-range.vue
@@ -96,6 +96,9 @@
       },
 
       showAmPm() {
+        // Even if `toggle-am-pm` is set to true, if the time format doesn't include AM/PM then they won't be shown,
+        // since this would create an inconsistency between the picker and the formatted time value. Also, although it
+        // isn't required, AM/PM toggling should be used along with the `arrow-control` option to provide the best result.
         return this.toggleAmPm && ((this.format || '').indexOf('a') !== -1 || (this.format || '').indexOf('A') !== -1);
       },
 

--- a/packages/date-picker/src/panel/time-range.vue
+++ b/packages/date-picker/src/panel/time-range.vue
@@ -17,6 +17,7 @@
               :show-seconds="showSeconds"
               :show-am-pm="showAmPm"
               :am-pm-mode="amPmMode"
+              :twelve-hour-clock="twelveHourClock"
               :zero-pad-hour="zeroPadHour"
               @change="handleMinChange"
               :arrow-control="arrowControl"
@@ -35,6 +36,8 @@
               :show-seconds="showSeconds"
               :show-am-pm="showAmPm"
               :am-pm-mode="amPmMode"
+              :twelve-hour-clock="twelveHourClock"
+              :zero-pad-hour="zeroPadHour"
               @change="handleMaxChange"
               :arrow-control="arrowControl"
               @select-range="setMaxSelectionRange"
@@ -118,6 +121,10 @@
         if ((this.format || '').indexOf('A') !== -1) return 'A';
         if ((this.format || '').indexOf('a') !== -1) return 'a';
         return '';
+      },
+
+      twelveHourClock() {
+        return (this.format || '').indexOf('hh') !== -1 || (this.format || '').indexOf('h') !== -1;
       },
 
       zeroPadHour() {
@@ -223,10 +230,10 @@
       changeSelectionRange(step) {
         const secondsOffset = this.showSeconds ? 3 : 0;
 
-        const minHoursLen = !this.zeroPadHour && this.minDate && (this.minDate.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const minHoursLen = !this.zeroPadHour && this.minDate && (this.twelveHourClock ? (this.minDate.getHours() % 12 || 12) : this.minDate.getHours()) < 10 ? 1 : 2;
         const list1 = [0, 3 - (2 - minHoursLen)].concat(this.showSeconds ? [6 - (2 - minHoursLen)] : []).concat(this.showAmPm ? [6 + secondsOffset - (2 - minHoursLen)] : []);
 
-        const maxHoursLen = !this.zeroPadHour && this.maxDate && (this.maxDate.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const maxHoursLen = !this.zeroPadHour && this.maxDate && (this.twelveHourClock ? (this.maxDate.getHours() % 12 || 12) : this.maxDate.getHours()) < 10 ? 1 : 2;
         const list2 = [this.offset, this.offset + 3 - (2 - maxHoursLen)].concat(this.showSeconds ? [this.offset + 6 - (2 - maxHoursLen)] : []).concat(this.showAmPm ? [this.offset + 6 + secondsOffset - (2 - maxHoursLen)] : []);
 
         const list = list1.concat(list2);

--- a/packages/date-picker/src/panel/time-range.vue
+++ b/packages/date-picker/src/panel/time-range.vue
@@ -15,7 +15,9 @@
             <time-spinner
               ref="minSpinner"
               :show-seconds="showSeconds"
+              :show-am-pm="showAmPm"
               :am-pm-mode="amPmMode"
+              :zero-pad-hour="zeroPadHour"
               @change="handleMinChange"
               :arrow-control="arrowControl"
               @select-range="setMinSelectionRange"
@@ -31,6 +33,7 @@
             <time-spinner
               ref="maxSpinner"
               :show-seconds="showSeconds"
+              :show-am-pm="showAmPm"
               :am-pm-mode="amPmMode"
               @change="handleMaxChange"
               :arrow-control="arrowControl"
@@ -92,8 +95,12 @@
         return (this.format || '').indexOf('ss') !== -1;
       },
 
+      showAmPm() {
+        return this.toggleAmPm && ((this.format || '').indexOf('a') !== -1 || (this.format || '').indexOf('A') !== -1);
+      },
+
       offset() {
-        return this.showSeconds ? 11 : 8;
+        return 8 + (this.showSeconds ? 3 : 0) + (this.showAmPm ? 3 : 0);
       },
 
       spinner() {
@@ -103,10 +110,15 @@
       btnDisabled() {
         return this.minDate.getTime() > this.maxDate.getTime();
       },
+
       amPmMode() {
         if ((this.format || '').indexOf('A') !== -1) return 'A';
         if ((this.format || '').indexOf('a') !== -1) return 'a';
         return '';
+      },
+
+      zeroPadHour() {
+        return (this.format || '').indexOf('HH') !== -1 || (this.format || '').indexOf('hh') !== -1;
       }
     },
 
@@ -121,6 +133,7 @@
         format: 'HH:mm:ss',
         visible: false,
         selectionRange: [0, 2],
+        toggleAmPm: false,
         arrowControl: false
       };
     },
@@ -205,8 +218,16 @@
       },
 
       changeSelectionRange(step) {
-        const list = this.showSeconds ? [0, 3, 6, 11, 14, 17] : [0, 3, 8, 11];
-        const mapping = ['hours', 'minutes'].concat(this.showSeconds ? ['seconds'] : []);
+        const secondsOffset = this.showSeconds ? 3 : 0;
+
+        const minHoursLen = !this.zeroPadHour && this.minDate && (this.minDate.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const list1 = [0, 3 - (2 - minHoursLen)].concat(this.showSeconds ? [6 - (2 - minHoursLen)] : []).concat(this.showAmPm ? [6 + secondsOffset - (2 - minHoursLen)] : []);
+
+        const maxHoursLen = !this.zeroPadHour && this.maxDate && (this.maxDate.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const list2 = [this.offset, this.offset + 3 - (2 - maxHoursLen)].concat(this.showSeconds ? [this.offset + 6 - (2 - maxHoursLen)] : []).concat(this.showAmPm ? [this.offset + 6 + secondsOffset - (2 - maxHoursLen)] : []);
+
+        const list = list1.concat(list2);
+        const mapping = ['hours', 'minutes'].concat(this.showSeconds ? ['seconds'] : []).concat(this.showAmPm ? ['amPm'] : []);
         const index = list.indexOf(this.selectionRange[0]);
         const next = (index + step + list.length) % list.length;
         const half = list.length / 2;

--- a/packages/date-picker/src/panel/time.vue
+++ b/packages/date-picker/src/panel/time.vue
@@ -110,6 +110,9 @@
         return (this.format || '').indexOf('ss') !== -1;
       },
       showAmPm() {
+        // Even if `toggle-am-pm` is set to true, if the time format doesn't include AM/PM then they won't be shown,
+        // since this would create an inconsistency between the picker and the formatted time value. Also, although it
+        // isn't required, AM/PM toggling should be used along with the `arrow-control` option to provide the best result.
         return this.toggleAmPm && ((this.format || '').indexOf('a') !== -1 || (this.format || '').indexOf('A') !== -1);
       },
       useArrow() {

--- a/packages/date-picker/src/panel/time.vue
+++ b/packages/date-picker/src/panel/time.vue
@@ -12,6 +12,7 @@
           :show-seconds="showSeconds"
           :show-am-pm="showAmPm"
           :am-pm-mode="amPmMode"
+          :twelve-hour-clock="twelveHourClock"
           :zero-pad-hour="zeroPadHour"
           @select-range="setSelectionRange"
           :date="date">
@@ -123,6 +124,9 @@
         if ((this.format || '').indexOf('a') !== -1) return 'a';
         return '';
       },
+      twelveHourClock() {
+        return (this.format || '').indexOf('hh') !== -1 || (this.format || '').indexOf('h') !== -1;
+      },
       zeroPadHour() {
         return (this.format || '').indexOf('HH') !== -1 || (this.format || '').indexOf('hh') !== -1;
       }
@@ -185,7 +189,7 @@
       },
 
       changeSelectionRange(step) {
-        const hoursLen = !this.zeroPadHour && (this.date.getHours() % 12 || 12) < 10 ? 1 : 2;
+        const hoursLen = !this.zeroPadHour && (this.twelveHourClock ? (this.date.getHours() % 12 || 12) : this.date.getHours()) < 10 ? 1 : 2;
         const secondsOffset = this.showSeconds ? 3 : 0;
         const list = [0, (3 - (2 - hoursLen))].concat(this.showSeconds ? [(6 - (2 - hoursLen))] : []).concat(this.showAmPm ? [(6 + secondsOffset - (2 - hoursLen))] : []);
         const mapping = ['hours', 'minutes'].concat(this.showSeconds ? ['seconds'] : []).concat(this.showAmPm ? ['amPm'] : []);

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -831,6 +831,7 @@ export default {
       this.picker.selectionMode = this.selectionMode;
       this.picker.unlinkPanels = this.unlinkPanels;
       this.picker.arrowControl = this.arrowControl || this.timeArrowControl || false;
+      this.picker.toggleAmPm = this.toggleAmPm || false;
       this.$watch('format', (format) => {
         this.picker.format = format;
       });

--- a/packages/date-picker/src/picker/time-picker.js
+++ b/packages/date-picker/src/picker/time-picker.js
@@ -9,7 +9,11 @@ export default {
 
   props: {
     isRange: Boolean,
-    arrowControl: Boolean
+    arrowControl: Boolean,
+    toggleAmPm: {
+      type: Boolean,
+      default: false
+    }
   },
 
   data() {

--- a/packages/theme-chalk/src/date-picker/time-picker.scss
+++ b/packages/theme-chalk/src/date-picker/time-picker.scss
@@ -46,13 +46,23 @@
       margin-left: 12%;
     }
 
-    &.has-seconds {
+    &.has-seconds:not(.has-am-pm), &.has-am-pm:not(.has-seconds) {
       &::after {
         left: calc(100% / 3 * 2);
       }
 
       &::before {
         padding-left: calc(100% / 3);
+      }
+    }
+
+    &.has-seconds.has-am-pm {
+      &::after {
+        left: calc(100% / 4 * 2);
+      }
+
+      &::before {
+        padding-left: calc(100% / 4);
       }
     }
   }

--- a/packages/theme-chalk/src/date-picker/time-spinner.scss
+++ b/packages/theme-chalk/src/date-picker/time-spinner.scss
@@ -1,9 +1,15 @@
 @import "../common/var";
 
 @include b(time-spinner) {
-  &.has-seconds {
+  &.has-seconds:not(.has-am-pm), &.has-am-pm:not(.has-seconds) {
     .el-time-spinner__wrapper {
       width: 33.3%;
+    }
+  }
+
+  &.has-seconds.has-am-pm {
+    .el-time-spinner__wrapper {
+      width: 25%;
     }
   }
 

--- a/test/unit/specs/time-picker.spec.js
+++ b/test/unit/specs/time-picker.spec.js
@@ -1,4 +1,4 @@
-import { createTest, destroyVM, createVue, triggerEvent, triggerKeyDown } from '../util';
+import { createTest, destroyVM, createVue, triggerEvent, triggerKeyDown, wait } from '../util';
 import TimePicker from 'packages/time-picker';
 
 const DELAY = 100;
@@ -71,7 +71,7 @@ describe('TimePicker', () => {
     }, DELAY);
   });
 
-  it('selection range', done => {
+  it('selection range', async() => {
     vm = createVue({
       template: '<el-time-picker ref="compo" v-model="value"></el-time-picker>',
       data() {
@@ -82,27 +82,21 @@ describe('TimePicker', () => {
     }, true);
     const timePicker = vm.$refs.compo;
     const input = timePicker.$el.querySelector('input');
-
     input.blur();
     input.focus();
-
-    setTimeout(_ => {
-      expect(timePicker.picker.selectionRange.join(',')).to.equal('0,2');
-      triggerKeyDown(input, 39);
-      triggerEvent(input, 'keyup');
-      setTimeout(_ => {
-        expect(timePicker.picker.selectionRange.join(',')).to.equal('3,5');
-        triggerKeyDown(input, 39);
-        triggerEvent(input, 'keyup');
-        setTimeout(_ => {
-          expect(timePicker.picker.selectionRange.join(',')).to.equal('6,8');
-          done();
-        }, DELAY);
-      }, DELAY);
-    }, DELAY);
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('0,2');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('3,5');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('6,8');
   });
 
-  it('selection range with 1 digit hour', done => {
+  it('selection range with 1 digit hour', async() => {
     vm = createVue({
       template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm v-model="value"></el-time-picker>',
       data() {
@@ -113,24 +107,18 @@ describe('TimePicker', () => {
     }, true);
     const timePicker = vm.$refs.compo;
     const input = timePicker.$el.querySelector('input');
-
     input.blur();
     input.focus();
-
-    setTimeout(_ => {
-      expect(timePicker.picker.selectionRange.join(',')).to.equal('0,1');
-      triggerKeyDown(input, 39);
-      triggerEvent(input, 'keyup');
-      setTimeout(_ => {
-        expect(timePicker.picker.selectionRange.join(',')).to.equal('2,4');
-        triggerKeyDown(input, 39);
-        triggerEvent(input, 'keyup');
-        setTimeout(_ => {
-          expect(timePicker.picker.selectionRange.join(',')).to.equal('5,7');
-          done();
-        }, DELAY);
-      }, DELAY);
-    }, DELAY);
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('0,1');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('2,4');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('5,7');
   });
 
   it('select time', done => {
@@ -179,7 +167,7 @@ describe('TimePicker', () => {
     }, DELAY);
   });
 
-  it('select AM/PM', done => {
+  it('select AM/PM', async() => {
     vm = createVue({
       template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm v-model="value"></el-time-picker>',
       data() {
@@ -190,44 +178,40 @@ describe('TimePicker', () => {
     }, true);
     const timePicker = vm.$refs.compo;
     const input = timePicker.$el.querySelector('input');
-
     expect(input.value).to.equal('7:00 AM');
 
     input.blur();
     input.focus();
+    await wait(DELAY);
 
-    setTimeout(_ => {
-      const list = timePicker.picker.$el.querySelectorAll('.el-time-spinner__list');
+    const list = timePicker.picker.$el.querySelectorAll('.el-time-spinner__list');
 
-      // Assert that the hours list is 1-12 without AM/PM suffix
-      const hours = Array.prototype.map.call(list[0].querySelectorAll('.el-time-spinner__item'), (i) => i.innerText);
-      expect(hours.join(',')).to.equal('12 AM,01 AM,02 AM,03 AM,04 AM,05 AM,06 AM,07 AM,08 AM,09 AM,10 AM,11 AM,12 PM,01 PM,02 PM,03 PM,04 PM,05 PM,06 PM,07 PM,08 PM,09 PM,10 PM,11 PM');
+    // Assert that the hours list is 1-12 without AM/PM suffix
+    const hours = Array.prototype.map.call(list[0].querySelectorAll('.el-time-spinner__item'), (i) => i.innerText);
+    expect(hours.join(',')).to.equal('12 AM,01 AM,02 AM,03 AM,04 AM,05 AM,06 AM,07 AM,08 AM,09 AM,10 AM,11 AM,12 PM,01 PM,02 PM,03 PM,04 PM,05 PM,06 PM,07 PM,08 PM,09 PM,10 PM,11 PM');
 
-      // Assert that the list is "AM" (active) and "PM" as expected
-      const amPmEl = list[3];
-      const amPmElOptions = amPmEl.querySelectorAll('.el-time-spinner__item');
-      expect(amPmElOptions.length).to.equal(2);
-      const amEl = amPmElOptions[0];
-      expect(amEl.classList.contains('active')).to.true;
-      const pmEl = amPmElOptions[1];
-      expect(pmEl.classList.contains('active')).to.false;
+    // Assert that the list is "AM" (active) and "PM" as expected
+    const amPmEl = list[3];
+    const amPmElOptions = amPmEl.querySelectorAll('.el-time-spinner__item');
+    expect(amPmElOptions.length).to.equal(2);
+    const amEl = amPmElOptions[0];
+    expect(amEl.classList.contains('active')).to.true;
+    const pmEl = amPmElOptions[1];
+    expect(pmEl.classList.contains('active')).to.false;
 
-      // click 'PM'
-      pmEl.click();
-      setTimeout(_ => {
-        const date = timePicker.picker.date;
-        expect(amEl.classList.contains('active')).to.false;
-        expect(pmEl.classList.contains('active')).to.true;
-        expect(input.value).to.equal('7:00 PM');
-        expect(date.getHours()).to.equal(19);
-        expect(date.getMinutes()).to.equal(0);
-        expect(date.getSeconds()).to.equal(0);
-        done();
-      }, DELAY);
-    }, DELAY);
+    // click 'PM'
+    pmEl.click();
+    await wait(DELAY);
+    const date = timePicker.picker.date;
+    expect(amEl.classList.contains('active')).to.false;
+    expect(pmEl.classList.contains('active')).to.true;
+    expect(input.value).to.equal('7:00 PM');
+    expect(date.getHours()).to.equal(19);
+    expect(date.getMinutes()).to.equal(0);
+    expect(date.getSeconds()).to.equal(0);
   });
 
-  it('toggle AM/PM', done => {
+  it('toggle AM/PM', async() => {
     vm = createVue({
       template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm arrow-control v-model="value"></el-time-picker>',
       data() {
@@ -238,26 +222,19 @@ describe('TimePicker', () => {
     }, true);
     const timePicker = vm.$refs.compo;
     const input = timePicker.$el.querySelector('input');
-
     expect(input.value).to.equal('6:00 AM');
-
     input.blur();
     input.focus();
-
-    setTimeout(_ => {
-      expect(timePicker.picker.selectionRange.join(',')).to.equal('0,1');
-      triggerKeyDown(input, 37);
-      triggerEvent(input, 'keyup');
-      setTimeout(_ => {
-        expect(timePicker.picker.selectionRange.join(',')).to.equal('5,7');
-        triggerKeyDown(input, 40);
-        triggerEvent(input, 'keyup');
-        setTimeout(_ => {
-          expect(input.value).to.equal('6:00 PM');
-          done();
-        }, DELAY);
-      }, DELAY);
-    }, DELAY);
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('0,1');
+    triggerKeyDown(input, 37);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('5,7');
+    triggerKeyDown(input, 40);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(input.value).to.equal('6:00 PM');
   });
 
   it('click cancel button', done => {

--- a/test/unit/specs/time-picker.spec.js
+++ b/test/unit/specs/time-picker.spec.js
@@ -1,4 +1,4 @@
-import { createTest, destroyVM, createVue } from '../util';
+import { createTest, destroyVM, createVue, triggerEvent, triggerKeyDown } from '../util';
 import TimePicker from 'packages/time-picker';
 
 const DELAY = 100;
@@ -71,6 +71,68 @@ describe('TimePicker', () => {
     }, DELAY);
   });
 
+  it('selection range', done => {
+    vm = createVue({
+      template: '<el-time-picker ref="compo" v-model="value"></el-time-picker>',
+      data() {
+        return {
+          value: ''
+        };
+      }
+    }, true);
+    const timePicker = vm.$refs.compo;
+    const input = timePicker.$el.querySelector('input');
+
+    input.blur();
+    input.focus();
+
+    setTimeout(_ => {
+      expect(timePicker.picker.selectionRange.join(',')).to.equal('0,2');
+      triggerKeyDown(input, 39);
+      triggerEvent(input, 'keyup');
+      setTimeout(_ => {
+        expect(timePicker.picker.selectionRange.join(',')).to.equal('3,5');
+        triggerKeyDown(input, 39);
+        triggerEvent(input, 'keyup');
+        setTimeout(_ => {
+          expect(timePicker.picker.selectionRange.join(',')).to.equal('6,8');
+          done();
+        }, DELAY);
+      }, DELAY);
+    }, DELAY);
+  });
+
+  it('selection range with 1 digit hour', done => {
+    vm = createVue({
+      template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm v-model="value"></el-time-picker>',
+      data() {
+        return {
+          value: ''
+        };
+      }
+    }, true);
+    const timePicker = vm.$refs.compo;
+    const input = timePicker.$el.querySelector('input');
+
+    input.blur();
+    input.focus();
+
+    setTimeout(_ => {
+      expect(timePicker.picker.selectionRange.join(',')).to.equal('0,1');
+      triggerKeyDown(input, 39);
+      triggerEvent(input, 'keyup');
+      setTimeout(_ => {
+        expect(timePicker.picker.selectionRange.join(',')).to.equal('2,4');
+        triggerKeyDown(input, 39);
+        triggerEvent(input, 'keyup');
+        setTimeout(_ => {
+          expect(timePicker.picker.selectionRange.join(',')).to.equal('5,7');
+          done();
+        }, DELAY);
+      }, DELAY);
+    }, DELAY);
+  });
+
   it('select time', done => {
     vm = createVue({
       template: '<el-time-picker ref="compo" v-model="value"></el-time-picker>',
@@ -114,6 +176,87 @@ describe('TimePicker', () => {
           }, DELAY);
         });
       });
+    }, DELAY);
+  });
+
+  it('select AM/PM', done => {
+    vm = createVue({
+      template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm v-model="value"></el-time-picker>',
+      data() {
+        return {
+          value: new Date(1970, 0, 1, 7, 0) // 7:00 AM
+        };
+      }
+    }, true);
+    const timePicker = vm.$refs.compo;
+    const input = timePicker.$el.querySelector('input');
+
+    expect(input.value).to.equal('7:00 AM');
+
+    input.blur();
+    input.focus();
+
+    setTimeout(_ => {
+      const list = timePicker.picker.$el.querySelectorAll('.el-time-spinner__list');
+
+      // Assert that the hours list is 1-12 without AM/PM suffix
+      const hours = Array.prototype.map.call(list[0].querySelectorAll('.el-time-spinner__item'), (i) => i.innerText);
+      expect(hours.join(',')).to.equal('12 AM,01 AM,02 AM,03 AM,04 AM,05 AM,06 AM,07 AM,08 AM,09 AM,10 AM,11 AM,12 PM,01 PM,02 PM,03 PM,04 PM,05 PM,06 PM,07 PM,08 PM,09 PM,10 PM,11 PM');
+
+      // Assert that the list is "AM" (active) and "PM" as expected
+      const amPmEl = list[3];
+      const amPmElOptions = amPmEl.querySelectorAll('.el-time-spinner__item');
+      expect(amPmElOptions.length).to.equal(2);
+      const amEl = amPmElOptions[0];
+      expect(amEl.classList.contains('active')).to.true;
+      const pmEl = amPmElOptions[1];
+      expect(pmEl.classList.contains('active')).to.false;
+
+      // click 'PM'
+      pmEl.click();
+      setTimeout(_ => {
+        const date = timePicker.picker.date;
+        expect(amEl.classList.contains('active')).to.false;
+        expect(pmEl.classList.contains('active')).to.true;
+        expect(input.value).to.equal('7:00 PM');
+        expect(date.getHours()).to.equal(19);
+        expect(date.getMinutes()).to.equal(0);
+        expect(date.getSeconds()).to.equal(0);
+        done();
+      }, DELAY);
+    }, DELAY);
+  });
+
+  it('toggle AM/PM', done => {
+    vm = createVue({
+      template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm arrow-control v-model="value"></el-time-picker>',
+      data() {
+        return {
+          value: new Date(1970, 0, 1, 6, 0) // 6:00 AM
+        };
+      }
+    }, true);
+    const timePicker = vm.$refs.compo;
+    const input = timePicker.$el.querySelector('input');
+
+    expect(input.value).to.equal('6:00 AM');
+
+    input.blur();
+    input.focus();
+
+    setTimeout(_ => {
+      expect(timePicker.picker.selectionRange.join(',')).to.equal('0,1');
+      triggerKeyDown(input, 37);
+      triggerEvent(input, 'keyup');
+      setTimeout(_ => {
+        expect(timePicker.picker.selectionRange.join(',')).to.equal('5,7');
+        triggerKeyDown(input, 40);
+        triggerEvent(input, 'keyup');
+        setTimeout(_ => {
+          expect(input.value).to.equal('6:00 PM');
+          done();
+        }, DELAY);
+      }, DELAY);
     }, DELAY);
   });
 

--- a/test/unit/specs/time-picker.spec.js
+++ b/test/unit/specs/time-picker.spec.js
@@ -107,7 +107,7 @@ describe('TimePicker', () => {
       template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm v-model="value"></el-time-picker>',
       data() {
         return {
-          value: ''
+          value: new Date(1970, 0, 1, 9, 0, 0, 0)
         };
       }
     }, true);

--- a/test/unit/specs/time-picker.spec.js
+++ b/test/unit/specs/time-picker.spec.js
@@ -98,6 +98,52 @@ describe('TimePicker', () => {
 
   it('selection range with 1 digit hour', async() => {
     vm = createVue({
+      template: '<el-time-picker ref="compo" format="H:mm:ss" v-model="value"></el-time-picker>',
+      data() {
+        return {
+          value: new Date(1970, 0, 1, 13, 0, 0, 0)
+        };
+      }
+    }, true);
+    const timePicker = vm.$refs.compo;
+    const input = timePicker.$el.querySelector('input');
+    input.blur();
+    input.focus();
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('0,2');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('3,5');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('6,8');
+  });
+
+  it('selection range with 1 digit hour and 12 hour mode', async() => {
+    vm = createVue({
+      template: '<el-time-picker ref="compo" format="h:mm" v-model="value"></el-time-picker>',
+      data() {
+        return {
+          value: new Date(1970, 0, 1, 13, 0, 0, 0)
+        };
+      }
+    }, true);
+    const timePicker = vm.$refs.compo;
+    const input = timePicker.$el.querySelector('input');
+    input.blur();
+    input.focus();
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('0,1');
+    triggerKeyDown(input, 39);
+    triggerEvent(input, 'keyup');
+    await wait(DELAY);
+    expect(timePicker.picker.selectionRange.join(',')).to.equal('2,4');
+  });
+
+  it('selection range with AM/PM', async() => {
+    vm = createVue({
       template: '<el-time-picker ref="compo" format="h:mm A" toggle-am-pm v-model="value"></el-time-picker>',
       data() {
         return {


### PR DESCRIPTION
Feature request #16524 [Feature Request] Ability to toggle AM/PM in the time picker

Basic support for scrolling between AM and PM is implemented in this commit. However, in the course of implementing this there were a few other considerations that came up:

- When scrolling between AM and PM is enabled, should only 12 hours be shown in the hour selection list? If not, the controls are a bit redundant. If so, then this opens a few other questions:
  - What should happen when you scroll down at the end of the list, and wrap around to the top? As it currently stands, scrolling down from 11 AM moves to 12 PM. This makes sense logically, but it means that the hours and AM/PM scrollbars are "tethered" together, which is not consistent with existing behavior. The minute scrollbar doesn't currently cause the hour to increment or decrement when it wraps around (same with seconds and minutes). Another option that comes to mind is to have a prop to control whether this behavior should be in effect or not. If not, which would probably be the default, none of the controls would impact each other. If the prop was enabled, then they would all impact each other consistently. This would also mean that incrementing the minute from 59 to 0 would increment the hour, and incrementing the second from 59 to 0 would increment the minute. Its worth nothing that none of this should impact the default behavior of the time picker.
  - If we're toggling AM / PM and only showing 12 hours (and the wrap around behavior doesn't happen), then should the hours be listed as 1-12 instead of 12, 1, 2, .. 11? It seems that the logical ordering of these values is 12, 1, 2, ... 11, as it is currently, but when the hour numbers operate independently and don't wrap around, it may seem like the user is really just editing a number, and the current ordering might seem strange.
- It seems that scrolling between AM and PM complicates the use of selectable time ranges. The control shows you what hours, minutes, and seconds can be selected. However, when the hours are split in two and AM / PM is toggled separately, then you can no longer see what hours can be selected. It seems if you're going to restrict the times that can be selected, then using the time spinner with AM / PM toggling enabled is not a good choice of user interface, so it may be acceptable to do nothing about it.
- Currently when you enable AM/PM toggling, and arrow controls are NOT used, then all 24 hours are shown. It may be that these two options are co-dependent. You can't toggle AM/PM unless you use arrow controls, since scrolling is really better suited for the 24 hour format. Thoughts?

Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.

Changes to support AM/PM:
- Add 'toggleAmPm' prop
- Add 'amPm' to list of time parts to scroll
- Handle the conditionally available 'AM/PM' in selection range
- Determine whether the hour is zero padded based on the format
- Take into account the hour length in selection range logic
- Add 'has-am-pm' class to the time picker content element
- Only show 12 hours when toggling AM/PM with arrow controls
- Set the selection range after scrolling up or down

Also...

When using a 12-hour format, the selected characters in the time spinner are off by 1 when the hour is less than 10. This fixes the problem by determining the length that the selection should be for the hour part, based on the AM/PM mode and the hour value, and adjusts every part based on that value. This fixes issue #16865  - [Bug Report] Time picker selected text is off by 1 when 12-hour format is used


After scrolling up or down in the time picker's text box, the selected text is lost and the cursor goes to the end of the input (though scrolling continues to work). This fixes the problem by calling emitSelectRange at the end of the scrollDown method - `this.$nextTick(() => this.emitSelectRange(this.currentScrollbar));`. Fixes #16866 - [Bug Report] Time picker doesn't visually select the part being edited via directional keys