### PR TITLE
Image: bug fixed.

### DIFF
--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -290,13 +290,12 @@ export default {
           break;
       }
       transform.enableTransition = enableTransition;
+    },
+    focusToImageViewer() {
+      // add tabindex then wrapper can be focusable via Javascript
+      // focus wrapper so arrow key can't cause inner scroll behavior underneath
+      this.$refs['el-image-viewer__wrapper'].focus();
     }
-  },
-  mounted() {
-    this.deviceSupportInstall();
-    // add tabindex then wrapper can be focusable via Javascript
-    // focus wrapper so arrow key can't cause inner scroll behavior underneath
-    this.$refs['el-image-viewer__wrapper'].focus();
   }
 };
 </script>

--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -16,7 +16,7 @@
       :style="imageStyle"
       :class="{ 'el-image__inner--center': alignCenter, 'el-image__preview': preview }">
     <template v-if="preview">
-      <image-viewer :z-index="zIndex" :initial-index="imageIndex" v-show="showViewer" :on-close="closeViewer" :url-list="previewSrcList"/>
+      <image-viewer ref="imageViewer" :z-index="zIndex" :initial-index="imageIndex" v-show="showViewer" :on-close="closeViewer" :url-list="previewSrcList"/>
     </template>
   </div>
 </template>
@@ -222,6 +222,10 @@
         prevOverflow = document.body.style.overflow;
         document.body.style.overflow = 'hidden';
         this.showViewer = true;
+
+        const $imageViewer = this.$refs['imageViewer'];
+        $imageViewer.deviceSupportInstall();
+        $imageViewer.focusToImageViewer();
       },
       closeViewer() {
         document.body.style.overflow = prevOverflow;

--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -94,7 +94,8 @@
         return Array.isArray(previewSrcList) && previewSrcList.length > 0;
       },
       imageIndex() {
-        return this.previewSrcList.indexOf(this.src);
+        const index = this.previewSrcList.indexOf(this.src);
+        return index > -1 ? index : 0;
       }
     },
 


### PR DESCRIPTION
1.修复 当前src值(小图) 不在previewSrcList（大图预览列表） 中,导致第一次点击预览是空的问题.

2.目前只有第一次预览大图的时候,才支持键盘和鼠标事件.关闭后再次预览事件无效.（由于在hide的时候事件被移除）


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
