### PR TITLE
image: fix keyboard events handling logic

### DIFF
--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -1,6 +1,6 @@
 <template>
   <transition name="viewer-fade">
-    <div tabindex="-1" ref="el-image-viewer__wrapper" class="el-image-viewer__wrapper" :style="{ 'z-index': zIndex }">
+    <div v-show="visible" tabindex="-1" ref="el-image-viewer__wrapper" class="el-image-viewer__wrapper" :style="{ 'z-index': zIndex }">
       <div class="el-image-viewer__mask"></div>
       <!-- CLOSE -->
       <span class="el-image-viewer__btn el-image-viewer__close" @click="hide">
@@ -91,7 +91,8 @@ export default {
     initialIndex: {
       type: Number,
       default: 0
-    }
+    },
+    visible: Boolean
   },
 
   data() {
@@ -151,15 +152,30 @@ export default {
           this.loading = true;
         }
       });
+    },
+    visible(val) {
+      if (val) {
+        this.show();
+      }
     }
   },
   methods: {
+    show() {
+      this.deviceSupportInstall();
+      this.$nextTick(_ => {
+        // add tabindex then wrapper can be focusable via Javascript
+        // focus wrapper so arrow key can't cause inner scroll behavior underneath
+        this.$refs['el-image-viewer__wrapper'].focus();
+      });
+    },
     hide() {
       this.deviceSupportUninstall();
       this.onClose();
     },
     deviceSupportInstall() {
       this._keyDownHandler = rafThrottle(e => {
+        // prevent scroll behavior
+        e.preventDefault();
         const keyCode = e.keyCode;
         switch (keyCode) {
           // ESC
@@ -202,11 +218,11 @@ export default {
           });
         }
       });
-      on(document, 'keydown', this._keyDownHandler);
+      on(this.$refs['el-image-viewer__wrapper'], 'keydown', this._keyDownHandler);
       on(document, mousewheelEventName, this._mouseWheelHandler);
     },
     deviceSupportUninstall() {
-      off(document, 'keydown', this._keyDownHandler);
+      off(this.$refs['el-image-viewer__wrapper'], 'keydown', this._keyDownHandler);
       off(document, mousewheelEventName, this._mouseWheelHandler);
       this._keyDownHandler = null;
       this._mouseWheelHandler = null;
@@ -291,12 +307,6 @@ export default {
       }
       transform.enableTransition = enableTransition;
     }
-  },
-  mounted() {
-    this.deviceSupportInstall();
-    // add tabindex then wrapper can be focusable via Javascript
-    // focus wrapper so arrow key can't cause inner scroll behavior underneath
-    this.$refs['el-image-viewer__wrapper'].focus();
   }
 };
 </script>

--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -16,7 +16,7 @@
       :style="imageStyle"
       :class="{ 'el-image__inner--center': alignCenter, 'el-image__preview': preview }">
     <template v-if="preview">
-      <image-viewer :z-index="zIndex" :initial-index="imageIndex" v-show="showViewer" :on-close="closeViewer" :url-list="previewSrcList"/>
+      <image-viewer :z-index="zIndex" :initial-index="imageIndex" :visible.sync="showViewer" :on-close="closeViewer" :url-list="previewSrcList"/>
     </template>
   </div>
 </template>
@@ -37,8 +37,6 @@
     FILL: 'fill',
     SCALE_DOWN: 'scale-down'
   };
-
-  let prevOverflow = '';
 
   export default {
     name: 'ElImage',
@@ -217,13 +215,9 @@
         }
       },
       clickHandler() {
-        // prevent body scroll
-        prevOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
         this.showViewer = true;
       },
       closeViewer() {
-        document.body.style.overflow = prevOverflow;
         this.showViewer = false;
       }
     }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

close #18393

1. main.vue line 221, manipulating document.body.style directly is not good, and events may propagate to a parent which are not body element, and still cause scrolling, so I use e.stopPropagation() on key events to stop scrolling instead of #16997.

2. image-viewer.vue line 295:
```
mounted() {	
  this.deviceSupportInstall();	
  this.$refs['el-image-viewer__wrapper'].focus();	
}
```
the mounted function only called once, cause reopen the image-viewer, all keyboard events and mouse scale events are not allowed. so add an prop 'visible' to solve this case.
