### PR TITLE
Cascader: fix bug Determine whether the child node has been loaded

### DIFF
--- a/examples/docs/en-US/cascader.md
+++ b/examples/docs/en-US/cascader.md
@@ -1215,7 +1215,7 @@ Dynamic load its child nodes when checked a node.
 
 :::demo Set `lazy = true` to use dynamic loading, and you have to specify how to load the data source by `lazyload`. There are two parameters of `lazyload`,the first parameter `node` is the node currently clicked, and the `resolve` is a callback that indicate loading is finished which must invoke. To display the status of node more accurately, you can add a `leaf` field (can be modified by `props.leaf`) to indicate whether it is a leaf node. Otherwise, it will be inferred by if has any child nodes.
 ```html
-<el-cascader :props="props"></el-cascader>
+<el-cascader v-model="value" :props="props" :options="options"></el-cascader>
 
 <script>
   let id = 0;
@@ -1223,8 +1223,10 @@ Dynamic load its child nodes when checked a node.
   export default {
     data() {
       return {
+        value: [1, 2],
         props: {
           lazy: true,
+          checkStrictly: true,
           lazyLoad (node, resolve) {
             const { level } = node;
             setTimeout(() => {
@@ -1238,7 +1240,18 @@ Dynamic load its child nodes when checked a node.
               resolve(nodes);
             }, 1000);
           }
-        }
+        },
+        options: [{
+          label: 'Option - 1',
+          value: 1,
+          children: [{
+            label: 'Option - 2',
+            value: 2
+          }, {
+            label: 'Option - 3',
+            value: 3
+          }]
+        }]
       };
     }
   };

--- a/examples/docs/zh-CN/cascader.md
+++ b/examples/docs/zh-CN/cascader.md
@@ -1194,7 +1194,7 @@
 
 :::demo 通过`lazy`开启动态加载，并通过`lazyload`来设置加载数据源的方法。`lazyload`方法有两个参数，第一个参数`node`为当前点击的节点，第二个`resolve`为数据加载完成的回调(必须调用)。为了更准确的显示节点的状态，还可以对节点数据添加是否为叶子节点的标志位 (默认字段为`leaf`，可通过`props.leaf`修改)，否则会简单的以有无子节点来判断是否为叶子节点。
 ```html
-<el-cascader :props="props"></el-cascader>
+<el-cascader v-model="value" :props="props" :options="options"></el-cascader>
 
 <script>
   let id = 0;
@@ -1202,8 +1202,10 @@
   export default {
     data() {
       return {
+        value: [1, 2],
         props: {
           lazy: true,
+          checkStrictly: true,
           lazyLoad (node, resolve) {
             const { level } = node;
             setTimeout(() => {
@@ -1217,7 +1219,18 @@
               resolve(nodes);
             }, 1000);
           }
-        }
+        },
+        options: [{
+          label: '选项1',
+          value: 1,
+          children: [{
+            label: '选项2',
+            value: 2
+          }, {
+            label: '选项3',
+            value: 3
+          }]
+        }]
       };
     }
   };

--- a/packages/cascader-panel/src/node.js
+++ b/packages/cascader-panel/src/node.js
@@ -27,7 +27,7 @@ export default class Node {
 
     // lazy load
     this.loading = false;
-    this.loaded = false;
+    this.loaded = this.data.children && !!this.data.children.length;
   }
 
   initChildren() {


### PR DESCRIPTION
When the child node has been loaded, it should be displayed immediately.

当子节点已经有数据时，点击父节点应该直接加载子节点，而不是再去动态加载

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
