### PR TITLE
Table: fix serious memory leak when using "row-key" property

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -655,6 +655,10 @@
     },
 
     destroyed() {
+      // store是一个Vue实例，调用$destroy解绑和释放监听。
+      if (this.store) {
+        this.store.$destroy();
+      }
       this.unbindEvents();
     },
 


### PR DESCRIPTION
Table组件，使用了row-key属性，会有严重的内存泄露。
- 泄露原因：table源码中的tree.js的计算属性normalizedData，在rowKey不为空时，Vue会对store中的data生成大量watcher，这些watcher会持有table实例vm（以便nextTick调用vm的render）。
- 修复方法：table.js中的`store`是一个Vue实例，在table组件销毁钩子函数中调用`$destroy()`方法，来解除绑定和释放监听等。
- demo: https://jsfiddle.net/zhanghaiba/9k46Lhcz/12/ 
使用chrome memory timeline工具，不断”切换页面“后，截图如下：
![image](https://user-images.githubusercontent.com/4017787/69209874-c7e51a80-0b93-11ea-8079-ccb51215867c.png)



Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
