### PR TITLE
"list" is not a valid aria-haspopup value

### DIFF
--- a/packages/dropdown/src/dropdown.vue
+++ b/packages/dropdown/src/dropdown.vue
@@ -190,7 +190,7 @@
       },
       initAria() {
         this.dropdownElm.setAttribute('id', this.listId);
-        this.triggerElm.setAttribute('aria-haspopup', 'list');
+        this.triggerElm.setAttribute('aria-haspopup', 'menu');
         this.triggerElm.setAttribute('aria-controls', this.listId);
 
         if (!this.splitButton) { // 自定义


### PR DESCRIPTION
According to w3c `list` is not a valid value for `aria-haspop`. `menu` seems more appropriate.

https://www.w3.org/TR/wai-aria/#aria-haspopup

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
