### PR TITLE
popup:fix 组件触发弹窗后 焦点仍在组件上enter仍可以触发click事件

### DIFF
--- a/src/utils/popup/popup-manager.js
+++ b/src/utils/popup/popup-manager.js
@@ -105,7 +105,8 @@ const PopupManager = {
     }
     modalDom.tabIndex = 0;
     modalDom.style.display = '';
-
+    modalDom.focus();
+    
     this.modalStack.push({ id: id, zIndex: zIndex, modalClass: modalClass });
   },
 


### PR DESCRIPTION
官网示例中 点击button触发弹窗后 焦点仍在button上 此时按回车键 仍可触发button的click事件

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
