### PR TITLE
Dialog: fixed the timing when dialog content is recreated (#17124)

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -121,6 +121,9 @@
       visible(val) {
         if (val) {
           this.closed = false;
+          if (this.destroyOnClose) {
+            this.key++;
+          }
           this.$emit('open');
           this.$el.addEventListener('scroll', this.updatePopper);
           this.$nextTick(() => {
@@ -132,11 +135,6 @@
         } else {
           this.$el.removeEventListener('scroll', this.updatePopper);
           if (!this.closed) this.$emit('close');
-          if (this.destroyOnClose) {
-            this.$nextTick(() => {
-              this.key++;
-            });
-          }
         }
       }
     },


### PR DESCRIPTION
Changed the timing of the key updating to when the dialog is displayed. This will cause the component recreation happening while the dialog is being displayed, not while it is being closed.

`this.$nextTick()` should be avoided. Otherwise, vue will render the component once, and then the key is updated, the component will be rendered again.

This is related to the issue #17124 .

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
