### PR TITLE
Badge: fix badge content default class name

### DIFF
--- a/packages/badge/src/main.vue
+++ b/packages/badge/src/main.vue
@@ -7,7 +7,7 @@
         v-text="content"
         class="el-badge__content"
         :class="[
-          'el-badge__content--' + type,
+          type ? 'el-badge__content--' + type : '',
           {
             'is-fixed': $slots.default,
             'is-dot': isDot


### PR DESCRIPTION
The Badge Type defalut is undefined, so the content defalut class has `el-badge__content--undefined`.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
