### PR TITLE
[select component] — Added the slot `tag`

### DIFF
--- a/examples/docs/en-US/select.md
+++ b/examples/docs/en-US/select.md
@@ -570,6 +570,7 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 |    —    | Option component list |
 | prefix  | content as Select prefix |
 | empty  | content when there is no options |
+| tag  | customize the tag and get the option instance with the scope `option` |
 
 ### Option Group Attributes
 | Attribute      | Description          | Type      | Accepted Values       | Default  |
@@ -583,6 +584,7 @@ If the binding value of Select is an object, make sure to assign `value-key` as 
 | value | value of option | string/number/object | — | — |
 | label | label of option, same as `value` if omitted | string/number | — | — |
 | disabled | whether option is disabled | boolean | — | false |
+| item | If you would like store more information and used later | object | — | — |
 
 ### Methods
 | Method | Description | Parameters |

--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -34,6 +34,9 @@
       },
       label: [String, Number],
       created: Boolean,
+      item: {
+        type: Object
+      },
       disabled: {
         type: Boolean,
         default: false

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -38,7 +38,10 @@
           type="info"
           @close="deleteTag($event, item)"
           disable-transitions>
-          <span class="el-select__tags-text">{{ item.currentLabel }}</span>
+          <span v-if="$scopedSlots.tag || $slots.tag">
+            <slot name="tag" :option="item"></slot>
+          </span>
+          <span v-else class="el-select__tags-text">{{ item.currentLabel }}</span>
         </el-tag>
       </transition-group>
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

I use the `el-select` component to show users with their name and profile picture. Currently, it's not possible to customize the `el-tag` component. That's why i added a new slot to do that.

## Example with the remote search example on the documentation

```html
<template>
  <el-select
    v-model="value"
    multiple
    filterable
    remote
    reserve-keyword
    placeholder="Please enter a username"
    :remote-method="remoteMethod"
    :loading="loading">
    <template slot="tag" slot-scope="{option}">
      <img :src="option.item.picture" alt="Profile Picture"/>
      <span>{{ option.item.name }}</span>
    </template>
    <el-option
      v-for="item in options"
      :key="item.id"
      :label="item.name"
      :item="item"
      :value="item.id">
      {{ item.name }}
    </el-option>
  </el-select>
</template>

<script>
  export default {
    data() {
      return {
        options: [],
        value: [],
        list: [],
        loading: false,
        users: [{
          id: 1,
          name: 'John Doe',
          email: 'john@doe.com',
          picture: 'URL'
        }, {
          id: 2,
          name: 'Madeline Follin',
          email: 'madeline@follin.com',
          picture: 'URL'
        }]
      }
    },
    mounted() {
      this.list = this.states.map(item => {
        return { value: `value:${item}`, label: `label:${item}` };
      });
    },
    methods: {
      test(params) {
        console.log(params)
      },
      remoteMethod(query) {
        if (query !== '') {
          this.loading = true;
          setTimeout(() => {
            this.loading = false;
            this.options = this.users.filter(item => {
              return item.name.toLowerCase()
                .indexOf(query.toLowerCase()) > -1;
            });
          }, 200);
        } else {
          this.options = [];
        }
      }
    }
  }
</script>
```

