### PR TITLE
Container: fix direction inconsistent when Header/Footer children nam…

### DIFF
--- a/packages/container/src/main.vue
+++ b/packages/container/src/main.vue
@@ -23,8 +23,8 @@
         }
         return this.$slots && this.$slots.default
           ? this.$slots.default.some(vnode => {
-            const tag = vnode.componentOptions && vnode.componentOptions.tag;
-            return tag === 'el-header' || tag === 'el-footer';
+            const componentName = vnode.componentOptions && vnode.componentOptions.Ctor.options.name;
+            return componentName === 'ElHeader' || componentName === 'ElFooter';
           })
           : false;
       }

--- a/test/unit/specs/container.spec.js
+++ b/test/unit/specs/container.spec.js
@@ -28,6 +28,18 @@ describe('Container', () => {
     expect(vm.$children[0].$el.classList.contains('is-vertical')).to.true;
   });
 
+  it('vertical for PascalCase', () => {
+    vm = createVue({
+      template: `
+        <ElContainer>
+          <ElHeader></ElHeader>
+          <ElMain></ElMain>
+        </ElContainer>
+      `
+    }, true);
+    expect(vm.$children[0].$el.classList.contains('is-vertical')).to.true;
+  });
+
   it('direction', done => {
     vm = createVue({
       template: `


### PR DESCRIPTION
When I enable the [vue/component-name-in-template-casing eslint rule](https://eslint.vuejs.org/rules/component-name-in-template-casing.html#vue-component-name-in-template-casing) and autofix the code, there is an abnormal behavior.
I think of we should not presume others use the kebab-case and don't rename the componet.

And I think Vue inclined to use PascalCase more(by [style guide](https://vuejs.org/v2/style-guide/#Component-name-casing-in-templates-strongly-recommended) and [eslint rule default config](https://eslint.vuejs.org/rules/component-name-in-template-casing.html#options)).

Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.
