### PR TITLE
Drawer: fix drawer cannot close when pressing esc

### DIFF
--- a/packages/badge/src/main.vue
+++ b/packages/badge/src/main.vue
@@ -7,7 +7,7 @@
         v-text="content"
         class="el-badge__content"
         :class="[
-          'el-badge__content--' + type,
+          type ? 'el-badge__content--' + type : '',
           {
             'is-fixed': $slots.default,
             'is-dot': isDot

--- a/packages/drawer/src/main.vue
+++ b/packages/drawer/src/main.vue
@@ -30,7 +30,7 @@
               class="el-drawer__close-btn"
               type="button"
               v-if="showClose"
-              @click="closeDrawer">
+              @click="handleClose">
               <i class="el-dialog__close el-icon el-icon-close"></i>
             </button>
           </header>
@@ -58,6 +58,10 @@ export default {
     },
     beforeClose: {
       type: Function
+    },
+    closeOnPressEscape: {
+      type: Boolean,
+      default: true
     },
     customClass: {
       type: String,
@@ -140,10 +144,10 @@ export default {
     },
     handleWrapperClick() {
       if (this.wrapperClosable) {
-        this.closeDrawer();
+        this.handleClose();
       }
     },
-    closeDrawer() {
+    handleClose() {
       if (typeof this.beforeClose === 'function') {
         this.beforeClose(this.hide);
       } else {


### PR DESCRIPTION
The drawer cannot close when pressing esc and drawer attribute `close-on-press-escape` default value  is `true`.Thank you.
Closes #17319 

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
