### PR TITLE
Message: fix Error instance signed to Ctor.data

### DIFF
--- a/packages/message/src/main.js
+++ b/packages/message/src/main.js
@@ -11,7 +11,7 @@ let seed = 1;
 const Message = function(options) {
   if (Vue.prototype.$isServer) return;
   options = options || {};
-  if (typeof options === 'string') {
+  if (typeof options === 'string' || options instanceof Error) {
     options = {
       message: options
     };


### PR DESCRIPTION
When an error seted to the first param, like the Message(error).it occurs when promises uncaught error rejected, and it's resolving npm packages errors.
```
axios().catch(error => Message(error))
```
[Vue warn]: data functions should return an object:

and serveral big errors.