### PR TITLE
Image: disable set overflow to body after click (#18740)

### DIFF
--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -217,13 +217,17 @@
         }
       },
       clickHandler() {
-        // prevent body scroll
-        prevOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
+        if (this.preview) {
+          // prevent body scroll
+          prevOverflow = document.body.style.overflow;
+          document.body.style.overflow = 'hidden';
+        }
         this.showViewer = true;
       },
       closeViewer() {
-        document.body.style.overflow = prevOverflow;
+        if (this.preview) {
+          document.body.style.overflow = prevOverflow;
+        }
         this.showViewer = false;
       }
     }


### PR DESCRIPTION
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Issue: https://github.com/ElemeFE/element/issues/18740

Removed the strange behavior of adding styles to the body after just clicking on the image (without preview).

Now overflow is added only when popup is opened.