### PR TITLE
FormItem: field name support dot in prop

### DIFF
--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -43,10 +43,17 @@ export const getValueByPath = function(object, prop) {
 
 export function getPropByPath(obj, path, strict) {
   let tempObj = obj;
-  path = path.replace(/\[(\w+)\]/g, '.$1');
+  // remove start dot in path
   path = path.replace(/^\./, '');
+  // replace .=>[]
+  path = path.replace(/\.(\w+)((?:\.)|\[|$)/g, '[$1]$2');
+  // replace start key
+  path = path.replace(/^(\w+)/, '[$1]');
 
-  let keyArr = path.split('.');
+  // sometime path is empty when init, so match will get null
+  let keyArr = path.match(/(?:\[)(.*?)(?:\])/g) || [];
+  // remove [|]|"|' in key
+  keyArr = keyArr.map((k) => k.replace(/(\[|\]|"|')/g, ''));
   let i = 0;
   for (let len = keyArr.length; i < len - 1; ++i) {
     if (!tempObj && !strict) break;

--- a/test/unit/specs/form.spec.js
+++ b/test/unit/specs/form.spec.js
@@ -348,7 +348,7 @@ describe('Form', () => {
             },
             rules: {
               region: [
-                {required: true, message: '请选择活动区域', trigger: 'change' }
+                { required: true, message: '请选择活动区域', trigger: 'change' }
               ]
             }
           };
@@ -389,7 +389,7 @@ describe('Form', () => {
             },
             rules: {
               date: [
-                {type: 'date', required: true, message: '请选择日期', trigger: 'change' }
+                { type: 'date', required: true, message: '请选择日期', trigger: 'change' }
               ]
             }
           };
@@ -445,7 +445,7 @@ describe('Form', () => {
             },
             rules: {
               date: [
-                {type: 'date', required: true, message: '请选择时间', trigger: 'change' }
+                { type: 'date', required: true, message: '请选择时间', trigger: 'change' }
               ]
             }
           };
@@ -594,6 +594,41 @@ describe('Form', () => {
         }
       }, true);
       vm.$refs.form.validateField('name', valid => {
+        expect(valid).to.not.true;
+        done();
+      });
+    });
+    it('validate field name with dot', done => {
+      vm = createVue({
+        template: `
+          <el-form :model="form" :rules="rules" ref="form">
+            <el-form-item label="2.4G信道编号" prop='["2.4g"].channel' ref="field">
+              <el-input v-model.number="form['2.4g'].channel"></el-input>
+            </el-form-item>
+          </el-form>
+        `,
+        data() {
+          return {
+            form: {
+              '2.4g': {
+                channel: 0
+              }
+
+            },
+            rules: {
+              '["2.4g"].channel': [
+                { type: 'number', required: true, message: '请输入2.4G信道编号', trigger: 'change', min: 11, max: 14 }
+              ]
+            }
+          };
+        },
+        methods: {
+          setValue(value) {
+            this.form['2.4g'].channel = value;
+          }
+        }
+      }, true);
+      vm.$refs.form.validateField('["2.4g"].channel', valid => {
         expect(valid).to.not.true;
         done();
       });


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

### description
Sometimes property name has `.` in form object, so need support to parse this key in form.
### example
```html
<el-form :model="wifi">
  <el-form-item prop="bands['2.4g'].channel"></el-form-item>
</el-form>
```
```js
rules: {
  "bands['2.4g'].channel": [{
     // validators
  }]
},
wifi: {
  bands: {
    "2.4g": {
        channel: 11
    },
    "5g": {
        channel: 40
    }
  }
}
```
Now this will cause an error that says this prop is not valid
### related issues
#10299
