### PR TITLE
BackTop: use requestAnimationFrame and cubic bezier for scrolling

### DIFF
--- a/packages/backtop/src/main.vue
+++ b/packages/backtop/src/main.vue
@@ -18,6 +18,11 @@
 <script>
 import throttle from 'throttle-debounce/throttle';
 
+const cubic = value => Math.pow(value, 3);
+const easeInOutCubic = value => value < 0.5
+  ? cubic(value * 2) / 2
+  : 1 - cubic((1 - value) * 2) / 2;
+
 export default {
   name: 'ElBacktop',
 
@@ -81,16 +86,20 @@ export default {
       this.$emit('click', e);
     },
     scrollToTop() {
-      let el = this.el;
-      let step = 0;
-      let interval = setInterval(() => {
-        if (el.scrollTop <= 0) {
-          clearInterval(interval);
-          return;
+      const el = this.el;
+      const beginTime = Date.now();
+      const beginValue = el.scrollTop;
+      const rAF = window.requestAnimationFrame || (func => setTimeout(func, 16));
+      const frameFunc = () => {
+        const progress = (Date.now() - beginTime) / 500;
+        if (progress < 1) {
+          el.scrollTop = beginValue * (1 - easeInOutCubic(progress));
+          rAF(frameFunc);
+        } else {
+          el.scrollTop = 0;
         }
-        step += 10;
-        el.scrollTop -= step;
-      }, 20);
+      };
+      rAF(frameFunc);
     }
   },
 


### PR DESCRIPTION
Use `requestAnimationFrame`(more smoothly) and cubic bezier(acceleration until halfway, then deceleration) for scrolling.

**DEMO**
After: <https://jsfiddle.net/lon/ye1fq9u8/>
Before: <https://jsfiddle.net/lon/8p5q974z/>



Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
