### PR TITLE
Menu: fix that the SubMenu parent component is not a Menu component cause stack overflow

### DIFF
--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -198,7 +198,7 @@
         }, showTimeout);
 
         if (this.appendToBody) {
-          this.$parent.$el.dispatchEvent(new MouseEvent('mouseenter'));
+          this.parentMenu.$el.dispatchEvent(new MouseEvent('mouseenter'));
         }
       },
       handleMouseleave(deepDispatch = false) {
@@ -216,8 +216,8 @@
         }, this.hideTimeout);
 
         if (this.appendToBody && deepDispatch) {
-          if (this.$parent.$options.name === 'ElSubmenu') {
-            this.$parent.handleMouseleave(true);
+          if (this.parentMenu.$options.name === 'ElSubmenu') {
+            this.parentMenu.handleMouseleave(true);
           }
         }
       },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

When a menu needs to be generated recursively, submenu is wrapped as a recursive component, and submenu's `mouseenter` event can cause a stack overflow. Because the parent component of submenu is the recursive component, and its $el is submenu itself. And the `mouseleave` event will not trigger as expected submenu's `mouseleave` event.

problem link：[https://codepen.io/SAMAPENG/pen/MWgjXaJ](https://codepen.io/SAMAPENG/pen/MWgjXaJ)
