### PR TITLE
Fix: Select & Cascader didn't show corresponding style when changing size property

### DIFF
--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -2,7 +2,8 @@
   <div
     :class="[
       'el-cascader-panel',
-      border && 'is-bordered'
+      border && 'is-bordered',
+      { [`el-cascader-panel--${_computedSize}`] : !!_computedSize }
     ]"
     @keydown="handleKeyDown">
     <cascader-menu
@@ -88,6 +89,7 @@ export default {
 
   props: {
     value: {},
+    size: String,
     options: Array,
     props: Object,
     border: {
@@ -132,6 +134,9 @@ export default {
     },
     renderLabelFn() {
       return this.renderLabel || this.$scopedSlots.default;
+    },
+    _computedSize() {
+      return this.size || (this.$ELEMENT || {}).size;
     }
   },
 

--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -77,6 +77,7 @@
           :options="options"
           :props="config"
           :border="false"
+          :size="realSize"
           :render-label="$scopedSlots.default"
           @expand-change="handleExpandChange"
           @close="toggleDropDownVisible(false)"></el-cascader-panel>

--- a/packages/select/src/select-dropdown.vue
+++ b/packages/select/src/select-dropdown.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="el-select-dropdown el-popper"
-    :class="[{ 'is-multiple': $parent.multiple }, popperClass]"
+    :class="[{ 'is-multiple': $parent.multiple }, popperClass, { [`el-select-dropdown--${_computedSize}`] : !!_computedSize }]"
     :style="{ minWidth: minWidth }">
     <slot></slot>
   </div>
@@ -18,6 +18,7 @@
     mixins: [Popper],
 
     props: {
+      size: String,
       placement: {
         default: 'bottom-start'
       },
@@ -53,6 +54,9 @@
     computed: {
       popperClass() {
         return this.$parent.popperClass;
+      },
+      _computedSize() {
+        return this.size || (this.$ELEMENT || {}).size;
       }
     },
 

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -105,6 +105,7 @@
       @after-leave="doDestroy">
       <el-select-menu
         ref="popper"
+        :size="selectSize"
         :append-to-body="popperAppendToBody"
         v-show="visible && emptyText !== false">
         <el-scrollbar

--- a/packages/theme-chalk/src/cascader-panel.scss
+++ b/packages/theme-chalk/src/cascader-panel.scss
@@ -13,6 +13,77 @@
     border: $--cascader-menu-border;
     border-radius: $--cascader-menu-radius;
   }
+  @include m(medium) {
+    @include b(cascader-menu) {
+      min-width: 170px;
+    }
+    @include b(cascader-node) {
+      padding: 0 26px 0 16px;
+      height: 28px;
+      line-height: 28px;
+      font-size: 14px;
+ 
+      @include e(prefix) {
+        left: 10px;
+      }
+    
+      @include e(postfix) {
+        right: 10px;
+      }
+    
+      @include e(label) {
+        padding: 0 10px;
+      }
+    }
+  }
+
+  @include m(small) {
+    @include b(cascader-menu) {
+      min-width: 160px;
+    }
+    @include b(cascader-node) {
+      padding: 0 24px 0 14px;
+      height: 26px;
+      line-height: 26px;
+      font-size: 13px;
+ 
+      @include e(prefix) {
+        left: 8px;
+      }
+    
+      @include e(postfix) {
+        right: 8px;
+      }
+    
+      @include e(label) {
+        padding: 0 8px;
+      }
+    }
+  }
+
+  @include m(mini) {
+    @include b(cascader-menu) {
+      min-width: 140px;
+    }
+    @include b(cascader-node) {
+      padding: 0 20px 0 10px;
+      height: 24px;
+      line-height: 24px;
+      font-size: 12px;
+ 
+      @include e(prefix) {
+        left: 6px;
+      }
+    
+      @include e(postfix) {
+        right: 6px;
+      }
+    
+      @include e(label) {
+        padding: 0 6px;
+      }
+    }
+  }
 }
 
 @include b(cascader-menu) {

--- a/packages/theme-chalk/src/cascader-panel.scss
+++ b/packages/theme-chalk/src/cascader-panel.scss
@@ -21,7 +21,7 @@
       padding: 0 26px 0 16px;
       height: 28px;
       line-height: 28px;
-      font-size: 14px;
+      font-size: $--font-size-base;
  
       @include e(prefix) {
         left: 10px;
@@ -45,7 +45,7 @@
       padding: 0 24px 0 14px;
       height: 26px;
       line-height: 26px;
-      font-size: 13px;
+      font-size: $--font-size-small;
  
       @include e(prefix) {
         left: 8px;
@@ -69,7 +69,7 @@
       padding: 0 20px 0 10px;
       height: 24px;
       line-height: 24px;
-      font-size: 12px;
+      font-size: $--font-size-extra-small;
  
       @include e(prefix) {
         left: 6px;

--- a/packages/theme-chalk/src/select-dropdown.scss
+++ b/packages/theme-chalk/src/select-dropdown.scss
@@ -34,6 +34,33 @@
     }
   }
 
+  @include m(medium) {
+    @include e(item) {
+      height: 30px;
+      line-height: 30px;
+      padding: 0 17px;
+      font-size: 14px;
+    }
+  }
+
+  @include m(small) {
+    @include e(item) {
+      height: 27px;
+      line-height: 27px;
+      padding: 0 15px;
+      font-size: 13px;
+    }
+  }
+
+  @include m(mini) {
+    @include e(item) {
+      height: 24px;
+      line-height: 24px;
+      padding: 0 10px;
+      font-size: 12px;
+    }
+  }
+
   .el-scrollbar.is-empty .el-select-dropdown__list{
     padding: 0;
   }

--- a/packages/theme-chalk/src/select-dropdown.scss
+++ b/packages/theme-chalk/src/select-dropdown.scss
@@ -39,7 +39,7 @@
       height: 30px;
       line-height: 30px;
       padding: 0 17px;
-      font-size: 14px;
+      font-size: $--font-size-base;
     }
   }
 
@@ -48,7 +48,7 @@
       height: 27px;
       line-height: 27px;
       padding: 0 15px;
-      font-size: 13px;
+      font-size: $--font-size-small;
     }
   }
 
@@ -57,7 +57,7 @@
       height: 24px;
       line-height: 24px;
       padding: 0 10px;
-      font-size: 12px;
+      font-size: $--font-size-extra-small;
     }
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

Close #16725

Add size property and corresponding css style to select-dropdown && cascader panel.

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
