### PR TITLE
Dialog: handler wrapper event change to mousedown

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -6,7 +6,7 @@
     <div
       v-show="visible"
       class="el-dialog__wrapper"
-      @click.self="handleWrapperClick">
+      @mousedown.self="handleWrapperClick">
       <div
         role="dialog"
         :key="key"

--- a/test/unit/specs/dialog.spec.js
+++ b/test/unit/specs/dialog.spec.js
@@ -1,4 +1,4 @@
-import { createVue, destroyVM, waitImmediate } from '../util';
+import { createVue, destroyVM, waitImmediate, triggerEvent } from '../util';
 
 describe('Dialog', () => {
   let vm;
@@ -225,7 +225,7 @@ describe('Dialog', () => {
     }, true);
     const dialog = vm.$children[0];
     setTimeout(() => {
-      dialog.$el.click();
+      triggerEvent(dialog.$el, 'mousedown');
       setTimeout(() => {
         expect(vm.visible).to.be.false;
         done();
@@ -282,7 +282,7 @@ describe('Dialog', () => {
     }, true);
     const dialog = vm.$children[0];
     setTimeout(() => {
-      dialog.$el.click();
+      triggerEvent(dialog.$el, 'mousedown');
       setTimeout(() => {
         expect(spy.called).to.be.true;
         done();
@@ -310,7 +310,7 @@ describe('Dialog', () => {
     const dialog = vm.$children[0];
     await waitImmediate();
     dialog.$el.querySelector('input').value = '123';
-    dialog.$el.click();
+    triggerEvent(dialog.$el, 'mousedown');
     await waitImmediate();
     vm.visible = true;
     await waitImmediate();


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

使用`click`事件的时候，点击body任意位置，然后按住不放移动到wrapper层时，`click`事件会被触发。这种情况在body内容为文本，或者输入框，或者任意其他需要用鼠标拖动选择范围的时候会出现，特别是在表单修改的时候，选中输入框的数据很容易鼠标就拖动到wrapper区域，导致dialog误触关闭。

故而改为使用 `mousedown`事件，可以有效的防止这种情况。 
我看到很多issue提到这种情况，希望能将这个问题彻底解决

Fix #13861
Fix #14806 
Fix #17920
Fix #16930
Fix #17563
Fix #17920