### PR TITLE
CheckboxGroup: fix change event cannot get modified value (#18358)

### DIFF
--- a/packages/checkbox/src/checkbox-button.vue
+++ b/packages/checkbox/src/checkbox-button.vue
@@ -68,6 +68,10 @@
       };
     },
 
+    model: {
+      prop: 'value',
+      event: 'change'
+    },
     props: {
       value: {},
       label: {},
@@ -97,11 +101,7 @@
               (this.isLimitExceeded = true));
 
             this.isLimitExceeded === false &&
-            this.dispatch('ElCheckboxGroup', 'input', [val]);
-          } else if (this.value !== undefined) {
-            this.$emit('input', val);
-          } else {
-            this.selfModel = val;
+            this.dispatch('ElCheckboxGroup', 'change', [val]);
           }
         }
       },
@@ -170,9 +170,13 @@
           Array.isArray(this.model) &&
           this.model.indexOf(this.label) === -1
         ) {
-          this.model.push(this.label);
+          this.store.push(this.label);
+          this.dispatch('ElCheckboxGroup', 'change', [this.store]);
         } else {
-          this.model = this.trueLabel || true;
+          this.selfModel = this.trueLabel || true;
+          if (this.value !== this.selfModel) {
+            this.$emit('change', this.selfModel);
+          }
         }
       },
       handleChange(ev) {
@@ -183,12 +187,8 @@
         } else {
           value = this.falseLabel === undefined ? false : this.falseLabel;
         }
+        this.selfModel = value;
         this.$emit('change', value, ev);
-        this.$nextTick(() => {
-          if (this._checkboxGroup) {
-            this.dispatch('ElCheckboxGroup', 'change', [this._checkboxGroup.value]);
-          }
-        });
       }
     },
 

--- a/packages/checkbox/src/checkbox-group.vue
+++ b/packages/checkbox/src/checkbox-group.vue
@@ -14,6 +14,10 @@
       }
     },
 
+    model: {
+      prop: 'value',
+      event: 'change'
+    },
     props: {
       value: {},
       disabled: Boolean,

--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -100,10 +100,7 @@
               (this.isLimitExceeded = true));
 
             this.isLimitExceeded === false &&
-            this.dispatch('ElCheckboxGroup', 'input', [val]);
-          } else {
-            this.$emit('input', val);
-            this.selfModel = val;
+            this.dispatch('ElCheckboxGroup', 'change', [val]);
           }
         }
       },
@@ -161,6 +158,10 @@
       }
     },
 
+    model: {
+      prop: 'value',
+      event: 'change'
+    },
     props: {
       value: {},
       label: {},
@@ -182,9 +183,13 @@
           Array.isArray(this.model) &&
           this.model.indexOf(this.label) === -1
         ) {
-          this.model.push(this.label);
+          this.store.push(this.label);
+          this.dispatch('ElCheckboxGroup', 'change', [this.store]);
         } else {
-          this.model = this.trueLabel || true;
+          this.selfModel = this.trueLabel || true;
+          if (this.value !== this.selfModel) {
+            this.$emit('change', this.selfModel);
+          }
         }
       },
       handleChange(ev) {
@@ -195,12 +200,8 @@
         } else {
           value = this.falseLabel === undefined ? false : this.falseLabel;
         }
+        this.selfModel = value;
         this.$emit('change', value, ev);
-        this.$nextTick(() => {
-          if (this.isGroup) {
-            this.dispatch('ElCheckboxGroup', 'change', [this._checkboxGroup.value]);
-          }
-        });
       }
     },
 

--- a/test/unit/specs/checkbox.spec.js
+++ b/test/unit/specs/checkbox.spec.js
@@ -100,7 +100,7 @@ describe('Checkbox', () => {
   it('checkbox group change event', done => {
     vm = createVue({
       template: `
-        <el-checkbox-group v-model="checkList" @change="onChange">
+        <el-checkbox-group :value="checkList" @change="onChange">
           <el-checkbox label="a" ref="a"></el-checkbox>
           <el-checkbox label="b" ref="b"></el-checkbox>
         </el-checkbox-group>


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

![img](https://user-images.githubusercontent.com/23102610/70640366-d0061680-1c76-11ea-8bde-e3fcf4e8d5c9.png)
官方文档上只提到了 `change` 事件, 使人以为 `<el-checkbox-group>` 上的 `v-model` 等于 `:value + @change`,   
实际 `<el-checkbox-group>` 上还有一个没在文档里提到的 `input` 事件, `v-model` 实际等于默认行为 `:value + @input`,   
而 `<el-checkbox-group>` 上的`change`只是补发出来的一个事件, 如果没有在 `@input` 或者 `v-model` 里把值更新掉, `@change` 拿到的就还是更新前的值.

fix: 去除 `input` 事件, 统一使用 `change` 事件.

补充说明: 以下情况初始化时若 `aVar` 不为true | trueLabel, 会加一次 `change` 事件
```
<el-checkbox v-model="aVar" checked></el-checkbox>
```