### PR TITLE
* fix: Promise was rejected with a non-error when close dialog or form validate not valid

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -115,9 +115,15 @@
         let promise;
         // if no callback, return promise
         if (typeof callback !== 'function' && window.Promise) {
-          promise = new window.Promise((resolve) => {
+          promise = new window.Promise((resolve, reject) => {
             callback = function(valid) {
-              resolve(valid);
+              if (valid) {
+                resolve(valid)
+              } else {
+                const retError = new Error('Form Validation Error');
+                retError.valid = valid;
+                reject(retError);
+              }
             };
           });
         }

--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -118,7 +118,7 @@
           promise = new window.Promise((resolve, reject) => {
             callback = function(valid) {
               if (valid) {
-                resolve(valid)
+                resolve(valid);
               } else {
                 const retError = new Error('Form Validation Error');
                 retError.valid = valid;

--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -115,9 +115,9 @@
         let promise;
         // if no callback, return promise
         if (typeof callback !== 'function' && window.Promise) {
-          promise = new window.Promise((resolve, reject) => {
+          promise = new window.Promise((resolve) => {
             callback = function(valid) {
-              valid ? resolve(valid) : reject(valid);
+              resolve(valid);
             };
           });
         }

--- a/packages/message-box/src/main.js
+++ b/packages/message-box/src/main.js
@@ -43,6 +43,13 @@ const MessageBoxConstructor = Vue.extend(msgboxVue);
 let currentMsg, instance;
 let msgQueue = [];
 
+export class MessageBoxRejectError extends Error {
+  constructor(action) {
+    super('MessageBox Reject');
+    this.action = action;
+  }
+}
+
 const defaultCallback = action => {
   if (currentMsg) {
     let callback = currentMsg.callback;
@@ -61,7 +68,7 @@ const defaultCallback = action => {
           currentMsg.resolve(action);
         }
       } else if (currentMsg.reject && (action === 'cancel' || action === 'close')) {
-        currentMsg.reject(action);
+        currentMsg.reject(new MessageBoxRejectError(action));
       }
     }
   }

--- a/test/unit/specs/form.spec.js
+++ b/test/unit/specs/form.spec.js
@@ -921,8 +921,8 @@ describe('Form', () => {
           };
         }
       }, true);
-      vm.$refs.form.validate().catch(validFailed => {
-        expect(validFailed).to.false;
+      vm.$refs.form.validate().catch(validFailedError => {
+        expect(validFailedError.valid).to.false;
         done();
       });
     });

--- a/test/unit/specs/message-box.spec.js
+++ b/test/unit/specs/message-box.spec.js
@@ -251,8 +251,8 @@ describe('MessageBox', () => {
 
     it('reject', done => {
       MessageBox.confirm('此操作将永久删除该文件, 是否继续?', '提示')
-        .catch(action => {
-          expect(action).to.equal('cancel');
+        .catch(actionError => {
+          expect(actionError.action).to.equal('cancel');
           done();
         });
       setTimeout(() => {


### PR DESCRIPTION
* fix: Promise was rejected with a non-error when close dialog or form validate not valid #19053

https://eslint.org/docs/rules/prefer-promise-reject-errors
