### PR TITLE
[Form] Adding capability to validate part of the fields while still getting a promise in return

### DIFF
--- a/packages/form/src/form.vue
+++ b/packages/form/src/form.vue
@@ -106,10 +106,19 @@
           field.clearValidate();
         });
       },
-      validate(callback) {
+      validate(callback, fieldProps) {
         if (!this.model) {
           console.warn('[Element Warn][Form]model is required for validate to work!');
           return;
+        }
+
+        fieldProps = [].concat(fieldProps);
+        let fields;
+        // 没传入fieldProps或者传入的为空数组时，验证所有字段
+        if (fieldProps.length === 0) {
+          fields = this.fields;
+        } else {
+          fields = this.fields.filter(field => fieldProps.indexOf(field.prop) !== -1);
         }
 
         let promise;
@@ -125,17 +134,17 @@
         let valid = true;
         let count = 0;
         // 如果需要验证的fields为空，调用验证时立刻返回callback
-        if (this.fields.length === 0 && callback) {
+        if (fields.length === 0 && callback) {
           callback(true);
         }
         let invalidFields = {};
-        this.fields.forEach(field => {
+        fields.forEach(field => {
           field.validate('', (message, field) => {
             if (message) {
               valid = false;
             }
             invalidFields = objectAssign({}, invalidFields, field);
-            if (typeof callback === 'function' && ++count === this.fields.length) {
+            if (typeof callback === 'function' && ++count === fields.length) {
               callback(valid, invalidFields);
             }
           });

--- a/types/form.d.ts
+++ b/types/form.d.ts
@@ -64,8 +64,8 @@ export declare class ElForm extends ElementUIComponent {
    *
    * @param callback A callback to tell the validation result
    */
-  validate (callback: ValidateCallback): void
-  validate (): Promise<boolean>
+  validate (callback: ValidateCallback, fieldProps?: string[] | string): void
+  validate (fieldProps?: string[] | string): Promise<boolean>
   /**
    * Validate certain form items
    *


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

### This is a ...

- [ ] New feature
- [ ] Bug fix
- [ ] Site / document update
- [ ] Component style update
- [x] TypeScript definition update
- [x] Refactoring
- [ ] Code style optimization
- [ ] Branch merge
- [ ] Other (about what?)

### What's the background?
- I need to validate part of the fields and expect a `Promise` as return value.
- `Form.validate()` supports returning a promise, but doesn't support validating part of the fields. From my understanding, this method is to get a final result against all fields' validity.
- `Form.validateField()` supports validating part of the fields, but doesn't support returning a promise. From my understanding, this method is to apply a callback to each of the fields passed in.

### API Implementation
My original goal is to get a final result against **part of the fields' validity**, thus refactoring `Form.validate()` is my choice.

I added a second parameter to this method, making it `validate(callback, fieldProps)`. In order to avoid a destructive refactoring, I put `fieldProps` at the 2nd position - inserting it at the 1st position will break this method's backward compatibility, which is unacceptable IMO.

### What's the effect?
Now I can validate just part of the form fields while still getting a `Promise` in return,

```js
const valid = await this.$refs.dataForm.validate(undefined, ['fieldProp1', 'fieldProp2']);
```

### Changelog description
1. English description
> Add a second parameter `fieldProps` to `Form.validate()` to support validating part of the form fields and get a `Promise` in return.

2. Chinese description (optional)
> 给 `Form.validate()` 增加第二个参数 `fieldProps` 以支持验证部分字段的同时也能获得一个 `Promise` 作为返回值。

### Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [x] Demo is not needed
- [x] TypeScript definition is updated/provided
- [x] Changelog is provided
