### PR TITLE
Message: Fix removed element offsetHeight calculation bug

### DIFF
--- a/packages/message/src/main.js
+++ b/packages/message/src/main.js
@@ -58,9 +58,11 @@ const Message = function(options) {
 Message.close = function(id, userOnClose) {
   let len = instances.length;
   let index = -1;
+  let removedHeight = 0;
   for (let i = 0; i < len; i++) {
     if (id === instances[i].id) {
       index = i;
+      removedHeight = instances[index].$el.offsetHeight;
       if (typeof userOnClose === 'function') {
         userOnClose(instances[i]);
       }
@@ -69,8 +71,7 @@ Message.close = function(id, userOnClose) {
     }
   }
   if (len <= 1 || index === -1 || index > instances.length - 1) return;
-  const removedHeight = instances[index].$el.offsetHeight;
-  for (let i = index; i < len - 1 ; i++) {
+  for (let i = index; i < len - 1; i++) {
     let dom = instances[i].$el;
     dom.style['top'] =
       parseInt(dom.style['top'], 10) - removedHeight - 16 + 'px';


### PR DESCRIPTION

message组件，同时弹出多个消息的情况下，前一个消息框消失，计算offsetHeight的元素选择错误，会出现后面的消息框没置顶，或者覆盖的情况，在线演示见[message bug](https://codepen.io/moshang/pen/ZEEQWop?&editable=true)
![message bug](https://user-images.githubusercontent.com/29499430/66693567-de6a9d00-ecdc-11e9-841f-142f86030449.png)

错误见代码中的注释
```js
Message.close = function(id, userOnClose) {
  let len = instances.length;
  let index = -1;
  for (let i = 0; i < len; i++) {
    if (id === instances[i].id) {
      index = i;
      if (typeof userOnClose === 'function') {
        userOnClose(instances[i]);
      }
      instances.splice(i, 1);
      break;
    }
  }
  if (len <= 1 || index === -1 || index > instances.length - 1) return;
 // 这个地方计算的是 instances.splice(i, 1);移除后数组中的实例，index对应的instance不是被移除的那个元素，计算的offsetHeight 不正确
  const removedHeight = instances[index].$el.offsetHeight;
  for (let i = index; i < len - 1 ; i++) {
    let dom = instances[i].$el;
    dom.style['top'] =
      parseInt(dom.style['top'], 10) - removedHeight - 16 + 'px';
  }
};
```
