### PR TITLE
Fix "Cannot read property 'level' of null"

### DIFF
--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -198,8 +198,11 @@ export default {
       const { store, multiple, activePath, checkedValue } = this;
 
       if (!isEmpty(activePath)) {
-        const nodes = activePath.map(node => this.getNodeByValue(node.getValue()));
-        this.expandNodes(nodes);
+        const nodes = activePath.map(node => this.getNodeByValue(node.getValue()))
+        .filter(node => Boolean(node));
+        if(nodes.length){
+          this.expandNodes(nodes);
+        }
       } else if (!isEmpty(checkedValue)) {
         const value = multiple ? checkedValue[0] : checkedValue;
         const checkedNode = this.getNodeByValue(value) || {};

--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -199,8 +199,7 @@ export default {
 
       if (!isEmpty(activePath)) {
         const nodes = activePath.map(node => this.getNodeByValue(node.getValue()))
-        .filter(node => Boolean(node));
-        if(nodes.length){
+        if(!nodes.every(node => node === null)){
           this.expandNodes(nodes);
         }
       } else if (!isEmpty(checkedValue)) {


### PR DESCRIPTION
When we are trying to change `value` after updating options, an exception will be thrown with the following message:
```javascript
[Vue warn]: Error in callback for watcher "value": "TypeError: Cannot read property 'level' of null"

found in

---> <ElCascaderPanel> at packages/cascader-panel/src/cascader-panel.vue
       <ElCascader> at src/components/element-ui/Cascader.vue
```
