### PR TITLE
[Image]: Fix page cannot scroll up and down when previewSrcList is empty

### DIFF
--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -217,10 +217,12 @@
         }
       },
       clickHandler() {
-        // prevent body scroll
-        prevOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
-        this.showViewer = true;
+        if (this.preview) {
+          // prevent body scroll
+          prevOverflow = document.body.style.overflow;
+          document.body.style.overflow = 'hidden';
+          this.showViewer = true;
+        }
       },
       closeViewer() {
         document.body.style.overflow = prevOverflow;


### PR DESCRIPTION
Fix page cannot scroll up and down when previewSrcList is empty

