### PR TITLE
Cascader: Fix child options not closed when lazy load another node (#17260)

### DIFF
--- a/packages/cascader-panel/src/cascader-node.vue
+++ b/packages/cascader-panel/src/cascader-node.vue
@@ -58,6 +58,8 @@
         if (!checkStrictly && isDisabled || node.loading) return;
 
         if (config.lazy && !node.loaded) {
+          // hide children's menus before fetch async data，prevent user's error click
+          panel.changePanel(node, true);
           panel.lazyLoad(node, () => {
             // do not use cached leaf value here, invoke this.isLeaf to get new value.
             const { isLeaf } = this;

--- a/packages/cascader-panel/src/cascader-node.vue
+++ b/packages/cascader-panel/src/cascader-node.vue
@@ -58,7 +58,7 @@
         if (!checkStrictly && isDisabled || node.loading) return;
 
         if (config.lazy && !node.loaded) {
-          // hide children's menus before fetch async data，prevent user's error click
+          // close child options when lazy load another node's child options
           panel.changePanel(node, true);
           panel.lazyLoad(node, () => {
             // do not use cached leaf value here, invoke this.isLeaf to get new value.

--- a/packages/cascader-panel/src/cascader-node.vue
+++ b/packages/cascader-panel/src/cascader-node.vue
@@ -59,7 +59,7 @@
 
         if (config.lazy && !node.loaded) {
           // close child options when lazy load another node's child options
-          panel.changePanel(node, true);
+          panel.toggleExpand(node, false);
           panel.lazyLoad(node, () => {
             // do not use cached leaf value here, invoke this.isLeaf to get new value.
             const { isLeaf } = this;

--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -260,13 +260,13 @@ export default {
           return;
       }
     },
-    changePanel(node, lazy = false) {
+    toggleExpand(node, isExpand = true) {
       const { activePath } = this;
       const { level } = node;
       const path = activePath.slice(0, level - 1);
       const menus = this.menus.slice(0, level);
 
-      if (!lazy && !node.isLeaf) {
+      if (isExpand && !node.isLeaf) {
         path.push(node);
         menus.push(node.children);
       }
@@ -277,7 +277,7 @@ export default {
       return { path, activePath };
     },
     handleExpand(node, silent) {
-      const { path, activePath } = this.changePanel(node);
+      const { path, activePath } = this.toggleExpand(node);
 
       if (!silent) {
         const pathValues = path.map(node => node.getValue());

--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -260,19 +260,24 @@ export default {
           return;
       }
     },
-    handleExpand(node, silent) {
+    changePanel(node, lazy = false) {
       const { activePath } = this;
       const { level } = node;
       const path = activePath.slice(0, level - 1);
       const menus = this.menus.slice(0, level);
 
-      if (!node.isLeaf) {
+      if (!lazy && !node.isLeaf) {
         path.push(node);
         menus.push(node.children);
       }
 
       this.activePath = path;
       this.menus = menus;
+
+      return { path, activePath };
+    },
+    handleExpand(node, silent) {
+      const { path, activePath } = this.changePanel(node);
 
       if (!silent) {
         const pathValues = path.map(node => node.getValue());


### PR DESCRIPTION
close (#17260)

通过正确的交互，阻挡用户不正常的操作行为：在异步加载子结点之前，先隐藏同级的子节点。

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
