### PR TITLE
Slider: feature support reverse prop

### DIFF
--- a/examples/docs/en-US/slider.md
+++ b/examples/docs/en-US/slider.md
@@ -211,6 +211,44 @@ Selecting a range of values is supported.
 ```
 :::
 
+### Reverse mode
+
+:::demo Setting this `reverse` attribute can show it in the reverse direction. 
+```html
+<template>
+  <div class="block">
+    <el-slider
+      v-model="value"
+      range
+      reverse
+      :marks="marks">
+    </el-slider>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        value: [60, 30],
+        marks: {
+          0: '0°C',
+          8: '8°C',
+          37: '37°C',
+          50: {
+            style: {
+              color: '#1989FA'
+            },
+            label: this.$createElement('strong', '50%')
+          }
+        }
+      }
+    }
+  }
+</script>
+```
+:::
+
 ## Attributes
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
 |---------- |-------------- |---------- |--------------------------------  |-------- |
@@ -232,6 +270,7 @@ Selecting a range of values is supported.
 | debounce | debounce delay when typing, in milliseconds, works when `show-input` is true | number | — | 300 |
 | tooltip-class | custom class name for the tooltip | string | — | — |
 | marks | marks， type of key must be `number` and must in closed interval `[min, max]`, each mark can custom style| object | — | — |
+| reverse | reverse mode | boolean | — | false |
 
 ## Events
 | Event Name | Description | Parameters |

--- a/examples/docs/es/slider.md
+++ b/examples/docs/es/slider.md
@@ -213,6 +213,44 @@ Se soporta la selección de un rango de valores.
 ```
 :::
 
+### Reverse mode
+
+:::demo Setting this `reverse` attribute can show it in the reverse direction. 
+```html
+<template>
+  <div class="block">
+    <el-slider
+      v-model="value"
+      range
+      reverse
+      :marks="marks">
+    </el-slider>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        value: [60, 30],
+        marks: {
+          0: '0°C',
+          8: '8°C',
+          37: '37°C',
+          50: {
+            style: {
+              color: '#1989FA'
+            },
+            label: this.$createElement('strong', '50%')
+          }
+        }
+      }
+    }
+  }
+</script>
+```
+:::
+
 ## Atributos
 | Atributo            | Descripción                              | Tipo            | Valores aceptados | Por defecto |
 | ------------------- | ---------------------------------------- | --------------- | ----------------- | ----------- |
@@ -234,6 +272,7 @@ Se soporta la selección de un rango de valores.
 | debounce            | retardo al escribir, en milisegundos, funciona cuando`show-input` es true. | number          | —                 | 300         |
 | tooltip-class       | nombre personalizado de clase para el tooltip | string | — | — |
 | marks | marcas, tipo de clave debe ser `number` y debe estar en intervalo cerrado [min, max], cada marca puede tener estilo personalizado | object | — | — |
+| reverse | reverse mode | boolean | — | false |
 
 ## Eventos
 | Nombre | Descripción                              | Parametros               |

--- a/examples/docs/fr-FR/slider.md
+++ b/examples/docs/fr-FR/slider.md
@@ -209,6 +209,44 @@ Vous pouvez sélectionner des intervalles de valeurs au lieu d'une valeur unique
 ```
 :::
 
+### Reverse mode
+
+:::demo Setting this `reverse` attribute can show it in the reverse direction. 
+```html
+<template>
+  <div class="block">
+    <el-slider
+      v-model="value"
+      range
+      reverse
+      :marks="marks">
+    </el-slider>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        value: [60, 30],
+        marks: {
+          0: '0°C',
+          8: '8°C',
+          37: '37°C',
+          50: {
+            style: {
+              color: '#1989FA'
+            },
+            label: this.$createElement('strong', '50%')
+          }
+        }
+      }
+    }
+  }
+</script>
+```
+:::
+
 ## Attributs
 
 | Attribut      | Description          | Type      | Valeurs acceptées       | Défaut  |
@@ -231,6 +269,7 @@ Vous pouvez sélectionner des intervalles de valeurs au lieu d'une valeur unique
 | debounce | Délai après écriture en millisecondes, marche quand `show-input` est `true`. | number | — | 300 |
 | tooltip-class | Classe du tooltip. | string | — | — |
 | marks | Marqueurs, les clés doivent être des `number` et être comprises dans l'intervalle `[min, max]`. Chaque marqueur peut avoir un style particulier. | object | — | — |
+| reverse | reverse mode | boolean | — | false |
 
 ## Évènements
 

--- a/examples/docs/zh-CN/slider.md
+++ b/examples/docs/zh-CN/slider.md
@@ -208,6 +208,44 @@
 ```
 :::
 
