### PR TITLE
Tree: fix 数据较多的时候使用_setCheckedKeys页面卡死 bug

### DIFF
--- a/packages/tree/src/model/tree-store.js
+++ b/packages/tree/src/model/tree-store.js
@@ -228,7 +228,7 @@ export default class TreeStore {
     const allNodes = this._getAllNodes().sort((a, b) => b.level - a.level);
     const cache = Object.create(null);
     const keys = Object.keys(checkedKeys);
-    allNodes.forEach(node => node.setChecked(false, false));
+    allNodes.forEach(node => node.setChecked(false, false, true));
     for (let i = 0, j = allNodes.length; i < j; i++) {
       const node = allNodes[i];
       const nodeKey = node.data[key].toString();


### PR DESCRIPTION
解决使用树中的setCheckedKeys导致页面卡死的bug
原因：allNodes.forEach(node => node.setChecked(false, false, true)); 这里使用setChecked的时候以及是全部去设置了，setChecked里面还去使用了递归，导致遍历次数太多，页面卡死。没有必要这里去遍历。