### PR TITLE
locale: Fix the translation ru-RU popconfirm

### DIFF
--- a/src/locale/lang/ru-RU.js
+++ b/src/locale/lang/ru-RU.js
@@ -113,8 +113,8 @@ export default {
       title: 'Back' // to be translated
     },
     popconfirm: {
-      confirmButtonText: 'Yes', // to be translated
-      cancelButtonText: 'No' // to be translated
+      confirmButtonText: 'OK', // to be translated
+      cancelButtonText: 'Отмена' // to be translated
     }
   }
 };

--- a/src/locale/lang/ru-RU.js
+++ b/src/locale/lang/ru-RU.js
@@ -113,8 +113,8 @@ export default {
       title: 'Back' // to be translated
     },
     popconfirm: {
-      confirmButtonText: 'OK', // to be translated
-      cancelButtonText: 'Отмена' // to be translated
+      confirmButtonText: 'OK',
+      cancelButtonText: 'Отмена'
     }
   }
 };


### PR DESCRIPTION
Updated missing translations of popconfirm.cancelButtonText and popconfirm.cancelButtonText

Please make sure these boxes are checked before submitting your PR, thank you!
* [x]  Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
 * [x]  Make sure you are merging your commits to `dev` branch.
* [x]  Add some descriptions and refer relative issues for you PR.
