### PR TITLE
[DatePicker] Add defaultView option

### DIFF
--- a/packages/date-picker/src/panel/date.vue
+++ b/packages/date-picker/src/panel/date.vue
@@ -390,13 +390,7 @@
       },
 
       resetView() {
-        if (this.selectionMode === 'month') {
-          this.currentView = 'month';
-        } else if (this.selectionMode === 'year') {
-          this.currentView = 'year';
-        } else {
-          this.currentView = 'date';
-        }
+        this.currentView = this.computedDefaultView();
       },
 
       handleEnter() {
@@ -510,6 +504,7 @@
         value: '',
         defaultValue: null, // use getDefaultValue() for time computation
         defaultTime: null,
+        defaultView: null,
         showTime: false,
         selectionMode: 'day',
         shortcuts: '',
@@ -562,6 +557,20 @@
           return this.userInputDate;
         } else {
           return formatDate(this.value || this.defaultValue, this.dateFormat);
+        }
+      },
+
+      computedDefaultView() {
+        if (['month', 'year', 'date'].indexOf(this.defaultView) >= 0) {
+          return this.defaultView;
+        }
+
+        if (this.selectionMode === 'month') {
+          return 'month';
+        } else if (this.selectionMode === 'year') {
+          return 'year';
+        } else {
+          return 'date';
         }
       },
 


### PR DESCRIPTION
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Fixes the issue #15079

This allows for a datepicker to be opened with a default view (eg: year, month, date)

Using the option `<el-datepicker :picker-options="{defaultView:'year'}">`
