### PR TITLE
table列禁止拖拽，不触发mouseDown事件

### DIFF
--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -344,7 +344,7 @@ export default {
       if (this.$isServer) return;
       if (column.children && column.children.length > 0) return;
       /* istanbul ignore if */
-      if (this.draggingColumn && this.border) {
+      if (this.draggingColumn && this.draggingColumn.resizable && this.border) {
         this.dragging = true;
 
         this.$parent.resizeProxyVisible = true;


### PR DESCRIPTION
拖拽过快情况下，会触发已禁止拖拽列列宽变化