### PR TITLE
TimePicker: Add support for 'format' option in time-select

### DIFF
--- a/test/unit/specs/time-select.spec.js
+++ b/test/unit/specs/time-select.spec.js
@@ -31,6 +31,31 @@ describe('TimeSelect', () => {
     });
   });
 
+  it('supports custom format', done => {
+    vm = createTest(TimeSelect, {
+      format: 'h:mm A',
+      pickerOptions: {
+        start: '9:00 AM',
+        step: '01:00',
+        end: '5:00 PM'
+      },
+      placeholder: 'test'
+    }, true);
+    const input = vm.$el.querySelector('input');
+
+    input.focus();
+    input.blur();
+
+    Vue.nextTick(_ => {
+      expect(vm.picker.start).to.equal('9:00 AM');
+      expect(vm.picker.end).to.equal('5:00 PM');
+      expect(vm.picker.step).to.equal('01:00');
+      expect(vm.$el.querySelector('input').getAttribute('placeholder')).to.equal('test');
+      expect(Array.from(vm.picker.$el.querySelectorAll('div.time-select-item')).slice(0, 5).map(e => e.innerText).join(', ')).to.equal('9:00 AM, 10:00 AM, 11:00 AM, 12:00 PM, 1:00 PM');
+      done();
+    });
+  });
+
   it('select time', done => {
     vm = createVue({
       template: `


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.

---

For `<el-time-select>`, pass the `format` prop to the `time-select` panel. If it has a value, use it to format the options displayed in the list (and implicitly the expected format of the selected value). Would address feature request #17068.