### PR TITLE
优化表单校验逻辑：自定义校验在未出错的情况下不必手动调用 callback，menu: 新增方法 resetActiveIndex

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -129,6 +129,7 @@
           callback(true);
         }
         let invalidFields = {};
+        let callbacked = false;
         this.fields.forEach(field => {
           field.validate('', (message, field) => {
             if (message) {
@@ -137,10 +138,13 @@
             invalidFields = objectAssign({}, invalidFields, field);
             if (typeof callback === 'function' && ++count === this.fields.length) {
               callback(valid, invalidFields);
+              callbacked = true;
             }
           });
         });
-
+        if (!callbacked) {
+          callback(valid, invalidFields);
+        }
         if (promise) {
           return promise;
         }

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -158,6 +158,10 @@
       }
     },
     methods: {
+      resetActiveIndex() {
+        this.activeIndex = this.defaultActive
+      },
+
       updateActiveIndex(val) {
         const item = this.items[val] || this.items[this.activeIndex] || this.items[this.defaultActive];
         if (item) {


### PR DESCRIPTION
优化表单校验逻辑：自定义校验在未出错的情况下不必手动调用 callback，简化组件使用

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