+### 反向模式
+
+:::demo 设置`reverse`属性可以以相反的顺序展示 Slider
+```html
+<template>
+  <div class="block">
+    <el-slider
+      v-model="value"
+      range
+      reverse
+      :marks="marks">
+    </el-slider>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        value: [60, 30],
+        marks: {
+          0: '0°C',
+          8: '8°C',
+          37: '37°C',
+          50: {
+            style: {
+              color: '#1989FA'
+            },
+            label: this.$createElement('strong', '50%')
+          }
+        }
+      }
+    }
+  }
+</script>
+```
+:::
+
 ### Attributes
 | 参数      | 说明          | 类型      | 可选值                           | 默认值  |
 |---------- |-------------- |---------- |--------------------------------  |-------- |
@@ -229,6 +267,7 @@
 | debounce | 输入时的去抖延迟，毫秒，仅在`show-input`等于true时有效 | number | — | 300 |
 | tooltip-class | tooltip 的自定义类名 | string | — | — |
 | marks | 标记， key 的类型必须为 number 且取值在闭区间 `[min, max]` 内，每个标记可以单独设置样式 | object | — | — |
+| reverse | 是否反向模式 | boolean | — | false |
 
 ### Events
 | 事件名称      | 说明    | 回调参数      |

--- a/packages/slider/src/button.vue
+++ b/packages/slider/src/button.vue
@@ -46,7 +46,11 @@
         type: Boolean,
         default: false
       },
-      tooltipClass: String
+      tooltipClass: String,
+      reverse: {
+        type: Boolean,
+        default: false
+      }
     },
 
     data() {
@@ -90,7 +94,11 @@
       },
 
       currentPosition() {
-        return `${ (this.value - this.min) / (this.max - this.min) * 100 }%`;
+        if (this.reverse) {
+          return `${ (this.max - this.value) / (this.max - this.min) * 100 }%`;
+        } else {
+          return `${ (this.value - this.min) / (this.max - this.min) * 100 }%`;
+        }
       },
 
       enableFormat() {
@@ -186,6 +194,7 @@
             this.currentX = event.clientX;
             diff = (this.currentX - this.startX) / this.$parent.sliderSize * 100;
           }
+
           this.newPosition = this.startPosition + diff;
           this.setPosition(this.newPosition);
         }
@@ -222,7 +231,12 @@
         }
         const lengthPerStep = 100 / ((this.max - this.min) / this.step);
         const steps = Math.round(newPosition / lengthPerStep);
