### PR TITLE
Autocomplete: while focus, need dropdown all items, not just one

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -200,7 +200,7 @@
         this.activated = true;
         this.$emit('focus', event);
         if (this.triggerOnFocus) {
-          this.debouncedGetData(this.value);
+          this.debouncedGetData('');
         }
       },
       handleBlur(event) {


### PR DESCRIPTION
对于Autocomplete组件：
当triggerOnFocus时，若已有选中项，每次下拉只显示一个当前选中项，无多大意义。
多数时候我们希望在triggerOnFocus下拉时显示完整列表，类似一个下拉框。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
