### PR TITLE
Tree: fix currentNode becoming undefined when using setCurrentNode

### DIFF
--- a/packages/tree/src/model/tree-store.js
+++ b/packages/tree/src/model/tree-store.js
@@ -321,7 +321,7 @@ export default class TreeStore {
   }
 
   setUserCurrentNode(node) {
-    const key = node.data[this.key];
+    const key = node.data ? node.data[this.key] : node[this.key];
     const currNode = this.nodesMap[key];
     this.setCurrentNode(currNode);
   }

--- a/packages/tree/src/model/tree-store.js
+++ b/packages/tree/src/model/tree-store.js
@@ -321,7 +321,7 @@ export default class TreeStore {
   }
 
   setUserCurrentNode(node) {
-    const key = node[this.key];
+    const key = node.data[this.key];
     const currNode = this.nodesMap[key];
     this.setCurrentNode(currNode);
   }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Demo[中文]: https://codepen.io/almon123/pen/aboLaXK?editors=1010

bug 描述

在```element/packages/tree/src/model/tree-store.js```中的方法

```javascript
setUserCurrentNode(node) {
    const key = node[this.key];
    const currNode = this.nodesMap[key];
    this.setCurrentNode(currNode);
  }
```

this.key应该是node.data上的属性，链接到组件props ```node-key```。node[this.key]可能为空或者返回不可预知的值，导致currNode为undefined。所以应该为node.data[this.key]， 如果不存在node.data，再降级为node[this.key]

bug 修复
```javascript
setUserCurrentNode(node) {
    const key = node.data ? node.data[this.key] : node[this.key];
    const currNode = this.nodesMap[key];
    this.setCurrentNode(currNode);
  }
```

---

Bug description

The method in ```element/packages/tree/src/model/tree-store.js```:

```javascript
setUserCurrentNode(node) {
    const key = node[this.key];
    const currNode = this.nodesMap[key];
    this.setCurrentNode(currNode);
  }
```

```this.key```should be one property on ```node.data```, which has the same value with components props ```node-key```. Now ```node[this.key]```may be ```undefined``` or undetermined value. this will cause ```currNode``` becoming  ```undefined```, so it should be ```node.data[this.key]``` when ```node.data``` exist

Update:

```javascript
setUserCurrentNode(node) {
    const key = node.data ? node.data[this.key] : node[this.key];
    const currNode = this.nodesMap[key];
    this.setCurrentNode(currNode);
  }
```

---

La description d l'errur

La méthode dans ```element/packages/tree/src/model/tree-store.js```:

```javascript
setUserCurrentNode(node) {
    const key = node[this.key];
    const currNode = this.nodesMap[key];
    this.setCurrentNode(currNode);
  }
```

```this.key```doit être une propriété sur ```node.data```, qui avais la même valeur avec components props ```node-key```. Maintenant ```node[this.key]```peut être ```undefined``` ou une valeur indéterminée. ```currNode```va devenir  à ```undefined```. Donc ```node[this.key]``` doit transformer en ```node.data[this.key]``` quand ```node.data``` existe

Mis en jour

```javascript
setUserCurrentNode(node) {
    const key = node.data ? node.data[this.key] : node[this.key];
    const currNode = this.nodesMap[key];
    this.setCurrentNode(currNode);
  }
```

