### PR TITLE
Cascader: fix TypeScript 3.7 compatibility

### DIFF
--- a/types/cascader.d.ts
+++ b/types/cascader.d.ts
@@ -2,11 +2,7 @@ import { VNode } from 'vue';
 import { ElementUIComponent, ElementUIComponentSize } from './component'
 import { CascaderOption, CascaderProps, CascaderNode } from './cascader-panel';
 
-export type CascaderOption = CascaderOption
-
-export type CascaderProps<V, D> = CascaderProps<V, D>
-
-export type CascaderNode<V, D> = CascaderNode<V, D>
+export { CascaderOption, CascaderProps, CascaderNode };
 
 export interface CascaderSlots {
   /** Custom label content */


### PR DESCRIPTION
Fix error: 导入声明与“CascaderOption”的局部声明冲突

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
