### PR TITLE
Cascader: fix hasChildren logic（#17786）

### DIFF
--- a/packages/cascader-panel/src/node.js
+++ b/packages/cascader-panel/src/node.js
@@ -34,7 +34,7 @@ export default class Node {
     const { config } = this;
     const childrenKey = config.children;
     const childrenData = this.data[childrenKey];
-    this.hasChildren = Array.isArray(childrenData);
+    this.hasChildren = Array.isArray(childrenData) && childrenData.length;
     this.children = (childrenData || []).map(child => new Node(child, config, this));
   }
 


### PR DESCRIPTION
fix：When the children of the incoming data options array is [], the cascade selector can select the options

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
