### PR TITLE
Image: fix page can not scroll after click on Image without previewSr…

### DIFF
--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -218,9 +218,11 @@
       },
       clickHandler() {
         // prevent body scroll
-        prevOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
-        this.showViewer = true;
+        if (this.preview) {
+          prevOverflow = document.body.style.overflow;
+          document.body.style.overflow = 'hidden';
+          this.showViewer = true;
+        }
       },
       closeViewer() {
         document.body.style.overflow = prevOverflow;


### PR DESCRIPTION
修复**点击未提供预览图片地址**的Image组件后, `Html body` 中添加 `overflow:hidden` 样式, 导致页面无法滚动的bug

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
