### PR TITLE
[Input Number] Correctly compute inputNumberDisabled when false

### DIFF
--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -168,7 +168,7 @@
         return this.size || this._elFormItemSize || (this.$ELEMENT || {}).size;
       },
       inputNumberDisabled() {
-        return this.disabled || (this.elForm || {}).disabled;
+        return this.disabled || !!(this.elForm || {}).disabled;
       },
       displayValue() {
         if (this.userInput !== null) {


### PR DESCRIPTION
`input-number.vue` incorrectly calculates `inputNumberDisabled` when the prop `disabled` is set to false as well as `elForm` not existing. `inputNumberDisabled` returns `"undefined"` instead of `false` which is treated as a truthy value on `aria-disabled`.

No issue has been created, I just noticed the issue while debugging some of my own code. Will create and link issue if that is expected.

Fixed #18440