### PR TITLE
[locale es.js] Correct translation error

### DIFF
--- a/src/locale/lang/es.js
+++ b/src/locale/lang/es.js
@@ -12,7 +12,7 @@ export default {
       confirm: 'Confirmar',
       selectDate: 'Seleccionar fecha',
       selectTime: 'Seleccionar hora',
-      startDate: 'Fecha Incial',
+      startDate: 'Fecha Inicial',
       startTime: 'Hora Inicial',
       endDate: 'Fecha Final',
       endTime: 'Hora Final',


### PR DESCRIPTION
An error in the translation of the term "startDate" is corrected. "Fecha Incial" is changed to "Fecha Inicial" (missing an "i").
