### PR TITLE
Image: Fix shield the page when preview big image (#16796)

### DIFF
--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -290,6 +290,8 @@ export default {
   },
   mounted() {
     this.deviceSupportInstall();
+    // add tabindex then wrapper can be focusable via Javascript
+    // focus wrapper so arrow key can't cause inner scroll behavior underneath
     this.$refs['el-image-viewer__wrapper'].focus();
   }
 };

--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="viewer-fade">
-    <div class="el-image-viewer__wrapper" :style="{ 'z-index': zIndex }">
+    <div tabindex="-1" ref="el-image-viewer__wrapper" class="el-image-viewer__wrapper" :style="{ 'z-index': zIndex }">
       <div class="el-image-viewer__mask"></div>
       <!-- CLOSE -->
       <span class="el-image-viewer__btn el-image-viewer__close" @click="hide">
@@ -290,6 +290,7 @@ export default {
   },
   mounted() {
     this.deviceSupportInstall();
+    this.$refs['el-image-viewer__wrapper'].focus();
   }
 };
 </script>

--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -210,9 +210,11 @@
         }
       },
       clickHandler() {
+        document.body.style.overflow = 'hidden';
         this.showViewer = true;
       },
       closeViewer() {
+        document.body.style.overflow = 'auto';
         this.showViewer = false;
       }
     }

--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -36,6 +36,8 @@
     SCALE_DOWN: 'scale-down'
   };
 
+  let prevOverflow = '';
+
   export default {
     name: 'ElImage',
 
@@ -210,11 +212,12 @@
         }
       },
       clickHandler() {
+        prevOverflow = document.body.style.overflow;
         document.body.style.overflow = 'hidden';
         this.showViewer = true;
       },
       closeViewer() {
-        document.body.style.overflow = 'auto';
+        document.body.style.overflow = prevOverflow;
         this.showViewer = false;
       }
     }

--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -212,6 +212,7 @@
         }
       },
       clickHandler() {
+        // prevent body scroll
         prevOverflow = document.body.style.overflow;
         document.body.style.overflow = 'hidden';
         this.showViewer = true;


### PR DESCRIPTION
close #16796 
el-image 的 preview 在使用方向键↑↓进行缩放时，屏蔽页面的滚动。

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
