### PR TITLE
fix "clearFiles" to avoid clear "uploadFiles" errors in uploading mul…

### DIFF
--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -236,8 +236,15 @@ export default {
     abort(file) {
       this.$refs['upload-inner'].abort(file);
     },
-    clearFiles() {
-      this.uploadFiles = [];
+    clearFiles(status = ['success', 'fail']) {
+      let n;
+      this.uploadFiles = this.uploadFiles.filter(row => {
+        n = 0;
+        status.forEach(item => {
+          n += row.status === item;
+        });
+        return !n;
+      });
     },
     submit() {
       this.uploadFiles


### PR DESCRIPTION
## 修复clearFiles方法，避免同时上传多个文件时，清除uploadFiles列表，导致正在上传中的文件再上传完成后产生报错的问题

## Machine Translation：
Repair the clearfiles method to avoid clearing the uploadfiles list when multiple files are uploaded at the same time, resulting in an error message after the files being uploaded are uploaded again

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
