### PR TITLE
bugfix:未设置预览图片点击后body设为overflow:hidden

### DIFF
--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -217,6 +217,7 @@
         }
       },
       clickHandler() {
+        if (!this.preview) return
         // prevent body scroll
         prevOverflow = document.body.style.overflow;
         document.body.style.overflow = 'hidden';


### PR DESCRIPTION
未设置预览图片点击后body设为overflow:hidden，影响了页面原本的css

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
