### PR TITLE
[Step] Use steps $parent property instead of $children

### DIFF
--- a/packages/steps/src/step.vue
+++ b/packages/steps/src/step.vue
@@ -136,7 +136,7 @@ export default {
 
   methods: {
     updateStatus(val) {
-      const prevChild = this.$parent.$children[this.index - 1];
+      const prevChild = this.$parent.steps[this.index - 1];
 
       if (val > this.index) {
         this.internalStatus = this.$parent.finishStatus;


### PR DESCRIPTION
When using `el-steps` with elements other than `el-step` (To display content when vertical for instance)

When the step is changed, an error is thrown (`TypeError: prevChild.calcProgress is not a function`) because the element is using the `$children` property of the `$parent` (Refering to the el-step components *and also* the content elements that are not el-step and thus messing up the index of the `$children` property)

The el-step element is already adding a property `steps` to it's parent and this property should be used instead of `$children`

This fixes the previously described bug

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
