### PR TITLE
[pagination] added prev-aria-label and next-aria-label props

### DIFF
--- a/examples/docs/en-US/pagination.md
+++ b/examples/docs/en-US/pagination.md
@@ -177,7 +177,7 @@ When you don't want to display text in 'previous' / 'next' buttons but still wan
 <el-pagination
   small
   prev-aria-label="Go back"
-  prev-aria-next="Go next"
+  next-aria-label="Go next"
   layout="prev, pager, next"
   :total="50">
 </el-pagination>

--- a/examples/docs/en-US/pagination.md
+++ b/examples/docs/en-US/pagination.md
@@ -168,6 +168,22 @@ When there is only one page, hide the pagination by setting the `hide-on-single-
 ```
 :::
 
+### Aria labeling
+
+When you don't want to display text in 'previous' / 'next' buttons but still want buttons to be screen-reader friendly you can use `prev-aria-label` and `next-aria-label`.
+
+:::demo
+```html
+<el-pagination
+  small
+  prev-aria-label="Go back"
+  prev-aria-next="Go next"
+  layout="prev, pager, next"
+  :total="50">
+</el-pagination>
+```
+:::
+
 ### Attributes
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
 |--------------------|----------------------------------------------------------|-------------------|-------------|--------|
@@ -183,6 +199,8 @@ When there is only one page, hide the pagination by setting the `hide-on-single-
 | popper-class | custom class name for the page size Select's dropdown | string | — | — |
 | prev-text | text for the prev button | string | — | — |
 | next-text | text for the next button | string | — | — |
+| prev-aria-label | aria-label for prev button | string | - | - |
+| next-aria-label | aria-label for next button | string | - | - |
 | disabled | whether Pagination is disabled | boolean | — | false |
 | hide-on-single-page | whether to hide when there's only one page | boolean | — | - |
 

--- a/packages/pagination/src/pagination.js
+++ b/packages/pagination/src/pagination.js
@@ -48,7 +48,11 @@ export default {
 
     prevText: String,
 
+    prevAriaLabel: String,
+
     nextText: String,
+
+    nextAriaLabel: String,
 
     background: Boolean,
 
@@ -117,6 +121,7 @@ export default {
           <button
             type="button"
             class="btn-prev"
+            aria-label={ this.$parent.prevAriaLabel }
             disabled={ this.$parent.disabled || this.$parent.internalCurrentPage <= 1 }
             on-click={ this.$parent.prev }>
             {
@@ -135,6 +140,7 @@ export default {
           <button
             type="button"
             class="btn-next"
+            aria-label={ this.$parent.nextAriaLabel }
             disabled={ this.$parent.disabled || this.$parent.internalCurrentPage === this.$parent.internalPageCount || this.$parent.internalPageCount === 0 }
             on-click={ this.$parent.next }>
             {

--- a/types/pagination.d.ts
+++ b/types/pagination.d.ts
@@ -38,6 +38,12 @@ export declare class ElPagination extends ElementUIComponent {
   /** Text for the prev button */
   nextText: string
 
+  /** aria-label for prev button */
+  prevAriaLabel: string
+
+  /** aria-label for next button */
+  nextAriaLabel: string
+
   /** Whether to hide when thers's only one page */ 
   hideOnSinglePage: boolean
 }


### PR DESCRIPTION
This will make it possible to easily specify screen-reader friendly labels even if we want to keep icons for the buttons themselves. Makes it easier to fix the related issue reported by Google Lighthouse.
