### PR TITLE
[Popconfirm] Fix button's text translation

### DIFF
--- a/src/locale/lang/pt-br.js
+++ b/src/locale/lang/pt-br.js
@@ -113,8 +113,8 @@ export default {
       title: 'Voltar'
     },
     popconfirm: {
-      confirmButtonText: 'Yes', // to be translated
-      cancelButtonText: 'No' // to be translated
+      confirmButtonText: 'Sim',
+      cancelButtonText: 'Não'
     }
   }
 };


### PR DESCRIPTION
A simple fix to translate the popconfirm button's text to Brazilian Portuguese.