### PR TITLE
tree:change defaultExpandAll dynamicly

### DIFF
--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -173,6 +173,13 @@
 
       checkStrictly(newVal) {
         this.store.checkStrictly = newVal;
+      },
+
+      defaultExpandAll(newVal) {
+        this.defaultExpandAll = newVal;
+        this.createTree();
+        this.initTabIndex();
+        this.$el.addEventListener('keydown', this.handleKeydown);
       }
     },
 
@@ -316,171 +323,175 @@
           ev.preventDefault();
           hasInput.click();
         }
+      },
+
+      createTree() {
+        this.isTree = true;
+
+        this.store = new TreeStore({
+          key: this.nodeKey,
+          data: this.data,
+          lazy: this.lazy,
+          props: this.props,
+          load: this.load,
+          currentNodeKey: this.currentNodeKey,
+          checkStrictly: this.checkStrictly,
+          checkDescendants: this.checkDescendants,
+          defaultCheckedKeys: this.defaultCheckedKeys,
+          defaultExpandedKeys: this.defaultExpandedKeys,
+          autoExpandParent: this.autoExpandParent,
+          defaultExpandAll: this.defaultExpandAll,
+          filterNodeMethod: this.filterNodeMethod
+        });
+
+        this.root = this.store.root;
+
+        let dragState = this.dragState;
+        this.$on('tree-node-drag-start', (event, treeNode) => {
+          if (typeof this.allowDrag === 'function' && !this.allowDrag(treeNode.node)) {
+            event.preventDefault();
+            return false;
+          }
+          event.dataTransfer.effectAllowed = 'move';
+
+          // wrap in try catch to address IE's error when first param is 'text/plain'
+          try {
+            // setData is required for draggable to work in FireFox
+            // the content has to be '' so dragging a node out of the tree won't open a new tab in FireFox
+            event.dataTransfer.setData('text/plain', '');
+          } catch (e) {}
+          dragState.draggingNode = treeNode;
+          this.$emit('node-drag-start', treeNode.node, event);
+        });
+
+        this.$on('tree-node-drag-over', (event, treeNode) => {
+          const dropNode = findNearestComponent(event.target, 'ElTreeNode');
+          const oldDropNode = dragState.dropNode;
+          if (oldDropNode && oldDropNode !== dropNode) {
+            removeClass(oldDropNode.$el, 'is-drop-inner');
+          }
+          const draggingNode = dragState.draggingNode;
+          if (!draggingNode || !dropNode) return;
+
+          let dropPrev = true;
+          let dropInner = true;
+          let dropNext = true;
+          let userAllowDropInner = true;
+          if (typeof this.allowDrop === 'function') {
+            dropPrev = this.allowDrop(draggingNode.node, dropNode.node, 'prev');
+            userAllowDropInner = dropInner = this.allowDrop(draggingNode.node, dropNode.node, 'inner');
+            dropNext = this.allowDrop(draggingNode.node, dropNode.node, 'next');
+          }
+          event.dataTransfer.dropEffect = dropInner ? 'move' : 'none';
+          if ((dropPrev || dropInner || dropNext) && oldDropNode !== dropNode) {
+            if (oldDropNode) {
+              this.$emit('node-drag-leave', draggingNode.node, oldDropNode.node, event);
+            }
+            this.$emit('node-drag-enter', draggingNode.node, dropNode.node, event);
+          }
+
+          if (dropPrev || dropInner || dropNext) {
+            dragState.dropNode = dropNode;
+          }
+
+          if (dropNode.node.nextSibling === draggingNode.node) {
+            dropNext = false;
+          }
+          if (dropNode.node.previousSibling === draggingNode.node) {
+            dropPrev = false;
+          }
+          if (dropNode.node.contains(draggingNode.node, false)) {
+            dropInner = false;
+          }
+          if (draggingNode.node === dropNode.node || draggingNode.node.contains(dropNode.node)) {
+            dropPrev = false;
+            dropInner = false;
+            dropNext = false;
+          }
+
+          const targetPosition = dropNode.$el.getBoundingClientRect();
+          const treePosition = this.$el.getBoundingClientRect();
+
+          let dropType;
+          const prevPercent = dropPrev ? (dropInner ? 0.25 : (dropNext ? 0.45 : 1)) : -1;
+          const nextPercent = dropNext ? (dropInner ? 0.75 : (dropPrev ? 0.55 : 0)) : 1;
+
+          let indicatorTop = -9999;
+          const distance = event.clientY - targetPosition.top;
+          if (distance < targetPosition.height * prevPercent) {
+            dropType = 'before';
+          } else if (distance > targetPosition.height * nextPercent) {
+            dropType = 'after';
+          } else if (dropInner) {
+            dropType = 'inner';
+          } else {
+            dropType = 'none';
+          }
+
+          const iconPosition = dropNode.$el.querySelector('.el-tree-node__expand-icon').getBoundingClientRect();
+          const dropIndicator = this.$refs.dropIndicator;
+          if (dropType === 'before') {
+            indicatorTop = iconPosition.top - treePosition.top;
+          } else if (dropType === 'after') {
+            indicatorTop = iconPosition.bottom - treePosition.top;
+          }
+          dropIndicator.style.top = indicatorTop + 'px';
+          dropIndicator.style.left = (iconPosition.right - treePosition.left) + 'px';
+
+          if (dropType === 'inner') {
+            addClass(dropNode.$el, 'is-drop-inner');
+          } else {
+            removeClass(dropNode.$el, 'is-drop-inner');
+          }
+
+          dragState.showDropIndicator = dropType === 'before' || dropType === 'after';
+          dragState.allowDrop = dragState.showDropIndicator || userAllowDropInner;
+          dragState.dropType = dropType;
+          this.$emit('node-drag-over', draggingNode.node, dropNode.node, event);
+        });
+
+        this.$on('tree-node-drag-end', (event) => {
+          const { draggingNode, dropType, dropNode } = dragState;
+          event.preventDefault();
+          event.dataTransfer.dropEffect = 'move';
+
+          if (draggingNode && dropNode) {
+            const draggingNodeCopy = { data: draggingNode.node.data };
+            if (dropType !== 'none') {
+              draggingNode.node.remove();
+            }
+            if (dropType === 'before') {
+              dropNode.node.parent.insertBefore(draggingNodeCopy, dropNode.node);
+            } else if (dropType === 'after') {
+              dropNode.node.parent.insertAfter(draggingNodeCopy, dropNode.node);
+            } else if (dropType === 'inner') {
+              dropNode.node.insertChild(draggingNodeCopy);
+            }
+            if (dropType !== 'none') {
+              this.store.registerNode(draggingNodeCopy);
+            }
+
+            removeClass(dropNode.$el, 'is-drop-inner');
+
+            this.$emit('node-drag-end', draggingNode.node, dropNode.node, dropType, event);
+            if (dropType !== 'none') {
+              this.$emit('node-drop', draggingNode.node, dropNode.node, dropType, event);
+            }
+          }
+          if (draggingNode && !dropNode) {
+            this.$emit('node-drag-end', draggingNode.node, null, dropType, event);
+          }
+
+          dragState.showDropIndicator = false;
+          dragState.draggingNode = null;
+          dragState.dropNode = null;
+          dragState.allowDrop = true;
+        });
       }
     },
 
     created() {
-      this.isTree = true;
-
-      this.store = new TreeStore({
-        key: this.nodeKey,
-        data: this.data,
-        lazy: this.lazy,
-        props: this.props,
-        load: this.load,
-        currentNodeKey: this.currentNodeKey,
-        checkStrictly: this.checkStrictly,
-        checkDescendants: this.checkDescendants,
-        defaultCheckedKeys: this.defaultCheckedKeys,
-        defaultExpandedKeys: this.defaultExpandedKeys,
-        autoExpandParent: this.autoExpandParent,
-        defaultExpandAll: this.defaultExpandAll,
-        filterNodeMethod: this.filterNodeMethod
-      });
-
-      this.root = this.store.root;
-
-      let dragState = this.dragState;
-      this.$on('tree-node-drag-start', (event, treeNode) => {
-        if (typeof this.allowDrag === 'function' && !this.allowDrag(treeNode.node)) {
-          event.preventDefault();
-          return false;
-        }
-        event.dataTransfer.effectAllowed = 'move';
-
-        // wrap in try catch to address IE's error when first param is 'text/plain'
-        try {
-          // setData is required for draggable to work in FireFox
-          // the content has to be '' so dragging a node out of the tree won't open a new tab in FireFox
-          event.dataTransfer.setData('text/plain', '');
-        } catch (e) {}
-        dragState.draggingNode = treeNode;
-        this.$emit('node-drag-start', treeNode.node, event);
-      });
-
-      this.$on('tree-node-drag-over', (event, treeNode) => {
-        const dropNode = findNearestComponent(event.target, 'ElTreeNode');
-        const oldDropNode = dragState.dropNode;
-        if (oldDropNode && oldDropNode !== dropNode) {
-          removeClass(oldDropNode.$el, 'is-drop-inner');
-        }
-        const draggingNode = dragState.draggingNode;
-        if (!draggingNode || !dropNode) return;
-
-        let dropPrev = true;
-        let dropInner = true;
-        let dropNext = true;
-        let userAllowDropInner = true;
-        if (typeof this.allowDrop === 'function') {
-          dropPrev = this.allowDrop(draggingNode.node, dropNode.node, 'prev');
-          userAllowDropInner = dropInner = this.allowDrop(draggingNode.node, dropNode.node, 'inner');
-          dropNext = this.allowDrop(draggingNode.node, dropNode.node, 'next');
-        }
-        event.dataTransfer.dropEffect = dropInner ? 'move' : 'none';
-        if ((dropPrev || dropInner || dropNext) && oldDropNode !== dropNode) {
-          if (oldDropNode) {
-            this.$emit('node-drag-leave', draggingNode.node, oldDropNode.node, event);
-          }
-          this.$emit('node-drag-enter', draggingNode.node, dropNode.node, event);
-        }
-
-        if (dropPrev || dropInner || dropNext) {
-          dragState.dropNode = dropNode;
-        }
-
-        if (dropNode.node.nextSibling === draggingNode.node) {
-          dropNext = false;
-        }
-        if (dropNode.node.previousSibling === draggingNode.node) {
-          dropPrev = false;
-        }
-        if (dropNode.node.contains(draggingNode.node, false)) {
-          dropInner = false;
-        }
-        if (draggingNode.node === dropNode.node || draggingNode.node.contains(dropNode.node)) {
-          dropPrev = false;
-          dropInner = false;
-          dropNext = false;
-        }
-
-        const targetPosition = dropNode.$el.getBoundingClientRect();
-        const treePosition = this.$el.getBoundingClientRect();
-
-        let dropType;
-        const prevPercent = dropPrev ? (dropInner ? 0.25 : (dropNext ? 0.45 : 1)) : -1;
-        const nextPercent = dropNext ? (dropInner ? 0.75 : (dropPrev ? 0.55 : 0)) : 1;
-
-        let indicatorTop = -9999;
-        const distance = event.clientY - targetPosition.top;
-        if (distance < targetPosition.height * prevPercent) {
-          dropType = 'before';
-        } else if (distance > targetPosition.height * nextPercent) {
-          dropType = 'after';
-        } else if (dropInner) {
-          dropType = 'inner';
-        } else {
-          dropType = 'none';
-        }
-
-        const iconPosition = dropNode.$el.querySelector('.el-tree-node__expand-icon').getBoundingClientRect();
-        const dropIndicator = this.$refs.dropIndicator;
-        if (dropType === 'before') {
-          indicatorTop = iconPosition.top - treePosition.top;
-        } else if (dropType === 'after') {
-          indicatorTop = iconPosition.bottom - treePosition.top;
-        }
-        dropIndicator.style.top = indicatorTop + 'px';
-        dropIndicator.style.left = (iconPosition.right - treePosition.left) + 'px';
-
-        if (dropType === 'inner') {
-          addClass(dropNode.$el, 'is-drop-inner');
-        } else {
-          removeClass(dropNode.$el, 'is-drop-inner');
-        }
-
-        dragState.showDropIndicator = dropType === 'before' || dropType === 'after';
-        dragState.allowDrop = dragState.showDropIndicator || userAllowDropInner;
-        dragState.dropType = dropType;
-        this.$emit('node-drag-over', draggingNode.node, dropNode.node, event);
-      });
-
-      this.$on('tree-node-drag-end', (event) => {
-        const { draggingNode, dropType, dropNode } = dragState;
-        event.preventDefault();
-        event.dataTransfer.dropEffect = 'move';
-
-        if (draggingNode && dropNode) {
-          const draggingNodeCopy = { data: draggingNode.node.data };
-          if (dropType !== 'none') {
-            draggingNode.node.remove();
-          }
-          if (dropType === 'before') {
-            dropNode.node.parent.insertBefore(draggingNodeCopy, dropNode.node);
-          } else if (dropType === 'after') {
-            dropNode.node.parent.insertAfter(draggingNodeCopy, dropNode.node);
-          } else if (dropType === 'inner') {
-            dropNode.node.insertChild(draggingNodeCopy);
-          }
-          if (dropType !== 'none') {
-            this.store.registerNode(draggingNodeCopy);
-          }
-
-          removeClass(dropNode.$el, 'is-drop-inner');
-
-          this.$emit('node-drag-end', draggingNode.node, dropNode.node, dropType, event);
-          if (dropType !== 'none') {
-            this.$emit('node-drop', draggingNode.node, dropNode.node, dropType, event);
-          }
-        }
-        if (draggingNode && !dropNode) {
-          this.$emit('node-drag-end', draggingNode.node, null, dropType, event);
-        }
-
-        dragState.showDropIndicator = false;
-        dragState.draggingNode = null;
-        dragState.dropNode = null;
-        dragState.allowDrop = true;
-      });
+      this.createTree();
     },
 
     mounted() {


### PR DESCRIPTION
I hava come across a problem: the backend return a tree meun, sometimes the tree is too big, it is too difficult to render it, what I want to do is: expand the tree when tree is small and close it when the tree is too big,I found a api called `default-expand-all`, but it couldn't solve my problem, [example on codepen](https://codepen.io/ctum-the-bashful/pen/wvaxLxB?editable=true), so I pull this request to solve it.
if this are some other ways to solve it, you can close my PR, and let me konw.