### PR TITLE
table: fix checkbox still can be selected when there is no data

### DIFF
--- a/packages/table/src/store/watcher.js
+++ b/packages/table/src/store/watcher.js
@@ -175,7 +175,7 @@ export default Vue.extend({
       const value = states.selectOnIndeterminate
         ? !states.isAllSelected
         : !(states.isAllSelected || selection.length);
-      states.isAllSelected = value;
+      states.isAllSelected = data.length === 0 ? false : value;
 
       let selectionChanged = false;
       data.forEach((row, index) => {


### PR DESCRIPTION
[fix #17455](https://github.com/ElemeFE/element/issues/17455)
bug描述：当表格没有数据时，表头的复选框仍然可以勾选。