### PR TITLE
Dialog: Fix close modal on click

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -6,7 +6,7 @@
     <div
       v-show="visible"
       class="el-dialog__wrapper"
-      @mosedown.self="handleWrapperMouseDown"
+      @mousedown.self="handleWrapperMouseDown"
       @mouseup.self="handleWrapperMouseUp"
       @click.self="handleWrapperClick">
       <div

--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -6,7 +6,9 @@
     <div
       v-show="visible"
       class="el-dialog__wrapper"
-      @mosedown.self="handleWrapperClick">
+      @mosedown.self="handleWrapperMouseDown"
+      @mouseup.self="handleWrapperMouseUp"
+      @click.self="handleWrapperClick">
       <div
         role="dialog"
         :key="key"
@@ -14,7 +16,9 @@
         :aria-label="title || 'dialog'"
         :class="['el-dialog', { 'is-fullscreen': fullscreen, 'el-dialog--center': center }, customClass]"
         ref="dialog"
-        :style="style">
+        :style="style"
+        @mouseup.stop
+        @mousedown.stop>
         <div class="el-dialog__header">
           <slot name="title">
             <span class="el-dialog__title">{{ title }}</span>
@@ -113,7 +117,10 @@
     data() {
       return {
         closed: false,
-        key: 0
+        key: 0,
+
+        mouseDownFired: false,
+        mouseUpFired: false,
       };
     },
 
@@ -155,6 +162,17 @@
     },
 
     methods: {
+      handleWrapperMouseDown(){
+        this.mouseDownFired = false;
+      },
+      handleWrapperMouseUp(){
+        this.mouseUpFired = false;
+      },
+      handleWrapperClick(){
+        if(this.mouseUpFired && this.mouseDownFired) this.handleClose();
+        this.mouseUpFired = false;
+        this.mouseDownFired = false;
+      },
       getMigratingConfig() {
         return {
           props: {

--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -16,9 +16,7 @@
         :aria-label="title || 'dialog'"
         :class="['el-dialog', { 'is-fullscreen': fullscreen, 'el-dialog--center': center }, customClass]"
         ref="dialog"
-        :style="style"
-        @mouseup.stop
-        @mousedown.stop>
+        :style="style">
         <div class="el-dialog__header">
           <slot name="title">
             <span class="el-dialog__title">{{ title }}</span>

--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -161,10 +161,10 @@
 
     methods: {
       handleWrapperMouseDown(){
-        this.mouseDownFired = false;
+        this.mouseDownFired = true;
       },
       handleWrapperMouseUp(){
-        this.mouseUpFired = false;
+        this.mouseUpFired = true;
       },
       handleWrapperClick(){
         if(this.mouseUpFired && this.mouseDownFired) this.handleClose();

--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -6,7 +6,7 @@
     <div
       v-show="visible"
       class="el-dialog__wrapper"
-      @click.self="handleWrapperClick">
+      @mosedown.self="handleWrapperClick">
       <div
         role="dialog"
         :key="key"

--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -167,7 +167,7 @@
         this.mouseUpFired = true;
       },
       handleWrapperClick(){
-        if(this.mouseUpFired && this.mouseDownFired) this.handleClose();
+        if(this.mouseUpFired && this.mouseDownFired && this.closeOnClickModal) this.handleClose();
         this.mouseUpFired = false;
         this.mouseDownFired = false;
       },
@@ -177,10 +177,6 @@
             'size': 'size is removed.'
           }
         };
-      },
-      handleWrapperClick() {
-        if (!this.closeOnClickModal) return;
-        this.handleClose();
       },
       handleClose() {
         if (typeof this.beforeClose === 'function') {

--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -118,7 +118,7 @@
         key: 0,
 
         mouseDownFired: false,
-        mouseUpFired: false,
+        mouseUpFired: false
       };
     },
 
@@ -160,14 +160,14 @@
     },
 
     methods: {
-      handleWrapperMouseDown(){
+      handleWrapperMouseDown() {
         this.mouseDownFired = true;
       },
-      handleWrapperMouseUp(){
+      handleWrapperMouseUp() {
         this.mouseUpFired = true;
       },
-      handleWrapperClick(){
-        if(this.mouseUpFired && this.mouseDownFired && this.closeOnClickModal) this.handleClose();
+      handleWrapperClick() {
+        if (this.mouseUpFired && this.mouseDownFired && this.closeOnClickModal) this.handleClose();
         this.mouseUpFired = false;
         this.mouseDownFired = false;
       },

--- a/test/unit/specs/dialog.spec.js
+++ b/test/unit/specs/dialog.spec.js
@@ -225,6 +225,8 @@ describe('Dialog', () => {
     }, true);
     const dialog = vm.$children[0];
     setTimeout(() => {
+      dialog.$el.mousedown();
+      dialog.$el.mouseup();
       dialog.$el.click();
       setTimeout(() => {
         expect(vm.visible).to.be.false;
@@ -282,6 +284,8 @@ describe('Dialog', () => {
     }, true);
     const dialog = vm.$children[0];
     setTimeout(() => {
+      dialog.$el.mousedown();
+      dialog.$el.mouseup();
       dialog.$el.click();
       setTimeout(() => {
         expect(spy.called).to.be.true;
@@ -310,6 +314,8 @@ describe('Dialog', () => {
     const dialog = vm.$children[0];
     await waitImmediate();
     dialog.$el.querySelector('input').value = '123';
+    dialog.$el.mousedown();
+    dialog.$el.mouseup();
     dialog.$el.click();
     await waitImmediate();
     vm.visible = true;

--- a/test/unit/specs/dialog.spec.js
+++ b/test/unit/specs/dialog.spec.js
@@ -225,8 +225,8 @@ describe('Dialog', () => {
     }, true);
     const dialog = vm.$children[0];
     setTimeout(() => {
-      dialog.$el.mousedown();
-      dialog.$el.mouseup();
+      dialog.$el.dispatchEvent(new Event('mousedown'));
+      dialog.$el.dispatchEvent(new Event('mouseup'));
       dialog.$el.click();
       setTimeout(() => {
         expect(vm.visible).to.be.false;
@@ -284,8 +284,8 @@ describe('Dialog', () => {
     }, true);
     const dialog = vm.$children[0];
     setTimeout(() => {
-      dialog.$el.mousedown();
-      dialog.$el.mouseup();
+      dialog.$el.dispatchEvent(new Event('mousedown'));
+      dialog.$el.dispatchEvent(new Event('mouseup'));
       dialog.$el.click();
       setTimeout(() => {
         expect(spy.called).to.be.true;
@@ -314,8 +314,8 @@ describe('Dialog', () => {
     const dialog = vm.$children[0];
     await waitImmediate();
     dialog.$el.querySelector('input').value = '123';
-    dialog.$el.mousedown();
-    dialog.$el.mouseup();
+    dialog.$el.dispatchEvent(new Event('mousedown'));
+    dialog.$el.dispatchEvent(new Event('mouseup'));
     dialog.$el.click();
     await waitImmediate();
     vm.visible = true;


### PR DESCRIPTION
Hi,

Dialogs have a bug which if you `mousedown` inside the dialog but `mouseup` outside of the dialog (on the dialog wrapper), the dialog will be closed. It is pretty common for dialogs which are containing forms inside them.

Close action can be `mousedown` instead of the `click` but it hurts UX, so I handled it by ensuring that `mousedown` and `mouseup` events have happened on the wrapper not on the dialog content.

----------------------------------------------------------

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
