### PR TITLE
Image: Fix preview wrapper covered by other element with higher z-index(#17164)

### DIFF
--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -35,16 +35,16 @@
       <!-- CANVAS -->
       <div class="el-image-viewer__canvas">
         <img
-                v-for="(url, i) in urlList"
-                v-if="i === index"
-                ref="img"
-                class="el-image-viewer__img"
-                :key="url"
-                :src="currentImg"
-                :style="imgStyle"
-                @load="handleImgLoad"
-                @error="handleImgError"
-                @mousedown="handleMouseDown">
+          v-for="(url, i) in urlList"
+          v-if="i === index"
+          ref="img"
+          class="el-image-viewer__img"
+          :key="url"
+          :src="currentImg"
+          :style="imgStyle"
+          @load="handleImgLoad"
+          @error="handleImgError"
+          @mousedown="handleMouseDown">
       </div>
     </div>
   </transition>

--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -1,7 +1,6 @@
 <template>
   <transition name="viewer-fade">
-    <div class="el-image-viewer__wrapper" :style="{ 'z-index': zIndex }">
-      <div class="el-image-viewer__mask"></div>
+    <div v-show="visible" class="el-image-viewer__wrapper">
       <!-- CLOSE -->
       <span class="el-image-viewer__btn el-image-viewer__close" @click="hide">
         <i class="el-icon-circle-close"></i>
@@ -36,22 +35,23 @@
       <!-- CANVAS -->
       <div class="el-image-viewer__canvas">
         <img
-          v-for="(url, i) in urlList"
-          v-if="i === index"
-          ref="img"
-          class="el-image-viewer__img"
-          :key="url"
-          :src="currentImg"
-          :style="imgStyle"
-          @load="handleImgLoad"
-          @error="handleImgError"
-          @mousedown="handleMouseDown">
+                v-for="(url, i) in urlList"
+                v-if="i === index"
+                ref="img"
+                class="el-image-viewer__img"
+                :key="url"
+                :src="currentImg"
+                :style="imgStyle"
+                @load="handleImgLoad"
+                @error="handleImgError"
+                @mousedown="handleMouseDown">
       </div>
     </div>
   </transition>
 </template>
 
 <script>
+import Popup from 'element-ui/src/utils/popup';
 import { on, off } from 'element-ui/src/utils/dom';
 import { rafThrottle, isFirefox } from 'element-ui/src/utils/util';
 
@@ -71,14 +71,16 @@ const mousewheelEventName = isFirefox() ? 'DOMMouseScroll' : 'mousewheel';
 export default {
   name: 'elImageViewer',
 
+  mixins: [Popup],
+
   props: {
+    modal: {
+      type: Boolean,
+      default: true
+    },
     urlList: {
       type: Array,
       default: () => []
-    },
-    zIndex: {
-      type: Number,
-      default: 2000
     },
     onSwitch: {
       type: Function,
@@ -147,6 +149,11 @@ export default {
           this.loading = true;
         }
       });
+    },
+    visible(val) {
+      if (val) {
+        document.body.appendChild(this.$el);
+      }
     }
   },
   methods: {
@@ -290,6 +297,17 @@ export default {
   },
   mounted() {
     this.deviceSupportInstall();
+    if (this.visible) {
+      this.rendered = true;
+      this.open();
+      document.body.appendChild(this.$el);
+    }
+  },
+  destroyed() {
+    // remove DOM node after destroy
+    if (this.$el && this.$el.parentNode) {
+      this.$el.parentNode.removeChild(this.$el);
+    }
   }
 };
 </script>

--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -15,7 +15,9 @@
       :src="src"
       :style="imageStyle"
       :class="{ 'el-image__inner--center': alignCenter, 'el-image__preview': preview }">
-    <image-viewer :z-index="zIndex" v-if="preview && showViewer" :on-close="closeViewer" :url-list="previewSrcList"/>
+    <template v-if="preview">
+      <image-viewer :visible.sync="showViewer" :on-close="closeViewer" :url-list="previewSrcList"/>
+    </template>
   </div>
 </template>
 

--- a/test/unit/specs/image.spec.js
+++ b/test/unit/specs/image.spec.js
@@ -127,10 +127,12 @@ describe('Image', () => {
     await wait();
     vm.$el.querySelector('.el-image__inner').click();
     await wait();
-    expect(vm.$el.querySelector('.el-image-viewer__wrapper')).to.exist;
-    vm.$el.querySelector('.el-image-viewer__close').click();
+
+    const $wrapper = document.querySelector('.el-image-viewer__wrapper');
+    expect($wrapper).to.exist;
+    $wrapper.querySelector('.el-image-viewer__close').click();
     await wait(1000);
-    expect(vm.$el.querySelector('.el-image-viewer__wrapper')).to.not.exist;
+    expect($wrapper.style.display).to.equal('none');
   });
 });
 


### PR DESCRIPTION
close #17164
目前大图预览的弹窗是放在 Image 元素下的，有被其他层级高的遮盖住的问题。
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
