### PR TITLE
Autocomplete:  improve the prop of valueKey(#12449)

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -51,7 +51,7 @@
         :aria-selected="highlightedIndex === index"
       >
         <slot :item="item">
-          {{ item[valueKey] }}
+          {{ getValue(item, valueKey) }}
         </slot>
       </li>
     </el-autocomplete-suggestions>
@@ -85,7 +85,7 @@
 
     props: {
       valueKey: {
-        type: String,
+        type: [String, Number],
         default: 'value'
       },
       popperClass: String,
@@ -265,6 +265,12 @@
       },
       getInput() {
         return this.$refs.input.getInput();
+      },
+      getValue(item, valueKey) {
+        if (typeof item === 'string' && item.constructor === String) {
+          return item;
+        }
+        return item[valueKey];
       }
     },
     mounted() {


### PR DESCRIPTION
1. 增加valueKey支持的数据Number，使得建议数组的元素可以为数组
1. 增加建议数组可以为字符串数组，此时valueKey无效，值为字符串值