### PR TITLE
select：通过注释option.vue中的代码解决下拉框远程搜索默认值bug

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -153,10 +153,10 @@
     },
 
     beforeDestroy() {
-      let index = this.select.cachedOptions.indexOf(this);
-      if (index > -1) {
-        this.select.cachedOptions.splice(index, 1);
-      }
+      // let index = this.select.cachedOptions.indexOf(this);
+      // if (index > -1) {
+      //   this.select.cachedOptions.splice(index, 1);
+      // }
       this.select.onOptionDestroy(this.select.options.indexOf(this));
     }
   };


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [√ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [√ ] Make sure you are merging your commits to `dev` branch.
* [√ ] Add some descriptions and refer relative issues for you PR.

问题描述：select下拉框中的远程搜索，在value和label不相同时，进行第二次搜索时第一次选中的值的label会自己变为value，但是这个问题在2.10.1版本中是不存在的
2.10.1版本demo： https://codepen.io/xiaolong0114/pen/WNeZXXP?&editable=true
2.12.0版本demo：https://codepen.io/xiaolong0114/pen/pozWdWm?&editable=true
进行源码对比后发现是因为option.vue中的钩子函数beforeDestroy中的代码不同所导致的，在将不同的代码注释掉之后，此功能恢复正常，显示一直为label，达到期望效果。