### PR TITLE
Drawer: fix the focus issue when open the drawer

### DIFF
--- a/packages/drawer/src/main.vue
+++ b/packages/drawer/src/main.vue
@@ -26,7 +26,7 @@
           >
           <header class="el-drawer__header" id="el-drawer__title" v-if="withHeader">
             <slot name="title">
-              <span role="heading" tabindex="0" :title="title">{{ title }}</span>
+              <span role="heading" tabindex="-1" :title="title">{{ title }}</span>
             </slot>
             <button
               :aria-label="`close ${title || 'drawer'}`"


### PR DESCRIPTION
there is no enough reason to make the title focusable.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

fix the following issues:
https://github.com/ElemeFE/element/issues/18380
https://github.com/ElemeFE/element/issues/18279
https://github.com/ElemeFE/element/issues/18270
https://github.com/ElemeFE/element/issues/18230