### PR TITLE
Autocomplete: Don't debounce getData on focus

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -200,7 +200,7 @@
         this.activated = true;
         this.$emit('focus', event);
         if (this.triggerOnFocus) {
-          this.debouncedGetData(this.value);
+          this.getData(this.value);
         }
       },
       handleBlur(event) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.


Bug: When focusing an autocomplete, it shows old data for 300ms, then shows a loading spinner, then finally shows the correct suggestions. Even if `fetchSuggestions` calls `callback` synchronously, the 300ms delay causes the suggestions box animation to jerk around. Resolves #16825.

The underlying cause is that `getData` is debounced (added in #11323) both when typing and when focusing. It doesn't make sense to debounce the `focus` event, because it's not triggered as frequently as `input` events.