### PR TITLE
Update Russian locale (ru-RU.js) 

### DIFF
--- a/src/locale/lang/ru-RU.js
+++ b/src/locale/lang/ru-RU.js
@@ -107,7 +107,7 @@ export default {
       hasCheckedFormat: '{checked}/{total} выбрано'
     },
     image: {
-      error: 'FAILED' // to be translated
+      error: 'Произошла ошибка'
     },
     pageHeader: {
       title: 'Назад'

--- a/src/locale/lang/ru-RU.js
+++ b/src/locale/lang/ru-RU.js
@@ -110,7 +110,7 @@ export default {
       error: 'FAILED' // to be translated
     },
     pageHeader: {
-      title: 'Back' // to be translated
+      title: 'Назад'
     },
     popconfirm: {
       confirmButtonText: 'OK',

--- a/src/locale/lang/ru-RU.js
+++ b/src/locale/lang/ru-RU.js
@@ -85,7 +85,7 @@ export default {
     upload: {
       deleteTip: 'Нажмите [Удалить] для удаления',
       delete: 'Удалить',
-      preview: 'Превью',
+      preview: 'Предпросмотр',
       continue: 'Продолжить'
     },
     table: {


### PR DESCRIPTION
Translated missing translations in "pageHeader.header" and "image.error".
Fixed translation in "upload.preview", because a "preview" is a anglicism, in russian correct to say "предпросмотр".

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
