### PR TITLE
use parentElement instead of parentNode

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -204,8 +204,8 @@
 
     destroyed() {
       // if appendToBody is true, remove DOM node after destroy
-      if (this.appendToBody && this.$el && this.$el.parentNode) {
-        this.$el.parentNode.removeChild(this.$el);
+      if (this.appendToBody && this.$el && this.$el.parentElement) {
+        this.$el.parentElement.removeChild(this.$el);
       }
     }
   };


### PR DESCRIPTION
here should use parentElement instead of parentNode, because when you route to another route-view, then there will be a exception caused by this.$el is not a child of the this.$el.parentNode

Please make sure these boxes are checked before submitting your PR, thank you!

* [*] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [*] Make sure you are merging your commits to `dev` branch.
* [*] Add some descriptions and refer relative issues for you PR.
