### PR TITLE
Compilation: Fix #18304 (Compilation fails when the project is under a node_modules directory)

### DIFF
--- a/build/config.js
+++ b/build/config.js
@@ -46,4 +46,4 @@ exports.vue = {
   amd: 'vue'
 };
 
-exports.jsexclude = /node_modules|utils\/popper\.js|utils\/date\.js/;
+exports.jsexclude = [path.resolve('./node_modules'), path.resolve('./utils', 'popper.js'), path.resolve('./utils', 'date.js')]

--- a/build/config.js
+++ b/build/config.js
@@ -46,4 +46,4 @@ exports.vue = {
   amd: 'vue'
 };
 
-exports.jsexclude = [path.resolve('./node_modules'), path.resolve('./utils', 'popper.js'), path.resolve('./utils', 'date.js')]
+exports.jsexclude = [path.resolve('./node_modules'), path.resolve('./src/utils', 'popper.js'), path.resolve('./src/utils', 'date.js')]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A Component Library for Vue.js.",
   "main": "lib/element-ui.common.js",
   "files": [
+    ".babelrc",
+    ".eslintignore",
+    ".eslintrc",
     "components.json",
     "build",
     "lib",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Component Library for Vue.js.",
   "main": "lib/element-ui.common.js",
   "files": [
-    "build"
+    "build",
     "lib",
     "src",
     "packages",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A Component Library for Vue.js.",
   "main": "lib/element-ui.common.js",
   "files": [
+    "components.json",
     "build",
     "lib",
     "src",
@@ -13,6 +14,7 @@
   "typings": "types/index.d.ts",
   "scripts": {
     "bootstrap": "yarn || npm i",
+    "build": "npm run clean && npm run lint && webpack --config build/webpack.conf.js && webpack --config build/webpack.common.js && webpack --config build/webpack.component.js && npm run build:utils && npm run build:umd && npm run build:theme",
     "build:file": "node build/bin/iconInit.js & node build/bin/build-entry.js & node build/bin/i18n.js & node build/bin/version.js",
     "build:theme": "node build/bin/gen-cssfile && gulp build --gulpfile packages/theme-chalk/gulpfile.js && cp-cli packages/theme-chalk/lib lib/theme-chalk",
     "build:utils": "cross-env BABEL_ENV=utils babel src --out-dir lib --ignore src/index.js",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A Component Library for Vue.js.",
   "main": "lib/element-ui.common.js",
   "files": [
+    "build"
     "lib",
     "src",
     "packages",


### PR DESCRIPTION
Because the regex for including the babel loader doesn't care about the tree directory, if the project is under a node modules directory, everything will be excluded. Effectively making the compilation fail

Instead of a regex for exclusion, this PR resolves the actual path for the excluded files

Fixes #18304

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
