### PR TITLE
[popper] add type check

### DIFF
--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -1025,6 +1025,10 @@
      * @argument {String} property
      */
     function getStyleComputedProperty(element, property) {
+        if (typeof element !== Element) {
+            return null;
+        }
+        
         // NOTE: 1 DOM access here
         var css = root.getComputedStyle(element, null);
         return css[property];

--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -1025,8 +1025,8 @@
      * @argument {String} property
      */
     function getStyleComputedProperty(element, property) {
-        if (typeof element !== Element) {
-            return '';
+        if (element.nodeType !== 1) {
+            return [];
         }
         
         // NOTE: 1 DOM access here

--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -1026,7 +1026,7 @@
      */
     function getStyleComputedProperty(element, property) {
         if (typeof element !== Element) {
-            return null;
+            return '';
         }
         
         // NOTE: 1 DOM access here


### PR DESCRIPTION
When a popper's reference element is inside shadowRoot, popper fails:

> TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is parameter

See:
- https://github.com/popperjs/popper-core/blob/1ddf685b14489a63e389c0b52aaa9fc7484b9316/packages/popper/src/utils/getStyleComputedProperty.js#L8

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
