### PR TITLE
DropdownItem: 修复当出现横向滚动条并拖动滚动条后, DropdownItem 内容无法撑起容器的问题

### DIFF
--- a/packages/theme-chalk/src/dropdown.scss
+++ b/packages/theme-chalk/src/dropdown.scss
@@ -83,6 +83,7 @@
     color: $--color-text-regular;
     cursor: pointer;
     outline: none;
+    min-width: max-content;
     &:not(.is-disabled):hover, &:focus {
       background-color: $--dropdown-menuItem-hover-fill;
       color: $--dropdown-menuItem-hover-color;


### PR DESCRIPTION
## 问题描述
修复当出现横向滚动条并拖动滚动条后, DropdownItem 内容无法撑起容器宽度

## 操作复现
![bug](https://user-images.githubusercontent.com/34350871/65504160-faa6c580-def8-11e9-944c-998f663da3d8.gif)

## 最小可复现 demo
https://github.com/ta7sudan/dropdown-demo

## 解决方案
为 DropdownItem 加上样式 `min-width: max-content;`


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
