### PR TITLE
confirm中添加对默认选中cancel按钮的支持

### DIFF
--- a/packages/message-box/src/main.js
+++ b/packages/message-box/src/main.js
@@ -30,187 +30,213 @@ const defaults = {
   dangerouslyUseHTMLString: false,
   center: false,
   roundButton: false,
-  distinguishCancelAndClose: false
-};
+  distinguishCancelAndClose: false,
+  cancelDefualt: false,
+}
 
-import Vue from 'vue';
-import msgboxVue from './main.vue';
-import merge from 'element-ui/src/utils/merge';
-import { isVNode } from 'element-ui/src/utils/vdom';
+import Vue from 'vue'
+import msgboxVue from './main.vue'
+import merge from 'element-ui/src/utils/merge'
+import { isVNode } from 'element-ui/src/utils/vdom'
 
-const MessageBoxConstructor = Vue.extend(msgboxVue);
+const MessageBoxConstructor = Vue.extend(msgboxVue)
 
-let currentMsg, instance;
-let msgQueue = [];
+let currentMsg, instance
+let msgQueue = []
 
-const defaultCallback = action => {
+const defaultCallback = (action) => {
   if (currentMsg) {
-    let callback = currentMsg.callback;
+    let callback = currentMsg.callback
     if (typeof callback === 'function') {
       if (instance.showInput) {
-        callback(instance.inputValue, action);
+        callback(instance.inputValue, action)
       } else {
-        callback(action);
+        callback(action)
       }
     }
     if (currentMsg.resolve) {
       if (action === 'confirm') {
         if (instance.showInput) {
-          currentMsg.resolve({ value: instance.inputValue, action });
+          currentMsg.resolve({ value: instance.inputValue, action })
         } else {
-          currentMsg.resolve(action);
+          currentMsg.resolve(action)
         }
-      } else if (currentMsg.reject && (action === 'cancel' || action === 'close')) {
-        currentMsg.reject(action);
+      } else if (
+        currentMsg.reject &&
+        (action === 'cancel' || action === 'close')
+      ) {
+        currentMsg.reject(action)
       }
     }
   }
-};
+}
 
 const initInstance = () => {
   instance = new MessageBoxConstructor({
-    el: document.createElement('div')
-  });
+    el: document.createElement('div'),
+  })
 
-  instance.callback = defaultCallback;
-};
+  instance.callback = defaultCallback
+}
 
 const showNextMsg = () => {
   if (!instance) {
-    initInstance();
+    initInstance()
   }
-  instance.action = '';
+  instance.action = ''
 
   if (!instance.visible || instance.closeTimer) {
     if (msgQueue.length > 0) {
-      currentMsg = msgQueue.shift();
+      currentMsg = msgQueue.shift()
 
-      let options = currentMsg.options;
+      let options = currentMsg.options
       for (let prop in options) {
         if (options.hasOwnProperty(prop)) {
-          instance[prop] = options[prop];
+          instance[prop] = options[prop]
         }
       }
       if (options.callback === undefined) {
-        instance.callback = defaultCallback;
+        instance.callback = defaultCallback
       }
 
-      let oldCb = instance.callback;
+      let oldCb = instance.callback
       instance.callback = (action, instance) => {
-        oldCb(action, instance);
-        showNextMsg();
-      };
-      if (isVNode(instance.message)) {
-        instance.$slots.default = [instance.message];
-        instance.message = null;
-      } else {
-        delete instance.$slots.default;
+        oldCb(action, instance)
+        showNextMsg()
       }
-      ['modal', 'showClose', 'closeOnClickModal', 'closeOnPressEscape', 'closeOnHashChange'].forEach(prop => {
+      if (isVNode(instance.message)) {
+        instance.$slots.default = [instance.message]
+        instance.message = null
+      } else {
+        delete instance.$slots.default
+      }
+      ;[
+        'modal',
+        'showClose',
+        'closeOnClickModal',
+        'closeOnPressEscape',
+        'closeOnHashChange',
+      ].forEach((prop) => {
         if (instance[prop] === undefined) {
-          instance[prop] = true;
+          instance[prop] = true
         }
-      });
-      document.body.appendChild(instance.$el);
+      })
+      document.body.appendChild(instance.$el)
 
       Vue.nextTick(() => {
-        instance.visible = true;
-      });
+        instance.visible = true
+      })
     }
   }
-};
+}
 
-const MessageBox = function(options, callback) {
-  if (Vue.prototype.$isServer) return;
+const MessageBox = function (options, callback) {
+  if (Vue.prototype.$isServer) return
   if (typeof options === 'string' || isVNode(options)) {
     options = {
-      message: options
-    };
+      message: options,
+    }
     if (typeof arguments[1] === 'string') {
-      options.title = arguments[1];
+      options.title = arguments[1]
     }
   } else if (options.callback && !callback) {
-    callback = options.callback;
+    callback = options.callback
   }
 
   if (typeof Promise !== 'undefined') {
-    return new Promise((resolve, reject) => { // eslint-disable-line
+    return new Promise((resolve, reject) => {
+      // eslint-disable-line
       msgQueue.push({
         options: merge({}, defaults, MessageBox.defaults, options),
         callback: callback,
         resolve: resolve,
-        reject: reject
-      });
+        reject: reject,
+      })
 
-      showNextMsg();
-    });
+      showNextMsg()
+    })
   } else {
     msgQueue.push({
       options: merge({}, defaults, MessageBox.defaults, options),
-      callback: callback
-    });
+      callback: callback,
+    })
 
-    showNextMsg();
+    showNextMsg()
   }
-};
+}
 
