### PR TITLE
Autocomplete:fix bug that suggestion is invisible after  clearing inp…

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -189,6 +189,7 @@
       },
       handleInput(value) {
         this.$emit('input', value);
+        this.activated = true;
         this.suggestionDisabled = false;
         if (!this.triggerOnFocus && !value) {
           this.suggestionDisabled = true;


### PR DESCRIPTION
修复问题:Autocomplete clearble 设为true,清除文字后activated被设为false，但是此时input还是focus状态，此后再输入时无法显示建议，问题同[#19050](https://github.com/ElemeFE/element/issues/19050)