### PR TITLE
fix "clearFiles" to avoid uploading multiple files clear files errors

### DIFF
--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -236,9 +236,14 @@ export default {
     abort(file) {
       this.$refs['upload-inner'].abort(file);
     },
-    clearFiles() {
-      this.uploadFiles = this.uploadFiles.filter((item) => {
-        return item.status !== 'success'
+    clearFiles(status = ['ready', 'success', 'fail']) {
+      let n;
+      this.uploadFiles = this.uploadFiles.filter((row) => {
+        n = 0;
+        status.forEach(item => {
+          n += row.status === item
+        });
+        return  !n;
       });
     },
     submit() {

--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -237,7 +237,9 @@ export default {
       this.$refs['upload-inner'].abort(file);
     },
     clearFiles() {
-      this.uploadFiles = [];
+      this.uploadFiles = this.uploadFiles.filter((item) => {
+        return item.status !== 'success'
+      });
     },
     submit() {
       this.uploadFiles


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.



fix "clearFiles" to avoid uploading multiple files clear files errors

## 解决在使用upload组件的时候，且多文件上传！在on-success时调用clearFiles()方法，清除已成功的文件。此时会清除尚未上传完毕的文件，导致产生error的问题。