-        let value = steps * lengthPerStep * (this.max - this.min) * 0.01 + this.min;
+        let value;
+        if (this.reverse) {
+          value = this.max - steps * lengthPerStep * (this.max - this.min) * 0.01;
+        } else {
+          value = steps * lengthPerStep * (this.max - this.min) * 0.01 + this.min;
+        }
         value = parseFloat(value.toFixed(this.precision));
         this.$emit('input', value);
         this.$nextTick(() => {

--- a/packages/slider/src/main.vue
+++ b/packages/slider/src/main.vue
@@ -34,12 +34,14 @@
       </div>
       <slider-button
         :vertical="vertical"
+        :reverse="reverse"
         v-model="firstValue"
         :tooltip-class="tooltipClass"
         ref="button1">
       </slider-button>
       <slider-button
         :vertical="vertical"
+        :reverse="reverse"
         v-model="secondValue"
         :tooltip-class="tooltipClass"
         ref="button2"
@@ -151,7 +153,11 @@
         type: String
       },
       tooltipClass: String,
-      marks: Object
+      marks: Object,
+      reverse: {
+        type: Boolean,
+        default: false
+      }
     },
 
     components: {
@@ -189,7 +195,11 @@
 
       firstValue(val) {
         if (this.range) {
-          this.$emit('input', [this.minValue, this.maxValue]);
+          if (this.reverse) {
+            this.$emit('input', [this.maxValue, this.minValue]);
+          } else {
+            this.$emit('input', [this.minValue, this.maxValue]);
+          }
         } else {
           this.$emit('input', val);
         }
@@ -197,7 +207,11 @@
 
       secondValue() {
         if (this.range) {
-          this.$emit('input', [this.minValue, this.maxValue]);
+          if (this.reverse) {
+            this.$emit('input', [this.maxValue, this.minValue]);
+          } else {
+            this.$emit('input', [this.minValue, this.maxValue]);
+          }
         }
       },
 
@@ -258,7 +272,12 @@
       },
 
       setPosition(percent) {
-        const targetValue = this.min + percent * (this.max - this.min) / 100;
+        let targetValue;
+        if (this.reverse) {
+          targetValue = this.max - percent * (this.max - this.min) / 100;
+        } else {
+          targetValue = this.min + percent * (this.max - this.min) / 100;
+        }
         if (!this.range) {
           this.$refs.button1.setPosition(percent);
           return;
@@ -298,7 +317,19 @@
       },
 
       getStopStyle(position) {
-        return this.vertical ? { 'bottom': position + '%' } : { 'left': position + '%' };
+        if (this.vertical) {
+          if (this.reverse) {
+            return { 'bottom': this.max - position + '%' };
+          } else {
+            return { 'bottom': position + '%' };
+          }
+        } else {
+          if (this.reverse) {
+            return { 'left': this.max - position + '%' };
+          } else {
+            return { 'left': position + '%' };
+          }
+        }
       }
     },
 
@@ -357,9 +388,11 @@
       },
 
       barStart() {
-        return this.range
-          ? `${ 100 * (this.minValue - this.min) / (this.max - this.min) }%`
-          : '0%';
+        if (this.reverse) {
+          return `${ 100 * (this.max - this.maxValue) / (this.max - this.min) }%`;
+        } else {
+          return `${ 100 * (this.minValue - this.min) / (this.max - this.min) }%`;
+        }
       },
 
       precision() {

--- a/test/unit/specs/slider.spec.js
+++ b/test/unit/specs/slider.spec.js
@@ -373,7 +373,7 @@ describe('Slider', () => {
 
       data() {
         return {
-          value: 0
+          value: 100
         };
       }
     }, true);
@@ -381,7 +381,7 @@ describe('Slider', () => {
     await waitImmediate();
     slider.onSliderClick({ clientY: 100 });
     await waitImmediate();
-    expect(vm.value > 0).to.true;
+    expect(vm.value < 100).to.true;
   });
 
   describe('range', () => {

--- a/test/unit/specs/slider.spec.js
+++ b/test/unit/specs/slider.spec.js
@@ -142,6 +142,38 @@ describe('Slider', () => {
     }, 10);
   });
 
+  it('drag with reverse', async() => {
+    vm = createVue({
+      template: `
+        <div>
+          <el-slider v-model="value" :vertical="vertical" reverse></el-slider>
+        </div>
+      `,
+
+      data() {
+        return {
+          vertical: false,
+          value: 100
+        };
+      }
+    }, true);
+    const slider = vm.$children[0].$children[0];
+    slider.onButtonDown({ clientX: 0, preventDefault() {} });
+    slider.onDragging({ clientX: 100 });
+    slider.onDragEnd();
+    await waitImmediate();
+    expect(vm.value < 100).to.true;
+    vm.vertical = true;
+    vm.value = 100;
+    await waitImmediate();
+    expect(vm.value === 100).to.true;
+    slider.onButtonDown({ clientY: 0, preventDefault() {} });
+    slider.onDragging({ clientY: -100 });
+    slider.onDragEnd();
+    await waitImmediate();
+    expect(vm.value < 100).to.true;
+  });
+
   it('accessibility', done => {
     vm = createVue({
       template: `
@@ -329,6 +361,27 @@ describe('Slider', () => {
         done();
       }, 10);
     }, 10);
+  });
+
+  it('reverse mode', async() => {
+    vm = createVue({
+      template: `
+        <div>
+          <el-slider vertical reverse v-model="value" height="200px"></el-slider>
+        </div>
+      `,
+
+      data() {
+        return {
+          value: 0
+        };
+      }
+    }, true);
+    const slider = vm.$children[0];
+    await waitImmediate();
+    slider.onSliderClick({ clientY: 100 });
+    await waitImmediate();
+    expect(vm.value > 0).to.true;
   });
 
   describe('range', () => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

desc
---
`reverse` prop is use to control `slider` display order.

desc-zh
---
`reverse`属性是用来控制滑块的展示顺序，特别是跟`vertical`模式和`marks`标记一起使用的情况下。比如我们可能希望在`vertical`模式下从上往下数字递增，与`marks`标记一起使用时从左往右递减。