### PR TITLE
[tooltip]: 当开启openDelay配置时，在延迟期间，元素可能已被隐藏，导致tooltip显示在窗口的左上角（因元素已被隐藏，…

### DIFF
--- a/packages/tooltip/src/main.js
+++ b/packages/tooltip/src/main.js
@@ -180,7 +180,9 @@ export default {
       if (!this.expectedState || this.manual) return;
       clearTimeout(this.timeout);
       this.timeout = setTimeout(() => {
-        this.showPopper = true;
+        if (this.referenceElm.offsetParent !== null) {
+          this.showPopper = true;
+        }
       }, this.openDelay);
 
       if (this.hideAfter > 0) {


### PR DESCRIPTION
…popper插件getBoundingClientRect函数获取元素定位时，得到的都是top left等都是0，错误的定位到左上角）

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
