### PR TITLE
OptionGroup: set visible to true when children is empty

### DIFF
--- a/packages/select/src/option-group.vue
+++ b/packages/select/src/option-group.vue
@@ -43,7 +43,7 @@
       queryChange() {
         this.visible = this.$children &&
           Array.isArray(this.$children) &&
-          this.$children.some(option => option.visible === true);
+          (!this.$children.length || this.$children.some(option => option.visible === true));
       }
     },
 


### PR DESCRIPTION
The selection box is empty when first clicked.

[codepen example](https://codepen.io/juicecans/pen/eYOLeGJ)

![594F57C1-FA89-4559-B9E6-EF037134C274](https://user-images.githubusercontent.com/11648898/65036211-7fd02e80-d97d-11e9-9baf-4ea877d89e03.png)
