### PR TITLE
ImageViewer: fix 18713 bug

### DIFF
--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -155,7 +155,6 @@ export default {
   },
   methods: {
     hide() {
-      this.deviceSupportUninstall();
       this.onClose();
     },
     deviceSupportInstall() {
@@ -293,7 +292,6 @@ export default {
     }
   },
   mounted() {
-    this.deviceSupportInstall();
     // add tabindex then wrapper can be focusable via Javascript
     // focus wrapper so arrow key can't cause inner scroll behavior underneath
     this.$refs['el-image-viewer__wrapper'].focus();

--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -16,7 +16,7 @@
       :style="imageStyle"
       :class="{ 'el-image__inner--center': alignCenter, 'el-image__preview': preview }">
     <template v-if="preview">
-      <image-viewer :z-index="zIndex" :initial-index="imageIndex" v-show="showViewer" :on-close="closeViewer" :url-list="previewSrcList"/>
+      <image-viewer ref="imageViewer" :z-index="zIndex" :initial-index="imageIndex" v-show="showViewer" :on-close="closeViewer" :url-list="previewSrcList"/>
     </template>
   </div>
 </template>
@@ -104,6 +104,13 @@
       },
       show(val) {
         val && this.loadImage();
+      },
+      showViewer(val) {
+        if (val) {
+          this.$refs.imageViewer.deviceSupportInstall();
+        } else {
+          this.$refs.imageViewer.deviceSupportUninstall();
+        }
       }
     },
 


### PR DESCRIPTION

修复[bug](https://github.com/ElemeFE/element/issues/18713)。
原代码中，在组件绑定的时候，开启监听键盘 `esc`；在预览图隐藏的时候，取消事件监听。
在重新打开预览图片后，未重新进行事件监听，导致 `esc` 退出预览及其他预览相关功能失效；