### PR TITLE
Input: fix el-autocomplete Set the clearable attribute, after clicking clear, search again and the search drop-down box will not appear

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -146,7 +146,7 @@
       suggestionVisible() {
         const suggestions = this.suggestions;
         let isValidData = Array.isArray(suggestions) && suggestions.length > 0;
-        return (isValidData || this.loading) && this.activated;
+        return (isValidData || this.loading) && (this.activated || this.$refs.input.focused);
       },
       id() {
         return `el-autocomplete-${generateId()}`;


### PR DESCRIPTION
Closes #19050 这个问题是在清除之后，activated被设置了false，增加判断输入框是否在聚焦状态，如果是聚焦状态，下拉框也要显示出来