### PR TITLE
Tree: font-size for empty-text is 16px, it should be 14px

### DIFF
--- a/packages/theme-chalk/src/tree.scss
+++ b/packages/theme-chalk/src/tree.scss
@@ -23,6 +23,7 @@
     top: 50%;
     transform: translate(-50%, -50%);
     color: $--color-text-secondary;
+    font-size: $--font-size-base;
   }
 
   @include e(drop-indicator) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

# Desc
If a Tree control has no data, a empty-text, e.g. "No Data", will be shown. But its font-size is 16px which is by default. It should be 14px, just like empty-text for Table control.