### PR TITLE
Autocomplete:  fix autocomplete-suggestions issue when type is `textarea`(#15013)

### DIFF
--- a/packages/autocomplete/src/autocomplete-suggestions.vue
+++ b/packages/autocomplete/src/autocomplete-suggestions.vue
@@ -60,7 +60,7 @@
 
     mounted() {
       this.$parent.popperElm = this.popperElm = this.$el;
-      this.referenceElm = this.$parent.$refs.input.$refs.input;
+      this.referenceElm = this.$parent.$refs.input.$refs.input || this.$parent.$refs.input.$refs.textarea;
       this.referenceList = this.$el.querySelector('.el-autocomplete-suggestion__list');
       this.referenceList.setAttribute('role', 'listbox');
       this.referenceList.setAttribute('id', this.id);


### PR DESCRIPTION
fix issue [#15013](https://github.com/ElemeFE/element/issues/15013)

Before the fix:

<img width="1050" alt="before" src="https://user-images.githubusercontent.com/11495164/71162225-cdfb1380-2285-11ea-998e-2e13ae093b43.png">


After the fix:

<img width="1042" alt="after" src="https://user-images.githubusercontent.com/11495164/71162229-cf2c4080-2285-11ea-8702-2b9f6674e93d.png">


* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
