### PR TITLE
Tree: fix checkbox default all checked error in lazy loaded mode

### DIFF
--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -128,10 +128,6 @@ export default class Node {
       store.currentNode.isCurrent = true;
     }
 
-    if (store.lazy) {
-      store._initDefaultCheckedNode(this);
-    }
-
     this.updateLeafState();
   }
 
@@ -468,7 +464,7 @@ export default class Node {
         this.childNodes = [];
 
         this.doCreateChildren(children, defaultProps);
-
+        this.store._initDefaultCheckedNodes();
         this.updateLeafState();
         if (callback) {
           callback.call(this, children);

--- a/packages/tree/src/model/tree-store.js
+++ b/packages/tree/src/model/tree-store.js
@@ -118,14 +118,6 @@ export default class TreeStore {
     });
   }
 
-  _initDefaultCheckedNode(node) {
-    const defaultCheckedKeys = this.defaultCheckedKeys || [];
-
-    if (defaultCheckedKeys.indexOf(node.key) !== -1) {
-      node.setChecked(true, !this.checkStrictly);
-    }
-  }
-
   setDefaultCheckedKey(newVal) {
     if (newVal !== this.defaultCheckedKeys) {
       this.defaultCheckedKeys = newVal;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

复现：
[code example](https://codepen.io/zhoulin/pen/NWKLaPv)

描述：
在懒加载的模式下，`Node`被构造就会调用一次 `_initDefaultCheckedNode`, 而`setChecked`内部会重新初始化父类的`checked`状态，但此时`childNodes`并不一定是完整的子节点数组，这就会出现当不完整的`childNodes`里`checked`都是`true`的时候, 父类的`checked`也会是`true`。所以应该在`loadData`里创建完`childNodes`后再`_initDefaultCheckedNodes`一遍。
这个时候单个的`_initDefaultCheckedNode`就多余了，可以删掉它。