-MessageBox.setDefaults = defaults => {
-  MessageBox.defaults = defaults;
-};
+MessageBox.setDefaults = (defaults) => {
+  MessageBox.defaults = defaults
+}
 
 MessageBox.alert = (message, title, options) => {
   if (typeof title === 'object') {
-    options = title;
-    title = '';
+    options = title
+    title = ''
   } else if (title === undefined) {
-    title = '';
+    title = ''
   }
-  return MessageBox(merge({
-    title: title,
-    message: message,
-    $type: 'alert',
-    closeOnPressEscape: false,
-    closeOnClickModal: false
-  }, options));
-};
+  return MessageBox(
+    merge(
+      {
+        title: title,
+        message: message,
+        $type: 'alert',
+        closeOnPressEscape: false,
+        closeOnClickModal: false,
+      },
+      options
+    )
+  )
+}
 
 MessageBox.confirm = (message, title, options) => {
   if (typeof title === 'object') {
-    options = title;
-    title = '';
+    options = title
+    title = ''
   } else if (title === undefined) {
-    title = '';
+    title = ''
   }
-  return MessageBox(merge({
-    title: title,
-    message: message,
-    $type: 'confirm',
-    showCancelButton: true
-  }, options));
-};
+  return MessageBox(
+    merge(
+      {
+        title: title,
+        message: message,
+        $type: 'confirm',
+        showCancelButton: true,
+      },
+      options
+    )
+  )
+}
 
 MessageBox.prompt = (message, title, options) => {
   if (typeof title === 'object') {
-    options = title;
-    title = '';
+    options = title
+    title = ''
   } else if (title === undefined) {
-    title = '';
+    title = ''
   }
-  return MessageBox(merge({
-    title: title,
-    message: message,
-    showCancelButton: true,
-    showInput: true,
-    $type: 'prompt'
-  }, options));
-};
+  return MessageBox(
+    merge(
+      {
+        title: title,
+        message: message,
+        showCancelButton: true,
+        showInput: true,
+        $type: 'prompt',
+      },
+      options
+    )
+  )
+}
 
 MessageBox.close = () => {
-  instance.doClose();
-  instance.visible = false;
-  msgQueue = [];
-  currentMsg = null;
-};
+  instance.doClose()
+  instance.visible = false
+  msgQueue = []
+  currentMsg = null
+}
 
-export default MessageBox;
-export { MessageBox };
+export default MessageBox
+export { MessageBox }

--- a/packages/message-box/src/main.js
+++ b/packages/message-box/src/main.js
@@ -31,212 +31,187 @@ const defaults = {
   center: false,
   roundButton: false,
   distinguishCancelAndClose: false,
-  cancelDefualt: false,
-}
+  cancelDefualt: false
+};
 
-import Vue from 'vue'
-import msgboxVue from './main.vue'
-import merge from 'element-ui/src/utils/merge'
-import { isVNode } from 'element-ui/src/utils/vdom'
+import Vue from 'vue';
+import msgboxVue from './main.vue';
+import merge from 'element-ui/src/utils/merge';
+import { isVNode } from 'element-ui/src/utils/vdom';
 
-const MessageBoxConstructor = Vue.extend(msgboxVue)
+const MessageBoxConstructor = Vue.extend(msgboxVue);
 
-let currentMsg, instance
-let msgQueue = []
+let currentMsg, instance;
+let msgQueue = [];
 
-const defaultCallback = (action) => {
+const defaultCallback = action => {
   if (currentMsg) {
-    let callback = currentMsg.callback
+    let callback = currentMsg.callback;
     if (typeof callback === 'function') {
       if (instance.showInput) {
-        callback(instance.inputValue, action)
+        callback(instance.inputValue, action);
       } else {
-        callback(action)
+        callback(action);
       }
     }
     if (currentMsg.resolve) {
       if (action === 'confirm') {
         if (instance.showInput) {
-          currentMsg.resolve({ value: instance.inputValue, action })
+          currentMsg.resolve({ value: instance.inputValue, action });
         } else {
-          currentMsg.resolve(action)
+          currentMsg.resolve(action);
         }
-      } else if (
-        currentMsg.reject &&
-        (action === 'cancel' || action === 'close')
-      ) {
-        currentMsg.reject(action)
+      } else if (currentMsg.reject && (action === 'cancel' || action === 'close')) {
+        currentMsg.reject(action);
       }
     }
   }
-}
+};
 
 const initInstance = () => {
   instance = new MessageBoxConstructor({
-    el: document.createElement('div'),
-  })
+    el: document.createElement('div')
+  });
 
-  instance.callback = defaultCallback
-}
+  instance.callback = defaultCallback;
+};
 
 const showNextMsg = () => {
   if (!instance) {
-    initInstance()
+    initInstance();
   }
-  instance.action = ''
+  instance.action = '';
 
   if (!instance.visible || instance.closeTimer) {
     if (msgQueue.length > 0) {
-      currentMsg = msgQueue.shift()
+      currentMsg = msgQueue.shift();
 
-      let options = currentMsg.options
+      let options = currentMsg.options;
       for (let prop in options) {
         if (options.hasOwnProperty(prop)) {
-          instance[prop] = options[prop]
+          instance[prop] = options[prop];
         }
       }
       if (options.callback === undefined) {
-        instance.callback = defaultCallback
+        instance.callback = defaultCallback;
       }
 
-      let oldCb = instance.callback
+      let oldCb = instance.callback;
       instance.callback = (action, instance) => {
-        oldCb(action, instance)
-        showNextMsg()
-      }
+        oldCb(action, instance);
+        showNextMsg();
+      };
       if (isVNode(instance.message)) {
-        instance.$slots.default = [instance.message]
-        instance.message = null
+        instance.$slots.default = [instance.message];
+        instance.message = null;
       } else {
-        delete instance.$slots.default
+        delete instance.$slots.default;
       }
-      ;[
-        'modal',
-        'showClose',
-        'closeOnClickModal',
-        'closeOnPressEscape',
-        'closeOnHashChange',
-      ].forEach((prop) => {
+      ['modal', 'showClose', 'closeOnClickModal', 'closeOnPressEscape', 'closeOnHashChange'].forEach(prop => {
         if (instance[prop] === undefined) {
-          instance[prop] = true
+          instance[prop] = true;
         }
-      })
-      document.body.appendChild(instance.$el)
+      });
+      document.body.appendChild(instance.$el);
 
       Vue.nextTick(() => {
-        instance.visible = true
-      })
+        instance.visible = true;
+      });
     }
   }
-}
+};
 
-const MessageBox = function (options, callback) {
-  if (Vue.prototype.$isServer) return
+const MessageBox = function(options, callback) {
+  if (Vue.prototype.$isServer) return;
   if (typeof options === 'string' || isVNode(options)) {
     options = {
-      message: options,
-    }
+      message: options
+    };
     if (typeof arguments[1] === 'string') {
-      options.title = arguments[1]
+      options.title = arguments[1];
     }
   } else if (options.callback && !callback) {
-    callback = options.callback
+    callback = options.callback;
   }
 
   if (typeof Promise !== 'undefined') {
-    return new Promise((resolve, reject) => {
-      // eslint-disable-line
+    return new Promise((resolve, reject) => { // eslint-disable-line
       msgQueue.push({
         options: merge({}, defaults, MessageBox.defaults, options),
         callback: callback,
         resolve: resolve,
-        reject: reject,
-      })
+        reject: reject
+      });
 
-      showNextMsg()
-    })
+      showNextMsg();
+    });
   } else {
     msgQueue.push({
       options: merge({}, defaults, MessageBox.defaults, options),
-      callback: callback,
-    })
+      callback: callback
+    });
 
-    showNextMsg()
+    showNextMsg();
   }
