### PR TITLE
bugfix:解决同一个渲染周期前多次调用message导致弹窗黏连问题

### DIFF
--- a/packages/message/src/main.js
+++ b/packages/message/src/main.js
@@ -34,6 +34,7 @@ const Message = function(options) {
   document.body.appendChild(instance.$el);
   let verticalOffset = options.offset || 20;
   instances.forEach(item => {
+    item.$el.style.display = 'flex';
     verticalOffset += item.$el.offsetHeight + 16;
   });
   instance.verticalOffset = verticalOffset;


### PR DESCRIPTION
问题描述：当多个this.$message()在一个渲染周期前被调用时，导致消息框黏连
效果图：![image](https://user-images.githubusercontent.com/15673574/81557314-578ab980-93be-11ea-8315-ab65cc3fec50.png)
