### PR TITLE
fix vanishing korean last character on input

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -362,10 +362,11 @@
             this.$emit('input', text);
             return;
           }
+        } else if (text === this.nativeInputValue) {
+          // hack for https://github.com/ElemeFE/element/issues/8548
+          // should remove this else if block when we don't support IE
+          return;
         }
-        // hack for https://github.com/ElemeFE/element/issues/8548
-        // should remove the following line when we don't support IE
-        else if (text === this.nativeInputValue) return;
 
         this.$emit('input', text);
 

--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -356,11 +356,18 @@
         // see: https://github.com/ElemeFE/element/issues/10516
         if (this.isComposing) return;
 
+        const text = event.target.value;
+        if (isKorean(text[text.length - 1] || '')) {
+          if (text.length === this.nativeInputValue.length) {
+            this.$emit('input', text);
+            return;
+          }
+        }
         // hack for https://github.com/ElemeFE/element/issues/8548
         // should remove the following line when we don't support IE
-        if (event.target.value === this.nativeInputValue) return;
+        else if (text === this.nativeInputValue) return;
 
-        this.$emit('input', event.target.value);
+        this.$emit('input', text);
 
         // ensure native input value is controlled
         // see: https://github.com/ElemeFE/element/issues/12850


### PR DESCRIPTION
After typing Korean characters to element-ui input, last cahcrater is vanished when I move focus by mouse click not keyboard. But It seems to happen to only Chrome browser on Windows.

Maybe Korean character doesn't have composition process.