### PR TITLE
Autocomplete:  improve the prop of valueKey(#12449)

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -51,7 +51,7 @@
         :aria-selected="highlightedIndex === index"
       >
         <slot :item="item">
-          {{ item[valueKey] }}
+          {{ getValue(item, valueKey) }}
         </slot>
       </li>
     </el-autocomplete-suggestions>
@@ -85,7 +85,7 @@
 
     props: {
       valueKey: {
-        type: String,
+        type: [String, Number],
         default: 'value'
       },
       popperClass: String,
@@ -230,7 +230,7 @@
         }
       },
       select(item) {
-        this.$emit('input', item[this.valueKey]);
+        this.$emit('input', this.getValue(item, this.valueKey));
         this.$emit('select', item);
         this.$nextTick(_ => {
           this.suggestions = [];
@@ -265,6 +265,12 @@
       },
       getInput() {
         return this.$refs.input.getInput();
+      },
+      getValue(item, valueKey) {
+        if (typeof item == 'string' && item.constructor == String) {
+          return item
+        }
+        return item[valueKey]
       }
     },
     mounted() {


### PR DESCRIPTION
完善了prop中valueKey的取值类型，增加了对number类型的支持，保证建议数组元素可以是数组类型
增加了建议数组是字符串数组的支持