### PR TITLE
Cascader: fix isFunction predicate

### DIFF
--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -11,8 +11,7 @@ export function isHtmlElement(node) {
 }
 
 export const isFunction = (functionToCheck) => {
-  var getType = {};
-  return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+  return (Boolean(functionToCheck) && /^\[object ([a-zA-Z]+)?Function\]$/.test(Object.prototype.toString.call(functionToCheck)));
 };
 
 export const isUndefined = (val)=> {


### PR DESCRIPTION
在原生 es6 以及其上的版本，函数的构造函数还有很多
比如`AsyncFunction`、`GeneratorFunction`、`AsyncGeneratorFunction`

所以这里不能直接写等于`[object Function]`，应该匹配所有函数的构造函数