### PR TITLE
Progress: status add validator a empty string

### DIFF
--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -67,7 +67,7 @@
       },
       status: {
         type: String,
-        validator: val => ['success', 'exception', 'warning'].indexOf(val) > -1
+        validator: val => ['success', 'exception', 'warning', ''].indexOf(val) > -1
       },
       strokeWidth: {
         type: Number,


### PR DESCRIPTION
```
<el-progress
    :percentage="percent"
    :status="percent === 100 ? 'success' : ''"
/>
```
empty string [Vue warn]: Invalid prop: custom validator check failed for prop "status".
