### PR TITLE
AutoComplete: enable keyup&keydown when there is no suggestions

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -235,7 +235,7 @@
       },
       highlight(index, event) {
         if (!this.suggestionVisible || this.loading) { return; }
-        event.preventDefault();
+        if(event) { event.preventDefault(); }
 
         if (index < 0) {
           this.highlightedIndex = -1;

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -235,7 +235,7 @@
       },
       highlight(index, event) {
         if (!this.suggestionVisible || this.loading) { return; }
-        if(event) { event.preventDefault(); }
+        if (event) { event.preventDefault(); }
 
         if (index < 0) {
           this.highlightedIndex = -1;

--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -14,8 +14,8 @@
       @focus="handleFocus"
       @blur="handleBlur"
       @clear="handleClear"
-      @keydown.up.native.prevent="highlight(highlightedIndex - 1)"
-      @keydown.down.native.prevent="highlight(highlightedIndex + 1)"
+      @keydown.up.native="highlight(highlightedIndex - 1, $event)"
+      @keydown.down.native="highlight(highlightedIndex + 1, $event)"
       @keydown.enter.native="handleKeyEnter"
       @keydown.native.tab="close"
     >
@@ -233,8 +233,10 @@
           this.highlightedIndex = -1;
         });
       },
-      highlight(index) {
+      highlight(index, event) {
         if (!this.suggestionVisible || this.loading) { return; }
+        event.preventDefault();
+
         if (index < 0) {
           this.highlightedIndex = -1;
           return;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
-----

## 已知问题
AutoComplete在type=textarea情况下时，键盘的上键和下键默认是prevent的。
示例：
https://codepen.io/RickyWong33/pen/ExYdypN?editors=1111

输入多行数据后，键盘上下键不可用。

------

## 修复

正确是做法时，出现suggestions提示框时，才prevent；不然保留原始的功能