### PR TITLE
PageHeader: fix translation is not responsive

### DIFF
--- a/packages/page-header/src/main.vue
+++ b/packages/page-header/src/main.vue
@@ -3,7 +3,7 @@
     <div class="el-page-header__left" @click="$emit('back')">
       <i class="el-icon-back"></i>
       <div class="el-page-header__title">
-        <slot name="title">{{ title }}</slot>
+        <slot name="title">{{ title || t('el.pageHeader.title') }}</slot>
       </div>
     </div>
     <div class="el-page-header__content">
@@ -13,17 +13,14 @@
 </template>
 
 <script>
-import { t } from 'element-ui/src/locale';
+import Locale from 'element-ui/src/mixins/locale';
 export default {
   name: 'ElPageHeader',
 
+  mixins: [Locale],
+
   props: {
-    title: {
-      type: String,
-      default() {
-        return t('el.pageHeader.title');
-      }
-    },
+    title: String,
     content: String
   }
 };


### PR DESCRIPTION
Translation can not be placed in the default value of props where this will lead not responsive tracking.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
