### PR TITLE
Menu: fix click menu item open submenu again

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -266,6 +266,7 @@
 
         if (this.mode === 'horizontal' || this.collapse) {
           this.openedMenus = [];
+          this.broadcast('ElSubmenu', 'clear-mouse-event-timer');
         }
 
         if (this.router && hasIndex) {

--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -252,6 +252,9 @@
         this.mouseInChild = false;
         clearTimeout(this.timeout);
       });
+      this.$on('clear-mouse-event-timer', () => {
+        clearTimeout(this.timeout);
+      });
     },
     mounted() {
       this.parentMenu.addSubmenu(this);

--- a/test/unit/specs/menu.spec.js
+++ b/test/unit/specs/menu.spec.js
@@ -1,4 +1,4 @@
-import { createVue, triggerEvent, destroyVM } from '../util';
+import { createVue, triggerEvent, destroyVM, wait } from '../util';
 
 describe('Menu', () => {
   let vm;
@@ -275,6 +275,32 @@ describe('Menu', () => {
         expect(submenu.$el.classList.contains('is-opened')).to.be.false;
         done();
       }, 20);
+    });
+    it('click item not open again', async() => {
+      vm = createVue({
+        template: `
+          <el-menu mode="horizontal">
+            <el-menu-item index="1">处理中心</el-menu-item>
+            <el-submenu index="2" ref="submenu">
+              <template slot="title">我的工作台</template>
+              <el-menu-item index="2-1">选项1</el-menu-item>
+              <el-menu-item index="2-2" ref="submenuItem2">选项2</el-menu-item>
+              <el-menu-item index="2-3">选项3</el-menu-item>
+            </el-submenu>
+            <el-menu-item index="3">订单管理</el-menu-item>
+          </el-menu>
+        `
+      }, true);
+      let submenu = vm.$refs.submenu;
+      let submenuItem2 = vm.$refs.submenuItem2;
+      triggerEvent(submenu.$el, 'mouseenter');
+      await wait(500);
+      expect(submenu.$el.classList.contains('is-opened')).to.be.true;
+      triggerEvent(submenu.$el, 'mouseleave');
+      triggerEvent(submenu.$el, 'mouseenter');
+      submenuItem2.$el.click();
+      await wait(500);
+      expect(submenu.$el.classList.contains('is-opened')).to.be.false;
     });
   });
   it('unique-opened', done => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

#12512 

Desc
---
when follow this step
1. mouse enter submenu title
2. mouse enter submenu content
3. click menu item

submenu component trigger event like this
1. mouseenter
2. mouseleave
3. mouseenter
4. click

`event` 3 will clear `leave submenu timer` and create a `open submenu timer`. 
when trigger `click` slower than `open submenu timer` execute, nothing happened for open an already open submenu.
but when  trigger `click` faster than `timer`, submenu will reopen.