### PR TITLE
Cascader: Fix display empty with emitPath is false and checked value is null or empty string (#17106)

### DIFF
--- a/packages/cascader-panel/src/cascader-node.vue
+++ b/packages/cascader-panel/src/cascader-node.vue
@@ -34,6 +34,10 @@
         return this.panel.checkedValue;
       },
       isChecked() {
+        const { multiple } = this.panel;
+        if (multiple && !this.checkedValue) {
+          return false;
+        }
         return this.node.isSameNode(this.checkedValue);
       },
       inActivePath() {

--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -188,19 +188,24 @@ export default {
       this.$nextTick(this.scrollIntoView);
     },
     syncMultiCheckState() {
-      const nodes = this.getFlattedNodes(this.leafOnly);
+      const { checkedValue } = this;
 
-      nodes.forEach(node => {
-        node.syncCheckState(this.checkedValue);
-      });
+      if (!isEmpty(checkedValue)) {
+        const nodes = this.getFlattedNodes(this.leafOnly);
+
+        nodes.forEach(node => {
+          node.syncCheckState(this.checkedValue);
+        });
+      }
     },
     syncActivePath() {
-      const { store, multiple, activePath, checkedValue } = this;
+      const { store, multiple, activePath, checkedValue, config } = this;
+      const { emitPath } = config;
 
       if (!isEmpty(activePath)) {
         const nodes = activePath.map(node => this.getNodeByValue(node.getValue()));
         this.expandNodes(nodes);
-      } else if (!isEmpty(checkedValue)) {
+      } else if (!isEmpty(checkedValue) || (!emitPath && !multiple)) {
         const value = multiple ? checkedValue[0] : checkedValue;
         const checkedNode = this.getNodeByValue(value) || {};
         const nodes = (checkedNode.pathNodes || []).slice(0, -1);

--- a/packages/cascader-panel/src/store.js
+++ b/packages/cascader-panel/src/store.js
@@ -51,12 +51,9 @@ export default class Store {
   }
 
   getNodeByValue(value) {
-    if (value) {
-      const nodes = this.getFlattedNodes(false, !this.config.lazy)
-        .filter(node => (valueEquals(node.path, value) || node.value === value));
-      return nodes && nodes.length ? nodes[0] : null;
-    }
-    return null;
+    const nodes = this.getFlattedNodes(false, !this.config.lazy)
+      .filter(node => (valueEquals(node.path, value) || node.value === value));
+    return nodes && nodes.length ? nodes[0] : null;
   }
 
 }

--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -350,7 +350,8 @@ export default {
       this.inputInitialHeight = input.$el.offsetHeight || InputSizeMap[this.realSize] || 40;
     }
 
-    if (!isEmpty(this.value)) {
+    // call presentContent is (emitPath is false and multiple is false)
+    if (!isEmpty(this.value) || (!this.emitPath && !this.config.multiple)) {
       this.computePresentContent();
     }
 
@@ -487,7 +488,7 @@ export default {
     },
     computePresentText() {
       const { checkedValue, config } = this;
-      if (!isEmpty(checkedValue)) {
+      if (!isEmpty(checkedValue) || !this.emitPath) {
         const node = this.panel.getNodeByValue(checkedValue);
         if (node && (config.checkStrictly || node.isLeaf)) {
           this.presentText = node.getText(this.showAllLevels, this.separator);


### PR DESCRIPTION
close #(17106)
解决，多选模式下，emitPath = false 的时候，当 value 为 null 的选项被选中时，cascader 展示为空的问题。

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
