### PR TITLE
fix:progress pick the last color when color property is bound to an c…

### DIFF
--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -212,7 +212,7 @@
           if (typeof seriesColor === 'string') {
             return {
               color: seriesColor,
-              progress: (index + 1) * span
+              percentage: (index + 1) * span
             };
           }
           return seriesColor;


### PR DESCRIPTION
```
<el-progress :percentage="percent" :color="colors"></el-progress>
percent: 20
colors: ["red", "blue", "green", "yellow", "pink"]
```
when `el-progress` is used like this, it picks the last color element `pink` in `colors`, not `blue`.
we can fix it like this:
```
getColorArray() {
        const color = this.color;
        const span = 100 / color.length;
        return color.map((seriesColor, index) => {
          if (typeof seriesColor === 'string') {
            return {
              color: seriesColor,
              percentage: (index + 1) * span // here! It should be 'percentage', not 'progress'
            };
          }
          return seriesColor;
        });
      }
```
It should use `percentage` as key, not `progress`.
