### PR TITLE
Pagination: fix style error for slot of span tag

### DIFF
--- a/packages/theme-chalk/src/pagination.scss
+++ b/packages/theme-chalk/src/pagination.scss
@@ -10,7 +10,7 @@
   font-weight: bold;
   @include utils-clearfix;
 
-  span:not([class*=suffix]),
+  span[class*=el-pagination],
   button {
     display: inline-block;
     font-size: $--pagination-font-size;
@@ -115,7 +115,7 @@
       line-height: 24px;
     }
 
-    span:not([class*=suffix]),
+    span[class*=el-pagination],
     button {
       height: 22px;
       line-height: 22px;

--- a/packages/theme-chalk/src/pagination.scss
+++ b/packages/theme-chalk/src/pagination.scss
@@ -11,7 +11,8 @@
   @include utils-clearfix;
 
   span[class*=el-pagination],
-  button {
+  button.btn-prev,
+  button.btn-next {
     display: inline-block;
     font-size: $--pagination-font-size;
     min-width: $--pagination-button-width;
@@ -43,7 +44,8 @@
     }
   }
 
-  button {
+  button.btn-prev,
+  button.btn-next {
     border: none;
     padding: 0 6px;
     background: transparent;
@@ -116,7 +118,8 @@
     }
 
     span[class*=el-pagination],
-    button {
+    button.btn-prev,
+    button.btn-next {
       height: 22px;
       line-height: 22px;
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

修复问题：el-pagination 在使用 slot 样式影响里面内容的样式

操作步骤: el-pagination 里面使用 el-checkbox 或 el-radio 等带有span标签的

复现 demo：https://jsfiddle.net/xslmenghuan/Ltn0j9xr/1/

修复过程：只针对于el-pagination的span添加样式，其他的忽略。

