### PR TITLE
Image: don't show image-viewer when preview is false

### DIFF
--- a/packages/image/src/main.vue
+++ b/packages/image/src/main.vue
@@ -217,6 +217,10 @@
         }
       },
       clickHandler() {
+        // don't show viewer when preview is false
+        if (!this.preview) {
+          return;
+        }
         // prevent body scroll
         prevOverflow = document.body.style.overflow;
         document.body.style.overflow = 'hidden';


### PR DESCRIPTION
修复问题：Image 不需要预览效果，没有previewSrcList的时候，点击一下会触发clickHandler事件，导致body被加上overflow = 'hidden'样式。