### PR TITLE
Select: fix ie11上disabled状态还可以通过键盘操作下拉菜单的 bug

### DIFF
--- a/packages/select/src/navigation-mixin.js
+++ b/packages/select/src/navigation-mixin.js
@@ -24,6 +24,7 @@ export default {
 
   methods: {
     navigateOptions(direction) {
+      if (this.disabled) return;
       if (!this.visible) {
         this.visible = true;
         return;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

修复了在 ie11 下 Select 组件是 disabled 状态时,仍然可以通过键盘选择的 bug.

fix a bug ,that you can use narrow key to select options when disabled in the environment of ie11