### PR TITLE
Casader: fix 删除顺序错误 bug

### DIFF
--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -44,14 +44,14 @@
 
     <div v-if="multiple" class="el-cascader__tags">
       <el-tag
-        v-for="(tag, index) in presentTags"
+        v-for="(tag) in presentTags"
         :key="tag.key"
         type="info"
         :size="tagSize"
         :hit="tag.hitState"
         :closable="tag.closable"
         disable-transitions
-        @close="deleteTag(index)">
+        @close="deleteTag(tag)">
         <span>{{ tag.text }}</span>
       </el-tag>
       <input
@@ -123,7 +123,7 @@ import ElScrollbar from 'element-ui/packages/scrollbar';
 import ElCascaderPanel from 'element-ui/packages/cascader-panel';
 import AriaUtils from 'element-ui/src/utils/aria-utils';
 import { t } from 'element-ui/src/locale';
-import { isEqual, isEmpty, kebabCase } from 'element-ui/src/utils/util';
+import { isEqual, isEmpty, kebabCase, valueEquals } from 'element-ui/src/utils/util';
 import { isUndefined, isFunction } from 'element-ui/src/utils/types';
 import { isDef } from 'element-ui/src/utils/shared';
 import { addResizeListener, removeResizeListener } from 'element-ui/src/utils/resize-event';
@@ -588,7 +588,7 @@ export default {
 
       if (this.pressDeleteCount) {
         if (lastTag.hitState) {
-          this.deleteTag(lastIndex);
+          this.deleteTag(lastTag);
         } else {
           lastTag.hitState = true;
         }
@@ -607,8 +607,9 @@ export default {
         this.toggleDropDownVisible(false);
       }
     },
-    deleteTag(index) {
-      const { checkedValue } = this;
+    deleteTag(tag) {
+      const { checkedValue, props: { emitPath = true }} = this;
+      const index = checkedValue.findIndex(v => valueEquals(v, tag.node[emitPath ? 'path' : 'value']));
       const val = checkedValue[index];
       this.checkedValue = checkedValue.filter((n, i) => i !== index);
       this.$emit('remove-tag', val);
@@ -647,4 +648,3 @@ export default {
   }
 };
 </script>
-


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

## Why
fix #18071 ，用户设置初始的 checkedValue 时的顺序往往与 options 中的 value 顺序不符。此时 deleteTag 最好能精确删除对应的 value 而不是依赖隐式的 index 匹配

## How
根据 emitPath 来选取值匹配拿到真正的 index

## Test
在多选示例中，设置默认 value 如下，然后点击删除。删除正常
```js
{
  data() {
    return {
      value: [['zujian', 'notice'], ['zujian']],
      options: [
        {value: 'zujian', label: '组件', children: [{value: 'notice', label: 'Notice'}]}
      ]
    }
  }
}
```
### Unit Test
![image](https://user-images.githubusercontent.com/19591950/71802170-f8c3d500-3097-11ea-9e58-6a163b901c4c.png)