### PR TITLE
Fix change trigger slider

### DIFF
--- a/packages/slider/src/main.vue
+++ b/packages/slider/src/main.vue
@@ -293,7 +293,7 @@
 
       emitChange() {
         this.$nextTick(() => {
-          this.$emit('change', this.range ? [this.minValue, this.maxValue] : this.value);
+          this.$emit('change', this.range ? [this.minValue, this.maxValue] : this.firstValue);
         });
       },
 


### PR DESCRIPTION
The trigger change emit props value and should emit updated value from of button slider (firstValue) if is not a range.

If you use `value` and not `v-model` when trigger change emit value, the value emited from of props and is not value change by slider button.