### PR TITLE
Document: Fix explanation of el-input slots

### DIFF
--- a/examples/docs/en-US/input.md
+++ b/examples/docs/en-US/input.md
@@ -593,10 +593,10 @@ export default {
 
 | Name | Description |
 |------|--------|
-| prefix | content as Input prefix, only works when `type` is 'text' |
-| suffix | content as Input suffix, only works when `type` is 'text' |
-| prepend | content to prepend before Input, only works when `type` is 'text' |
-| append | content to append after Input, only works when `type` is 'text' |
+| prefix | content as Input prefix, only works when `type` is other than 'textarea' |
+| suffix | content as Input suffix, only works when `type` is other than 'textarea' |
+| prepend | content to prepend before Input, only works when `type` is other than 'textarea' |
+| append | content to append after Input, only works when `type` is other than 'textarea' |
 
 ### Input Events
 


### PR DESCRIPTION
Fix documentation of el-input slots. Although the document says these slots only works when type is 'text', they are also available when type is 'number', 'password', etc. The below link shows actually they works when type is NOT 'textarea'.

https://codepen.io/POPOPON/pen/yLYPVVd?editors=1010

- [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer relative issues for you PR.

