### PR TITLE
Image: fix  Esc can never close the preview at the second time #1…

### DIFF
--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -155,7 +155,6 @@ export default {
   },
   methods: {
     hide() {
-      this.deviceSupportUninstall();
       this.onClose();
     },
     deviceSupportInstall() {
@@ -297,6 +296,9 @@ export default {
     // add tabindex then wrapper can be focusable via Javascript
     // focus wrapper so arrow key can't cause inner scroll behavior underneath
     this.$refs['el-image-viewer__wrapper'].focus();
+  },
+  beforeDestroy() {
+    this.deviceSupportUninstall();
   }
 };
 </script>


### PR DESCRIPTION
Closes #18983
`hide`方法里面调用了`deviceSupportUninstall `导致document的事件被卸载，所以第二次打开没法使用esc关闭预览