### PR TITLE
Image: fix a race condition if src changes too frequently

### DIFF
--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -126,6 +126,10 @@
         // reset status
         this.loading = true;
         this.error = false;
+        if (this._loadingImage) {
+          this._loadingImage.onload = null;
+          this._loadingImage.onerror = null;
+        }
 
         const img = new Image();
         img.onload = e => this.handleLoad(e, img);
@@ -139,15 +143,18 @@
             img.setAttribute(key, value);
           });
         img.src = this.src;
+        this._loadingImage = img;
       },
       handleLoad(e, img) {
         this.imageWidth = img.width;
         this.imageHeight = img.height;
+        this._loadingImage = null;
         this.loading = false;
       },
       handleError(e) {
         this.loading = false;
         this.error = true;
+        this._loadingImage = null;
         this.$emit('error', e);
       },
       handleLazyLoad() {


### PR DESCRIPTION
Everytime `src` changes,
`loadImage` will create a new `HTMLImageElement` to detect errors,
so if `src` changes again before the before gets loaded/broken,
then `error` can be trapped in a wrong status.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
