### PR TITLE
input-number: remove duplicate input event emit

### DIFF
--- a/packages/input-number/src/input-number.vue
+++ b/packages/input-number/src/input-number.vue
@@ -135,7 +135,6 @@
           if (newVal <= this.min) newVal = this.min;
           this.currentValue = newVal;
           this.userInput = null;
-          this.$emit('input', newVal);
         }
       }
     },


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.


### Bug Description:
When input in the `input-number` components, the `input event` will be triggered 2 times for each input, it is not what user want.

![image](https://user-images.githubusercontent.com/14243906/77920004-7b8fb100-72d0-11ea-9274-1e5ae0611b24.png)


### BUG Demo: https://codepen.io/JuniorTour/pen/GRRXpzq

### Fix explanation:
After remove the line: `this.$emit('input', newVal);` , I keep only one emit for `input event` at line 251.

And everything works fine, the bugs above is solved.
