### PR TITLE
Submenu: fix native MouseEvent in IE (#17404, #18043)

### DIFF
--- a/packages/menu/src/submenu.vue
+++ b/packages/menu/src/submenu.vue
@@ -198,7 +198,9 @@
         }, showTimeout);
 
         if (this.appendToBody) {
-          this.$parent.$el.dispatchEvent(new MouseEvent('mouseenter'));
+          const event = document.createEvent('MouseEvent');
+          event.initEvent('mouseenter', true, true);
+          this.$parent.$el.dispatchEvent(event);
         }
       },
       handleMouseleave(deepDispatch = false) {


### PR DESCRIPTION
IE browser dose not suport the MouseEvent() constructor .