### PR TITLE
Allow for blank progress-bar status

### DIFF
--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -67,7 +67,7 @@
       },
       status: {
         type: String,
-        validator: val => ['success', 'exception', 'warning'].indexOf(val) > -1
+        validator: val => ['success', 'exception', 'warning', ''].indexOf(val) > -1
       },
       strokeWidth: {
         type: Number,


### PR DESCRIPTION
This is to avoid warnings on conditional status for progress

eg:

```
<el-progress :status="false ? 'success' : ''" />
```

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
