### PR TITLE
Message: fix Error instance signed to Ctor.data

### DIFF
--- a/packages/message/src/main.js
+++ b/packages/message/src/main.js
@@ -15,6 +15,10 @@ const Message = function(options) {
     options = {
       message: options
     };
+  } else if (options instanceof Error) {
+    options = {
+      message: '' + options
+    };
   }
   let userOnClose = options.onClose;
   let id = 'message_' + seed++;
@@ -48,6 +52,10 @@ const Message = function(options) {
     if (typeof options === 'string') {
       options = {
         message: options
+      };
+    } else if (options instanceof Error) {
+      options = {
+        message: '' + options
       };
     }
     options.type = type;


### PR DESCRIPTION
It raises [Vue warn] errors, when an Error instance seted to the first param like Message(error).
e.g.
1. Promises uncaught error rejected;
2. npm packages errors throwed.

```axios().catch(error => Message(error))```

[Vue warn]: data functions should return an object:

and serveral big errors showed in console.