### PR TITLE
Input: Triggle input event when using autofill under IME mode

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -426,10 +426,20 @@
       this.setNativeInputValue();
       this.resizeTextarea();
       this.updateIconOffset();
+      this.getInput().addEventListener('animationstart', (e) => {
+        switch (e.animationName) {
+          case 'onAutoFillStart':
+            this.isComposing = false;
+            break;
+        }
+      });
     },
 
     updated() {
       this.$nextTick(this.updateIconOffset);
+    },
+    beforeDestory() {
+      this.getInput().removeEventListener('animationstart');
     }
   };
 </script>

--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -35,6 +35,10 @@
       outline: none;
       border-color: $--input-focus-border;
     }
+    &:-webkit-autofill {
+      animation-name: onAutoFillStart;
+      transition: background-color .3s ease-in-out 0s;
+    }
   }
 
   & .el-input__count {
@@ -131,6 +135,14 @@
     &:focus {
       outline: none;
       border-color: $--input-focus-border;
+    }
+
+    &:-webkit-autofill {
+      // Expose a hook for JavaScript when auto fill is shown.
+      // JavaScript can capture 'animationstart' events
+      animation-name: onAutoFillStart;
+  
+      transition: background-color .3s ease-in-out 0s;
     }
   }
 
@@ -353,4 +365,9 @@
   display: none;
   width: 0;
   height: 0;
+}
+
+@keyframes onAutoFillStart {
+  from {/**/}
+  to {/**/}
 }


### PR DESCRIPTION
issue 产生原因在于 Chrome 的一个 bug，在 autocomplete 和 IME 输入状态下，选择 autofill 时不触发 compositionend 事件，导致 isComposing 状态始终为 true。影响 input 事件结果。

一个 workaround 借鉴于 Vue 下[一个 issue](https://github.com/vuejs/vue/issues/7058#issuecomment-441322358)，采用 css animation 监听的解决方案。经测试能解决问题。

Close #17146 

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
