### PR TITLE
Form: callback of validateField should be optional

### DIFF
--- a/types/form.d.ts
+++ b/types/form.d.ts
@@ -72,11 +72,11 @@ export declare class ElForm extends ElementUIComponent {
    * @param props The property of `model` or array of prop which is going to validate
    * @param callback A callback to tell the field validation result
    */
-  validateField (props: string | string[], callback: ValidateFieldCallback): void
+  validateField (props: string | string[], callback?: ValidateFieldCallback): void
 
   /** reset all the fields and remove validation result */
   resetFields (): void
-  
+
   /** clear validation message for certain fields */
   clearValidate (props?: string | string[]): void
 }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Fix: https://github.com/ElemeFE/element/issues/8756

Currently we must pass undefined ( but null ) as callback function to avoid this issue, which is ugly.