-}
+};
 
-MessageBox.setDefaults = (defaults) => {
-  MessageBox.defaults = defaults
-}
+MessageBox.setDefaults = defaults => {
+  MessageBox.defaults = defaults;
+};
 
 MessageBox.alert = (message, title, options) => {
   if (typeof title === 'object') {
-    options = title
-    title = ''
+    options = title;
+    title = '';
   } else if (title === undefined) {
-    title = ''
+    title = '';
   }
-  return MessageBox(
-    merge(
-      {
-        title: title,
-        message: message,
-        $type: 'alert',
-        closeOnPressEscape: false,
-        closeOnClickModal: false,
-      },
-      options
-    )
-  )
-}
+  return MessageBox(merge({
+    title: title,
+    message: message,
+    $type: 'alert',
+    closeOnPressEscape: false,
+    closeOnClickModal: false
+  }, options));
+};
 
 MessageBox.confirm = (message, title, options) => {
   if (typeof title === 'object') {
-    options = title
-    title = ''
+    options = title;
+    title = '';
   } else if (title === undefined) {
-    title = ''
+    title = '';
   }
-  return MessageBox(
-    merge(
-      {
-        title: title,
-        message: message,
-        $type: 'confirm',
-        showCancelButton: true,
-      },
-      options
-    )
-  )
-}
+  return MessageBox(merge({
+    title: title,
+    message: message,
+    $type: 'confirm',
+    showCancelButton: true
+  }, options));
+};
 
 MessageBox.prompt = (message, title, options) => {
   if (typeof title === 'object') {
-    options = title
-    title = ''
+    options = title;
+    title = '';
   } else if (title === undefined) {
-    title = ''
+    title = '';
   }
-  return MessageBox(
-    merge(
-      {
-        title: title,
-        message: message,
-        showCancelButton: true,
-        showInput: true,
-        $type: 'prompt',
-      },
-      options
-    )
-  )
-}
+  return MessageBox(merge({
+    title: title,
+    message: message,
+    showCancelButton: true,
+    showInput: true,
+    $type: 'prompt'
+  }, options));
+};
 
 MessageBox.close = () => {
-  instance.doClose()
-  instance.visible = false
-  msgQueue = []
-  currentMsg = null
-}
+  instance.doClose();
+  instance.visible = false;
+  msgQueue = [];
+  currentMsg = null;
+};
 
-export default MessageBox
-export { MessageBox }
+export default MessageBox;
+export { MessageBox };

--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -1,75 +1,76 @@
 <template>
   <transition name="msgbox-fade">
-    <div class="el-message-box__wrapper"
-         tabindex="-1"
-         v-show="visible"
-         @click.self="handleWrapperClick"
-         role="dialog"
-         aria-modal="true"
-         :aria-label="title || 'dialog'">
-      <div class="el-message-box"
-           :class="[customClass, center && 'el-message-box--center']">
-        <div class="el-message-box__header"
-             v-if="title !== null">
+    <div
+      class="el-message-box__wrapper"
+      tabindex="-1"
+      v-show="visible"
+      @click.self="handleWrapperClick"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="title || 'dialog'">
+      <div class="el-message-box" :class="[customClass, center && 'el-message-box--center']">
+        <div class="el-message-box__header" v-if="title !== null">
           <div class="el-message-box__title">
-            <div :class="['el-message-box__status', icon]"
-                 v-if="icon && center">
+            <div
+              :class="['el-message-box__status', icon]"
+              v-if="icon && center">
             </div>
             <span>{{ title }}</span>
           </div>
-          <button type="button"
-                  class="el-message-box__headerbtn"
-                  aria-label="Close"
-                  v-if="showClose"
-                  @click="handleAction(distinguishCancelAndClose ? 'close' : 'cancel')"
-                  @keydown.enter="handleAction(distinguishCancelAndClose ? 'close' : 'cancel')">
+          <button
+            type="button"
+            class="el-message-box__headerbtn"
+            aria-label="Close"
+            v-if="showClose"
+            @click="handleAction(distinguishCancelAndClose ? 'close' : 'cancel')"
+            @keydown.enter="handleAction(distinguishCancelAndClose ? 'close' : 'cancel')">
             <i class="el-message-box__close el-icon-close"></i>
           </button>
         </div>
         <div class="el-message-box__content">
           <div class="el-message-box__container">
-            <div :class="['el-message-box__status', icon]"
-                 v-if="icon && !center && message !== ''">
+            <div
+              :class="['el-message-box__status', icon]"
+              v-if="icon && !center && message !== ''">
             </div>
-            <div class="el-message-box__message"
-                 v-if="message !== ''">
+            <div class="el-message-box__message" v-if="message !== ''">
               <slot>
                 <p v-if="!dangerouslyUseHTMLString">{{ message }}</p>
-                <p v-else
-                   v-html="message"></p>
+                <p v-else v-html="message"></p>
               </slot>
             </div>
           </div>
-          <div class="el-message-box__input"
-               v-show="showInput">
-            <el-input v-model="inputValue"
-                      :type="inputType"
-                      @keydown.enter.native="handleInputEnter"
-                      :placeholder="inputPlaceholder"
-                      ref="input"></el-input>
-            <div class="el-message-box__errormsg"
-                 :style="{ visibility: !!editorErrorMessage ? 'visible' : 'hidden' }">{{ editorErrorMessage }}</div>
+          <div class="el-message-box__input" v-show="showInput">
+            <el-input
+              v-model="inputValue"
+              :type="inputType"
+              @keydown.enter.native="handleInputEnter"
+              :placeholder="inputPlaceholder"
+              ref="input"></el-input>
+            <div class="el-message-box__errormsg" :style="{ visibility: !!editorErrorMessage ? 'visible' : 'hidden' }">{{ editorErrorMessage }}</div>
           </div>
         </div>
         <div class="el-message-box__btns">
-          <el-button ref="cancel"
-                     :loading="cancelButtonLoading"
-                     :class="[ cancelButtonClasses ]"
-                     v-if="showCancelButton"
-                     :round="roundButton"
-                     size="small"
-                     @click.native="handleAction('cancel')"
-                     @keydown.enter="handleAction('cancel')">
+          <el-button
+            ref="cancel"
+            :loading="cancelButtonLoading"
+            :class="[ cancelButtonClasses ]"
+            v-if="showCancelButton"
+            :round="roundButton"
+            size="small"
+            @click.native="handleAction('cancel')"
+            @keydown.enter="handleAction('cancel')">
             {{ cancelButtonText || t('el.messagebox.cancel') }}
           </el-button>
