### PR TITLE
[Button]: Clear focus after clicking

### DIFF
--- a/packages/button/src/button.vue
+++ b/packages/button/src/button.vue
@@ -71,6 +71,7 @@
 
     methods: {
       handleClick(evt) {
+        document.activeElement.blur();
         this.$emit('click', evt);
       }
     }


### PR DESCRIPTION
If we set styles for `:focus` (as Element does), click on button will also apply these styles, you can reproduce it here (https://element.eleme.io/#/en-US/component/button on macOS with Chrome) that makes think in the way of something wrong, whether loading or bug. MDN says this behavior also depends on OS and browser, I think it make sense to set button free from focus event after clicking, make identical behavior on all platforms and browsers and keep accessibility with keyboard

MDN: 
<img width="1111" alt="Снимок экрана 2020-05-02 в 17 07 07" src="https://user-images.githubusercontent.com/14087100/80866459-6e7f2c80-8c97-11ea-8076-7fcc1436a98d.png">

