### PR TITLE
Notification: fix long word cannot display completely bug(#17854)

### DIFF
--- a/packages/theme-chalk/src/notification.scss
+++ b/packages/theme-chalk/src/notification.scss
@@ -43,6 +43,7 @@
 
     p {
       margin: 0;
+      word-break:break-all;
     }
   }
 


### PR DESCRIPTION
this PR is to fix the issue #17854 . 
When there are some long words in the message that the notification should show, the notification cannot show all the words, it just show part of the words.
Obviously, it is a bug. And this PR will fix it.
 