-          <el-button :loading="confirmButtonLoading"
-                     ref="confirm"
-                     :class="[ confirmButtonClasses ]"
-                     v-show="showConfirmButton"
-                     :round="roundButton"
-                     size="small"
-                     @click.native="handleAction('confirm')"
-                     @keydown.enter="handleAction('confirm')">
+          <el-button
+            :loading="confirmButtonLoading"
+            ref="confirm"
+            :class="[ confirmButtonClasses ]"
+            v-show="showConfirmButton"
+            :round="roundButton"
+            size="small"
+            @click.native="handleAction('confirm')"
+            @keydown.enter="handleAction('confirm')">
             {{ confirmButtonText || t('el.messagebox.confirm') }}
           </el-button>
         </div>
@@ -79,266 +80,267 @@
 </template>
 
 <script type="text/babel">
-import Popup from 'element-ui/src/utils/popup';
-import Locale from 'element-ui/src/mixins/locale';
-import ElInput from 'element-ui/packages/input';
-import ElButton from 'element-ui/packages/button';
-import { addClass, removeClass } from 'element-ui/src/utils/dom';
-import { t } from 'element-ui/src/locale';
-import Dialog from 'element-ui/src/utils/aria-dialog';
+  import Popup from 'element-ui/src/utils/popup';
+  import Locale from 'element-ui/src/mixins/locale';
+  import ElInput from 'element-ui/packages/input';
+  import ElButton from 'element-ui/packages/button';
+  import { addClass, removeClass } from 'element-ui/src/utils/dom';
+  import { t } from 'element-ui/src/locale';
+  import Dialog from 'element-ui/src/utils/aria-dialog';
 
-let messageBox;
-let typeMap = {
-  success: 'success',
-  info: 'info',
-  warning: 'warning',
-  error: 'error'
-};
+  let messageBox;
+  let typeMap = {
+    success: 'success',
+    info: 'info',
+    warning: 'warning',
+    error: 'error'
+  };
 
