### PR TITLE
Table组件： 修复在多选模式下调用toggleRowSelection方法后，表格的checkbox没有被选中的BUG

### DIFF
--- a/packages/table/src/store/expand.js
+++ b/packages/table/src/store/expand.js
@@ -32,7 +32,8 @@ export default {
     },
 
     toggleRowExpansion(row, expanded) {
-      const changed = toggleRowStatus(this.states.expandRows, row, expanded);
+      const { data = [] } = this.states;
+      const changed = toggleRowStatus(this.states.expandRows, data, row, expanded);
       if (changed) {
         this.table.$emit('expand-change', row, this.states.expandRows.slice());
         this.scheduleLayout();

--- a/packages/table/src/store/watcher.js
+++ b/packages/table/src/store/watcher.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import merge from 'element-ui/src/utils/merge';
-import { getKeysMap, getRowIdentity, getColumnById, getColumnByKey, orderBy, toggleRowStatus } from '../util';
+import { getKeysMap, getRowIdentity, getColumnById, getColumnByKey, orderBy, toggleRowStatus, getRowIndexOfSelection } from '../util';
 import expand from './expand';
 import current from './current';
 import tree from './tree';
@@ -118,8 +118,10 @@ export default Vue.extend({
 
     // 选择
     isSelected(row) {
-      const { selection = [] } = this.states;
-      return selection.indexOf(row) > -1;
+
+      const { selection = [], data = [] } = this.states;
+
+      return getRowIndexOfSelection(row, data, selection) > -1;
     },
 
     clearSelection() {
@@ -136,10 +138,13 @@ export default Vue.extend({
       const states = this.states;
       const { data, rowKey, selection } = states;
       let deleted;
+      console.log(states);
       if (rowKey) {
         deleted = [];
         const selectedMap = getKeysMap(selection, rowKey);
         const dataMap = getKeysMap(data, rowKey);
+        console.log(selectedMap);
+        console.log(dataMap);
         for (let key in selectedMap) {
           if (selectedMap.hasOwnProperty(key) && !dataMap[key]) {
             deleted.push(selectedMap[key].row);
@@ -156,7 +161,10 @@ export default Vue.extend({
     },
 
     toggleRowSelection(row, selected, emitChange = true) {
-      const changed = toggleRowStatus(this.states.selection, row, selected);
+
+      const { data = [] } = this.states;
+
+      const changed = toggleRowStatus(this.states.selection, data, row, selected);
       if (changed) {
         const newSelection = (this.states.selection || []).slice();
         // 调用 API 修改选中值，不触发 select 事件
@@ -180,11 +188,11 @@ export default Vue.extend({
       let selectionChanged = false;
       data.forEach((row, index) => {
         if (states.selectable) {
-          if (states.selectable.call(null, row, index) && toggleRowStatus(selection, row, value)) {
+          if (states.selectable.call(null, row, index) && toggleRowStatus(selection, data, row, value)) {
             selectionChanged = true;
           }
         } else {
-          if (toggleRowStatus(selection, row, value)) {
+          if (toggleRowStatus(selection, data, row, value)) {
             selectionChanged = true;
           }
         }

--- a/packages/table/src/util.js
+++ b/packages/table/src/util.js
@@ -195,9 +195,11 @@ export function compose(...funcs) {
   return funcs.reduce((a, b) => (...args) => a(b(...args)));
 }
 
-export function toggleRowStatus(statusArr, row, newVal) {
+export function toggleRowStatus(statusArr, data, row, newVal) {
+
   let changed = false;
-  const index = statusArr.indexOf(row);
+
+  const index = getRowIndexOfSelection(row, data, statusArr);
   const included = index !== -1;
 
   const addRow = () => {
@@ -252,4 +254,35 @@ export function walkTreeNode(root, cb, childrenKey = 'children', lazyKey = 'hasC
       _walker(item, children, 0);
     }
   });
+}
+
+export function getRowIndexOfSelection(row, data, selection) {
+
+  if (row === null) throw new Error('row object is required when multiple selection');
+  if (!data.length) throw new Error('table data is required when multiple selection');
+
+  const dataKeysMap = Object.keys(data[0]);
+  const rowKeysMap = Object.keys(row);
+
+  if (dataKeysMap.length !== rowKeysMap.length) throw new Error('The number of fields in the row object does not match');
+
+  const equal = dataKeysMap.every(key => {
+    return rowKeysMap.indexOf(key) > -1;
+  });
+
+  if (!equal) throw new Error('Row object\'s field name does not match ');
+
+  const isSameObj = i => {
+    return dataKeysMap.every(key => {
+      return selection[i][key] === row[key];
+    });
+  };
+
+  const includedRow = () => {
+    for (let i = 0; i < selection.length; i++) {
+      if (isSameObj(i)) return i;
+    }
+    return -1;
+  };
+  return includedRow();
 }


### PR DESCRIPTION
`Table`组件： 修复在多选模式下调用`toggleRowSelection`方法后，表格的`checkbox`没有被选中的BUG

> 当调用toggleRowSelection方法来设置行选中状态时，参数row是一个对象时，但此对象的地址引用与数据中的对象地址引用不同时，列表中的checkbox没有被选中。

例如：
```js
export default {
    data() {
      return {
        tableData: [{
          id: 1,
          name: '王小虎'
        }, {
          id: 2,
          name: '彭小呆'
        }]
      }
    },
    methods: {
      selectFirstRow1() {
         const row = tableData[0]
         this.$refs.multipleTable.toggleRowSelection(row, true);
      },
      selectFirstRow2() {
         const row = {
             id: 1,
             name: '王小虎'
         }
         this.$refs.multipleTable.toggleRowSelection(row, true);
      }
    }
  }
```
分别调用`selectFirstRow1`方法和`selectFirstRow2`方法，会得到完全不同的结果。

`selectFirstRow1`方法执行后，页面按照我们想要的结果渲染出勾选状态。
`selectFirstRow2`方法执行后，页面的多选表头中的的checkbox状态变成半全选，但是在第一行中的checkbox并没有勾选，出现了和我们预期不一样的结果。

经过排查，我发现在`table`组件中的`src/store/watcher.js`中的`isSelected`方法中的判断为`return selection.indexOf(row) > -1; `
当对象地址不同时，用这个方法判断会出现此问题。

于是我在 `src/util.js` 中新增了方法 `getRowIndexOfSelection` 去获取对象在数组中的位置，然后在 `src/util.js`文件中的`toggleRowStatus`方法和`src/store/watcher.js`文件中的`isSelected`方法调用此判断方法，正确获取对象在数组中的位置。具体细节在commit中可以查看。

经过测试没问题了。

执行 yarn dist 正确打包文件如下图：

![](http://img.pqs.guozhaoxi.top/9993F87F-903B-4436-8EC7-4713341955C8.png)

![](http://img.pqs.guozhaoxi.top/11ED0972-F02B-4699-9362-DB7B1638FB56.png)

![](http://img.pqs.guozhaoxi.top/5F9638D4-6AD8-439d-A83B-4BF8490CB2EA.png)

![](http://img.pqs.guozhaoxi.top/AE903195-A379-4e92-A213-37B97C1A6511.png)

![](http://img.pqs.guozhaoxi.top/BB86DE02-A16A-4010-B44B-24F39A3D37B5.png)
