### PR TITLE
Image:Get the first item of preview list when the src attribute of the current image isn't in preview list.

### DIFF
--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -94,7 +94,8 @@
         return Array.isArray(previewSrcList) && previewSrcList.length > 0;
       },
       imageIndex() {
-        return this.previewSrcList.indexOf(this.src);
+        const index = this.previewSrcList.indexOf(this.src);
+        return index > -1 ? index : 0;
       }
     },
 


### PR DESCRIPTION
#### 场景举例
`el-image` 的 `src` 属性值是原图缩略图，导致 `preview-src-list` 数组中找不到 `src` 的值， 从而引起点击预览大图，默认展示是空的，体验不是很友好。

```vue
<el-image
    src="http://a.b.c/xxx.jpg!100x100.jpg"
    :preview-src-list="['http://a.b.c/xxx.jpg']"
></el-image>
```
#### 解决策略
当 `preview-src-list` 中不存在 `src` 的值时，默认展示 `preview-src-list` 中的第一张图片。

-----

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