-export default {
-  mixins: [Popup, Locale],
+  export default {
+    mixins: [Popup, Locale],
 
-  props: {
-    modal: {
-      default: true
-    },
-    lockScroll: {
-      default: true
-    },
-    showClose: {
-      type: Boolean,
-      default: true
-    },
-    closeOnClickModal: {
-      default: true
-    },
-    closeOnPressEscape: {
-      default: true
-    },
-    closeOnHashChange: {
-      default: true
-    },
-    center: {
-      default: false,
-      type: Boolean
-    },
-    roundButton: {
-      default: false,
-      type: Boolean
-    },
-    cancelDefault: {
-      default: false,
-      type: Boolean
-    }
-  },
-
-  components: {
-    ElInput,
-    ElButton
-  },
-
-  computed: {
-    icon () {
-      const { type, iconClass } = this;
-      return iconClass || (type && typeMap[type] ? `el-icon-${typeMap[type]}` : '');
-    },
-
-    confirmButtonClasses () {
-      return `el-button--primary ${this.confirmButtonClass}`;
-    },
-    cancelButtonClasses () {
-      return `${this.cancelButtonClass}`;
-    }
-  },
-
-  methods: {
-    getSafeClose () {
-      const currentId = this.uid;
-      return () => {
-        this.$nextTick(() => {
-          if (currentId === this.uid) this.doClose();
-        });
-      };
-    },
-    doClose () {
-      if (!this.visible) return;
-      this.visible = false;
-      this._closing = true;
-
-      this.onClose && this.onClose();
-      messageBox.closeDialog(); // 解绑
-      if (this.lockScroll) {
-        setTimeout(this.restoreBodyStyle, 200);
-      }
-      this.opened = false;
-      this.doAfterClose();
-      setTimeout(() => {
-        if (this.action) this.callback(this.action, this);
-      });
-    },
-
-    handleWrapperClick () {
-      if (this.closeOnClickModal) {
-        this.handleAction(this.distinguishCancelAndClose ? 'close' : 'cancel');
+    props: {
+      modal: {
+        default: true
+      },
+      lockScroll: {
+        default: true
+      },
+      showClose: {
+        type: Boolean,
+        default: true
+      },
+      closeOnClickModal: {
+        default: true
+      },
+      closeOnPressEscape: {
+        default: true
+      },
+      closeOnHashChange: {
+        default: true
+      },
+      center: {
+        default: false,
+        type: Boolean
+      },
+      roundButton: {
+        default: false,
+        type: Boolean
+      },
+      cancelDefault: {
+        default: false,
+        type: Boolean
       }
     },
 
-    handleInputEnter () {
-      if (this.inputType !== 'textarea') {
-        return this.handleAction('confirm');
+    components: {
+      ElInput,
+      ElButton
+    },
+
+    computed: {
+      icon() {
+        const { type, iconClass } = this;
+        return iconClass || (type && typeMap[type] ? `el-icon-${ typeMap[type] }` : '');
+      },
+
+      confirmButtonClasses() {
+        return `el-button--primary ${ this.confirmButtonClass }`;
+      },
+      cancelButtonClasses() {
+        return `${ this.cancelButtonClass }`;
       }
     },
 
-    handleAction (action) {
-      if (this.$type === 'prompt' && action === 'confirm' && !this.validate()) {
-        return;
-      }
-      this.action = action;
-      if (typeof this.beforeClose === 'function') {
-        this.close = this.getSafeClose();
-        this.beforeClose(action, this, this.close);
-      } else {
-        this.doClose();
-      }
-    },
+    methods: {
+      getSafeClose() {
+        const currentId = this.uid;
+        return () => {
+          this.$nextTick(() => {
+            if (currentId === this.uid) this.doClose();
+          });
+        };
+      },
+      doClose() {
+        if (!this.visible) return;
+        this.visible = false;
+        this._closing = true;
 
-    validate () {
-      if (this.$type === 'prompt') {
-        const inputPattern = this.inputPattern;
-        if (inputPattern && !inputPattern.test(this.inputValue || '')) {
-          this.editorErrorMessage = this.inputErrorMessage || t('el.messagebox.error');
-          addClass(this.getInputElement(), 'invalid');
-          return false;
+        this.onClose && this.onClose();
+        messageBox.closeDialog(); // 解绑
+        if (this.lockScroll) {
+          setTimeout(this.restoreBodyStyle, 200);
         }
-        const inputValidator = this.inputValidator;
-        if (typeof inputValidator === 'function') {
-          const validateResult = inputValidator(this.inputValue);
-          if (validateResult === false) {
+        this.opened = false;
+        this.doAfterClose();
+        setTimeout(() => {
+          if (this.action) this.callback(this.action, this);
+        });
+      },
+
+      handleWrapperClick() {
+        if (this.closeOnClickModal) {
+          this.handleAction(this.distinguishCancelAndClose ? 'close' : 'cancel');
+        }
+      },
+
+      handleInputEnter() {
+        if (this.inputType !== 'textarea') {
+          return this.handleAction('confirm');
+        }
+      },
+
+      handleAction(action) {
+        if (this.$type === 'prompt' && action === 'confirm' && !this.validate()) {
+          return;
+        }
+        this.action = action;
+        if (typeof this.beforeClose === 'function') {
+          this.close = this.getSafeClose();
+          this.beforeClose(action, this, this.close);
+        } else {
+          this.doClose();
+        }
+      },
+
+      validate() {
+        if (this.$type === 'prompt') {
+          const inputPattern = this.inputPattern;
+          if (inputPattern && !inputPattern.test(this.inputValue || '')) {
             this.editorErrorMessage = this.inputErrorMessage || t('el.messagebox.error');
             addClass(this.getInputElement(), 'invalid');
             return false;
           }
-          if (typeof validateResult === 'string') {
-            this.editorErrorMessage = validateResult;
-            addClass(this.getInputElement(), 'invalid');
-            return false;
+          const inputValidator = this.inputValidator;
+          if (typeof inputValidator === 'function') {
+            const validateResult = inputValidator(this.inputValue);
+            if (validateResult === false) {
+              this.editorErrorMessage = this.inputErrorMessage || t('el.messagebox.error');
+              addClass(this.getInputElement(), 'invalid');
+              return false;
+            }
+            if (typeof validateResult === 'string') {
+              this.editorErrorMessage = validateResult;
+              addClass(this.getInputElement(), 'invalid');
+              return false;
+            }
           }
         }
-      }
-      this.editorErrorMessage = '';
-      removeClass(this.getInputElement(), 'invalid');
-      return true;
-    },
-    getFirstFocus () {
-      const btn = this.$el.querySelector('.el-message-box__btns .el-button');
-      const title = this.$el.querySelector('.el-message-box__btns .el-message-box__title');
-      return btn || title;
-    },
-    getInputElement () {
-      const inputRefs = this.$refs.input.$refs;
-      return inputRefs.input || inputRefs.textarea;
-    },
-    handleClose () {
-      this.handleAction('close');
-    }
-  },
-
-  watch: {
-    inputValue: {
-      immediate: true,
-      handler (val) {
-        this.$nextTick(_ => {
-          if (this.$type === 'prompt' && val !== null) {
-            this.validate();
-          }
-        });
+        this.editorErrorMessage = '';
+        removeClass(this.getInputElement(), 'invalid');
+        return true;
+      },
+      getFirstFocus() {
+        const btn = this.$el.querySelector('.el-message-box__btns .el-button');
+        const title = this.$el.querySelector('.el-message-box__btns .el-message-box__title');
+        return btn || title;
+      },
+      getInputElement() {
+        const inputRefs = this.$refs.input.$refs;
+        return inputRefs.input || inputRefs.textarea;
+      },
+      handleClose() {
+        this.handleAction('close');
       }
     },
 
-    visible (val) {
-      if (val) {
-        this.uid++;
-        if (this.$type === 'alert') {
-          this.$nextTick(() => {
-            this.$refs.confirm.$el.focus();
-          });
-        } else if (this.$type === 'confirm') {
-          this.$nextTick(() => {
-            if (this.cancelDefault) {
-              this.$refs.cancel.$el.focus();
-            } else {
-              this.$refs.confirm.$el.focus();
+    watch: {
+      inputValue: {
+        immediate: true,
+        handler(val) {
+          this.$nextTick(_ => {
+            if (this.$type === 'prompt' && val !== null) {
+              this.validate();
             }
           });
         }
-        this.focusAfterClosed = document.activeElement;
-        messageBox = new Dialog(this.$el, this.focusAfterClosed, this.getFirstFocus());
-      }
+      },
 
-      // prompt
-      if (this.$type !== 'prompt') return;
-      if (val) {
-        setTimeout(() => {
-          if (this.$refs.input && this.$refs.input.$el) {
-            this.getInputElement().focus();
+      visible(val) {
+        if (val) {
+          this.uid++;
+          if (this.$type === 'alert') {
+            this.$nextTick(() => {
+              this.$refs.confirm.$el.focus();
+            });
+          }else if(this.$type === 'confirm'){
+            this.$nextTick(() => {
+              if (this.cancelDefault) {
+                this.$refs.cancel.$el.focus();
+              }else {
+                this.$refs.confirm.$el.focus();
+              }
+              
+            });
           }
-        }, 500);
-      } else {
-        this.editorErrorMessage = '';
-        removeClass(this.getInputElement(), 'invalid');
-      }
-    }
-  },
+          this.focusAfterClosed = document.activeElement;
+          messageBox = new Dialog(this.$el, this.focusAfterClosed, this.getFirstFocus());
+        }
 
-  mounted () {
-    this.$nextTick(() => {
+        // prompt
+        if (this.$type !== 'prompt') return;
+        if (val) {
+          setTimeout(() => {
+            if (this.$refs.input && this.$refs.input.$el) {
+              this.getInputElement().focus();
+            }
+          }, 500);
+        } else {
+          this.editorErrorMessage = '';
+          removeClass(this.getInputElement(), 'invalid');
+        }
+      }
+    },
+
+    mounted() {
+      this.$nextTick(() => {
+        if (this.closeOnHashChange) {
+          window.addEventListener('hashchange', this.close);
+        }
+      });
+    },
+
+    beforeDestroy() {
       if (this.closeOnHashChange) {
-        window.addEventListener('hashchange', this.close);
+        window.removeEventListener('hashchange', this.close);
       }
-    });
-  },
+      setTimeout(() => {
+        messageBox.closeDialog();
+      });
+    },
 
-  beforeDestroy () {
-    if (this.closeOnHashChange) {
-      window.removeEventListener('hashchange', this.close);
+    data() {
+      return {
+        uid: 1,
+        title: undefined,
+        message: '',
+        type: '',
+        iconClass: '',
+        customClass: '',
+        showInput: false,
+        inputValue: null,
+        inputPlaceholder: '',
+        inputType: 'text',
+        inputPattern: null,
+        inputValidator: null,
+        inputErrorMessage: '',
+        showConfirmButton: true,
+        showCancelButton: false,
+        action: '',
+        confirmButtonText: '',
+        cancelButtonText: '',
+        confirmButtonLoading: false,
+        cancelButtonLoading: false,
+        confirmButtonClass: '',
+        confirmButtonDisabled: false,
+        cancelButtonClass: '',
+        editorErrorMessage: null,
+        callback: null,
+        dangerouslyUseHTMLString: false,
+        focusAfterClosed: null,
+        isOnComposition: false,
+        distinguishCancelAndClose: false
+      };
     }
-    setTimeout(() => {
-      messageBox.closeDialog();
-    });
-  },
-
-  data () {
-    return {
-      uid: 1,
-      title: undefined,
-      message: '',
-      type: '',
-      iconClass: '',
-      customClass: '',
-      showInput: false,
-      inputValue: null,
-      inputPlaceholder: '',
-      inputType: 'text',
-      inputPattern: null,
-      inputValidator: null,
-      inputErrorMessage: '',
-      showConfirmButton: true,
-      showCancelButton: false,
-      action: '',
-      confirmButtonText: '',
-      cancelButtonText: '',
-      confirmButtonLoading: false,
-      cancelButtonLoading: false,
-      confirmButtonClass: '',
-      confirmButtonDisabled: false,
-      cancelButtonClass: '',
-      editorErrorMessage: null,
-      callback: null,
-      dangerouslyUseHTMLString: false,
-      focusAfterClosed: null,
-      isOnComposition: false,
-      distinguishCancelAndClose: false
-    };
-  }
-};
+  };
 </script>

--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -1,75 +1,75 @@
 <template>
   <transition name="msgbox-fade">
-    <div
-      class="el-message-box__wrapper"
-      tabindex="-1"
-      v-show="visible"
-      @click.self="handleWrapperClick"
-      role="dialog"
-      aria-modal="true"
-      :aria-label="title || 'dialog'">
-      <div class="el-message-box" :class="[customClass, center && 'el-message-box--center']">
-        <div class="el-message-box__header" v-if="title !== null">
+    <div class="el-message-box__wrapper"
+         tabindex="-1"
+         v-show="visible"
+         @click.self="handleWrapperClick"
+         role="dialog"
+         aria-modal="true"
+         :aria-label="title || 'dialog'">
+      <div class="el-message-box"
+           :class="[customClass, center && 'el-message-box--center']">
+        <div class="el-message-box__header"
+             v-if="title !== null">
           <div class="el-message-box__title">
-            <div
-              :class="['el-message-box__status', icon]"
-              v-if="icon && center">
+            <div :class="['el-message-box__status', icon]"
+                 v-if="icon && center">
             </div>
             <span>{{ title }}</span>
           </div>
-          <button
-            type="button"
-            class="el-message-box__headerbtn"
-            aria-label="Close"
-            v-if="showClose"
-            @click="handleAction(distinguishCancelAndClose ? 'close' : 'cancel')"
-            @keydown.enter="handleAction(distinguishCancelAndClose ? 'close' : 'cancel')">
+          <button type="button"
+                  class="el-message-box__headerbtn"
+                  aria-label="Close"
+                  v-if="showClose"
+                  @click="handleAction(distinguishCancelAndClose ? 'close' : 'cancel')"
+                  @keydown.enter="handleAction(distinguishCancelAndClose ? 'close' : 'cancel')">
             <i class="el-message-box__close el-icon-close"></i>
           </button>
         </div>
         <div class="el-message-box__content">
           <div class="el-message-box__container">
-            <div
-              :class="['el-message-box__status', icon]"
-              v-if="icon && !center && message !== ''">
+            <div :class="['el-message-box__status', icon]"
+                 v-if="icon && !center && message !== ''">
             </div>
-            <div class="el-message-box__message" v-if="message !== ''">
+            <div class="el-message-box__message"
+                 v-if="message !== ''">
               <slot>
                 <p v-if="!dangerouslyUseHTMLString">{{ message }}</p>
-                <p v-else v-html="message"></p>
+                <p v-else
+                   v-html="message"></p>
               </slot>
             </div>
           </div>
-          <div class="el-message-box__input" v-show="showInput">
-            <el-input
-              v-model="inputValue"
-              :type="inputType"
-              @keydown.enter.native="handleInputEnter"
-              :placeholder="inputPlaceholder"
-              ref="input"></el-input>
-            <div class="el-message-box__errormsg" :style="{ visibility: !!editorErrorMessage ? 'visible' : 'hidden' }">{{ editorErrorMessage }}</div>
+          <div class="el-message-box__input"
+               v-show="showInput">
+            <el-input v-model="inputValue"
+                      :type="inputType"
+                      @keydown.enter.native="handleInputEnter"
+                      :placeholder="inputPlaceholder"
+                      ref="input"></el-input>
+            <div class="el-message-box__errormsg"
+                 :style="{ visibility: !!editorErrorMessage ? 'visible' : 'hidden' }">{{ editorErrorMessage }}</div>
           </div>
         </div>
         <div class="el-message-box__btns">
-          <el-button
-            :loading="cancelButtonLoading"
-            :class="[ cancelButtonClasses ]"
-            v-if="showCancelButton"
-            :round="roundButton"
-            size="small"
-            @click.native="handleAction('cancel')"
-            @keydown.enter="handleAction('cancel')">
+          <el-button ref="cancel"
+                     :loading="cancelButtonLoading"
+                     :class="[ cancelButtonClasses ]"
+                     v-if="showCancelButton"
+                     :round="roundButton"
+                     size="small"
+                     @click.native="handleAction('cancel')"
+                     @keydown.enter="handleAction('cancel')">
             {{ cancelButtonText || t('el.messagebox.cancel') }}
           </el-button>
-          <el-button
-            :loading="confirmButtonLoading"
-            ref="confirm"
-            :class="[ confirmButtonClasses ]"
-            v-show="showConfirmButton"
-            :round="roundButton"
-            size="small"
-            @click.native="handleAction('confirm')"
-            @keydown.enter="handleAction('confirm')">
+          <el-button :loading="confirmButtonLoading"
+                     ref="confirm"
+                     :class="[ confirmButtonClasses ]"
+                     v-show="showConfirmButton"
+                     :round="roundButton"
+                     size="small"
+                     @click.native="handleAction('confirm')"
+                     @keydown.enter="handleAction('confirm')">
             {{ confirmButtonText || t('el.messagebox.confirm') }}
           </el-button>
         </div>
@@ -79,254 +79,266 @@
 </template>
 
 <script type="text/babel">
-  import Popup from 'element-ui/src/utils/popup';
-  import Locale from 'element-ui/src/mixins/locale';
-  import ElInput from 'element-ui/packages/input';
-  import ElButton from 'element-ui/packages/button';
-  import { addClass, removeClass } from 'element-ui/src/utils/dom';
-  import { t } from 'element-ui/src/locale';
-  import Dialog from 'element-ui/src/utils/aria-dialog';
+import Popup from 'element-ui/src/utils/popup';
+import Locale from 'element-ui/src/mixins/locale';
+import ElInput from 'element-ui/packages/input';
+import ElButton from 'element-ui/packages/button';
+import { addClass, removeClass } from 'element-ui/src/utils/dom';
+import { t } from 'element-ui/src/locale';
+import Dialog from 'element-ui/src/utils/aria-dialog';
 
-  let messageBox;
-  let typeMap = {
-    success: 'success',
-    info: 'info',
-    warning: 'warning',
-    error: 'error'
-  };
+let messageBox;
+let typeMap = {
+  success: 'success',
+  info: 'info',
+  warning: 'warning',
+  error: 'error'
+};
 
-  export default {
-    mixins: [Popup, Locale],
+export default {
+  mixins: [Popup, Locale],
 
-    props: {
-      modal: {
-        default: true
-      },
-      lockScroll: {
-        default: true
-      },
-      showClose: {
-        type: Boolean,
-        default: true
-      },
-      closeOnClickModal: {
-        default: true
-      },
-      closeOnPressEscape: {
-        default: true
-      },
-      closeOnHashChange: {
-        default: true
-      },
-      center: {
-        default: false,
-        type: Boolean
-      },
-      roundButton: {
-        default: false,
-        type: Boolean
-      }
+  props: {
+    modal: {
+      default: true
+    },
+    lockScroll: {
+      default: true
+    },
+    showClose: {
+      type: Boolean,
+      default: true
+    },
+    closeOnClickModal: {
+      default: true
+    },
+    closeOnPressEscape: {
+      default: true
+    },
+    closeOnHashChange: {
+      default: true
+    },
+    center: {
+      default: false,
+      type: Boolean
+    },
+    roundButton: {
+      default: false,
+      type: Boolean
+    },
+    cancelDefault: {
+      default: false,
+      type: Boolean
+    }
+  },
+
+  components: {
+    ElInput,
+    ElButton
+  },
+
+  computed: {
+    icon () {
+      const { type, iconClass } = this;
+      return iconClass || (type && typeMap[type] ? `el-icon-${typeMap[type]}` : '');
     },
 
-    components: {
-      ElInput,
-      ElButton
+    confirmButtonClasses () {
+      return `el-button--primary ${this.confirmButtonClass}`;
     },
+    cancelButtonClasses () {
+      return `${this.cancelButtonClass}`;
+    }
+  },
 
-    computed: {
-      icon() {
-        const { type, iconClass } = this;
-        return iconClass || (type && typeMap[type] ? `el-icon-${ typeMap[type] }` : '');
-      },
-
-      confirmButtonClasses() {
-        return `el-button--primary ${ this.confirmButtonClass }`;
-      },
-      cancelButtonClasses() {
-        return `${ this.cancelButtonClass }`;
-      }
-    },
-
-    methods: {
-      getSafeClose() {
-        const currentId = this.uid;
-        return () => {
-          this.$nextTick(() => {
-            if (currentId === this.uid) this.doClose();
-          });
-        };
-      },
-      doClose() {
-        if (!this.visible) return;
-        this.visible = false;
-        this._closing = true;
-
-        this.onClose && this.onClose();
-        messageBox.closeDialog(); // 解绑
-        if (this.lockScroll) {
-          setTimeout(this.restoreBodyStyle, 200);
-        }
-        this.opened = false;
-        this.doAfterClose();
-        setTimeout(() => {
-          if (this.action) this.callback(this.action, this);
+  methods: {
+    getSafeClose () {
+      const currentId = this.uid;
+      return () => {
+        this.$nextTick(() => {
+          if (currentId === this.uid) this.doClose();
         });
-      },
+      };
+    },
+    doClose () {
+      if (!this.visible) return;
+      this.visible = false;
+      this._closing = true;
 
-      handleWrapperClick() {
-        if (this.closeOnClickModal) {
-          this.handleAction(this.distinguishCancelAndClose ? 'close' : 'cancel');
-        }
-      },
+      this.onClose && this.onClose();
+      messageBox.closeDialog(); // 解绑
+      if (this.lockScroll) {
+        setTimeout(this.restoreBodyStyle, 200);
+      }
+      this.opened = false;
+      this.doAfterClose();
+      setTimeout(() => {
+        if (this.action) this.callback(this.action, this);
+      });
+    },
 
-      handleInputEnter() {
-        if (this.inputType !== 'textarea') {
-          return this.handleAction('confirm');
-        }
-      },
+    handleWrapperClick () {
+      if (this.closeOnClickModal) {
+        this.handleAction(this.distinguishCancelAndClose ? 'close' : 'cancel');
+      }
+    },
 
-      handleAction(action) {
-        if (this.$type === 'prompt' && action === 'confirm' && !this.validate()) {
-          return;
-        }
-        this.action = action;
-        if (typeof this.beforeClose === 'function') {
-          this.close = this.getSafeClose();
-          this.beforeClose(action, this, this.close);
-        } else {
-          this.doClose();
-        }
-      },
+    handleInputEnter () {
+      if (this.inputType !== 'textarea') {
+        return this.handleAction('confirm');
+      }
+    },
 
-      validate() {
-        if (this.$type === 'prompt') {
-          const inputPattern = this.inputPattern;
-          if (inputPattern && !inputPattern.test(this.inputValue || '')) {
+    handleAction (action) {
+      if (this.$type === 'prompt' && action === 'confirm' && !this.validate()) {
+        return;
+      }
+      this.action = action;
+      if (typeof this.beforeClose === 'function') {
+        this.close = this.getSafeClose();
+        this.beforeClose(action, this, this.close);
+      } else {
+        this.doClose();
+      }
+    },
+
+    validate () {
+      if (this.$type === 'prompt') {
+        const inputPattern = this.inputPattern;
+        if (inputPattern && !inputPattern.test(this.inputValue || '')) {
+          this.editorErrorMessage = this.inputErrorMessage || t('el.messagebox.error');
+          addClass(this.getInputElement(), 'invalid');
+          return false;
+        }
+        const inputValidator = this.inputValidator;
+        if (typeof inputValidator === 'function') {
+          const validateResult = inputValidator(this.inputValue);
+          if (validateResult === false) {
             this.editorErrorMessage = this.inputErrorMessage || t('el.messagebox.error');
             addClass(this.getInputElement(), 'invalid');
             return false;
           }
-          const inputValidator = this.inputValidator;
-          if (typeof inputValidator === 'function') {
-            const validateResult = inputValidator(this.inputValue);
-            if (validateResult === false) {
-              this.editorErrorMessage = this.inputErrorMessage || t('el.messagebox.error');
-              addClass(this.getInputElement(), 'invalid');
-              return false;
-            }
-            if (typeof validateResult === 'string') {
-              this.editorErrorMessage = validateResult;
-              addClass(this.getInputElement(), 'invalid');
-              return false;
-            }
+          if (typeof validateResult === 'string') {
+            this.editorErrorMessage = validateResult;
+            addClass(this.getInputElement(), 'invalid');
+            return false;
           }
         }
-        this.editorErrorMessage = '';
-        removeClass(this.getInputElement(), 'invalid');
-        return true;
-      },
-      getFirstFocus() {
-        const btn = this.$el.querySelector('.el-message-box__btns .el-button');
-        const title = this.$el.querySelector('.el-message-box__btns .el-message-box__title');
-        return btn || title;
-      },
-      getInputElement() {
-        const inputRefs = this.$refs.input.$refs;
-        return inputRefs.input || inputRefs.textarea;
-      },
-      handleClose() {
-        this.handleAction('close');
+      }
+      this.editorErrorMessage = '';
+      removeClass(this.getInputElement(), 'invalid');
+      return true;
+    },
+    getFirstFocus () {
+      const btn = this.$el.querySelector('.el-message-box__btns .el-button');
+      const title = this.$el.querySelector('.el-message-box__btns .el-message-box__title');
+      return btn || title;
+    },
+    getInputElement () {
+      const inputRefs = this.$refs.input.$refs;
+      return inputRefs.input || inputRefs.textarea;
+    },
+    handleClose () {
+      this.handleAction('close');
+    }
+  },
+
+  watch: {
+    inputValue: {
+      immediate: true,
+      handler (val) {
+        this.$nextTick(_ => {
+          if (this.$type === 'prompt' && val !== null) {
+            this.validate();
+          }
+        });
       }
     },
 
-    watch: {
-      inputValue: {
-        immediate: true,
-        handler(val) {
-          this.$nextTick(_ => {
-            if (this.$type === 'prompt' && val !== null) {
-              this.validate();
+    visible (val) {
+      if (val) {
+        this.uid++;
+        if (this.$type === 'alert') {
+          this.$nextTick(() => {
+            this.$refs.confirm.$el.focus();
+          });
+        } else if (this.$type === 'confirm') {
+          this.$nextTick(() => {
+            if (this.cancelDefault) {
+              this.$refs.cancel.$el.focus();
+            } else {
+              this.$refs.confirm.$el.focus();
             }
           });
         }
-      },
+        this.focusAfterClosed = document.activeElement;
+        messageBox = new Dialog(this.$el, this.focusAfterClosed, this.getFirstFocus());
+      }
 
-      visible(val) {
-        if (val) {
-          this.uid++;
-          if (this.$type === 'alert' || this.$type === 'confirm') {
-            this.$nextTick(() => {
-              this.$refs.confirm.$el.focus();
-            });
+      // prompt
+      if (this.$type !== 'prompt') return;
+      if (val) {
+        setTimeout(() => {
+          if (this.$refs.input && this.$refs.input.$el) {
+            this.getInputElement().focus();
           }
-          this.focusAfterClosed = document.activeElement;
-          messageBox = new Dialog(this.$el, this.focusAfterClosed, this.getFirstFocus());
-        }
-
-        // prompt
-        if (this.$type !== 'prompt') return;
-        if (val) {
-          setTimeout(() => {
-            if (this.$refs.input && this.$refs.input.$el) {
-              this.getInputElement().focus();
-            }
-          }, 500);
-        } else {
-          this.editorErrorMessage = '';
-          removeClass(this.getInputElement(), 'invalid');
-        }
+        }, 500);
+      } else {
+        this.editorErrorMessage = '';
+        removeClass(this.getInputElement(), 'invalid');
       }
-    },
-
-    mounted() {
-      this.$nextTick(() => {
-        if (this.closeOnHashChange) {
-          window.addEventListener('hashchange', this.close);
-        }
-      });
-    },
-
-    beforeDestroy() {
-      if (this.closeOnHashChange) {
-        window.removeEventListener('hashchange', this.close);
-      }
-      setTimeout(() => {
-        messageBox.closeDialog();
-      });
-    },
-
-    data() {
-      return {
-        uid: 1,
-        title: undefined,
-        message: '',
-        type: '',
-        iconClass: '',
-        customClass: '',
-        showInput: false,
-        inputValue: null,
-        inputPlaceholder: '',
-        inputType: 'text',
-        inputPattern: null,
-        inputValidator: null,
-        inputErrorMessage: '',
-        showConfirmButton: true,
-        showCancelButton: false,
-        action: '',
-        confirmButtonText: '',
-        cancelButtonText: '',
-        confirmButtonLoading: false,
-        cancelButtonLoading: false,
-        confirmButtonClass: '',
-        confirmButtonDisabled: false,
-        cancelButtonClass: '',
-        editorErrorMessage: null,
-        callback: null,
-        dangerouslyUseHTMLString: false,
-        focusAfterClosed: null,
-        isOnComposition: false,
-        distinguishCancelAndClose: false
-      };
     }
-  };
+  },
+
+  mounted () {
+    this.$nextTick(() => {
+      if (this.closeOnHashChange) {
+        window.addEventListener('hashchange', this.close);
+      }
+    });
+  },
+
+  beforeDestroy () {
+    if (this.closeOnHashChange) {
+      window.removeEventListener('hashchange', this.close);
+    }
+    setTimeout(() => {
+      messageBox.closeDialog();
+    });
+  },
+
+  data () {
+    return {
+      uid: 1,
+      title: undefined,
+      message: '',
+      type: '',
+      iconClass: '',
+      customClass: '',
+      showInput: false,
+      inputValue: null,
+      inputPlaceholder: '',
+      inputType: 'text',
+      inputPattern: null,
+      inputValidator: null,
+      inputErrorMessage: '',
+      showConfirmButton: true,
+      showCancelButton: false,
+      action: '',
+      confirmButtonText: '',
+      cancelButtonText: '',
+      confirmButtonLoading: false,
+      cancelButtonLoading: false,
+      confirmButtonClass: '',
+      confirmButtonDisabled: false,
+      cancelButtonClass: '',
+      editorErrorMessage: null,
+      callback: null,
+      dangerouslyUseHTMLString: false,
+      focusAfterClosed: null,
+      isOnComposition: false,
+      distinguishCancelAndClose: false
+    };
+  }
+};
 </script>


### PR DESCRIPTION
在项目中经常有confirm默认选择取消按钮的需求，目前element的实现中没有对此作实现。而是写死选中了confirm按钮。
对此做了一下修改，添加了一个cancelDefault的prop，默认为false，即原样选中confirm，可以在options中添加{cancelDefault: true}来默认选中cancel按钮。
