### PR TITLE
[menu]: 移除点击即改变activeIndex的值。

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -258,10 +258,6 @@
         const oldActiveIndex = this.activeIndex;
         const hasIndex = item.index !== null;
 
-        if (hasIndex) {
-          this.activeIndex = item.index;
-        }
-
         this.$emit('select', index, indexPath, item);
 
         if (this.mode === 'horizontal' || this.collapse) {


### PR DESCRIPTION
当前的做法是：点击菜单项，即把activeIndex设置为点击项的index值，随后当前项也变为选择样式。

但是我遇到了这么一个场景：点击菜单项，会动态加载这个菜单项对应的页面文件，但是加载失败了，这个时候，页面还是之前的页面，但是菜单选择项却是刚才的点击项。两者是不对应的。

其实，组件已经提供了defaultActive属性给用户控制当前选中项，即设置了defaultActive，activeIndex也会被自动设置。

所以，这两行代码比较多余，还会在特殊的场景下带来bug。