### PR TITLE
Cascader: fix Popper to increase zindex at 110% of the page (fixed #17529)

### DIFF
--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -631,7 +631,8 @@ export default {
       }
 
       if (tags) {
-        const { offsetHeight } = tags;
+        // const { offsetHeight } = tags;
+        const offsetHeight = tags.getBoundingClientRect().height; 
         const height = Math.max(offsetHeight + 6, inputInitialHeight) + 'px';
         inputInner.style.height = height;
         this.updatePopper();


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
