### PR TITLE
Calendar：fix the part of dates cannot be selected when it sets range attributes and is cross-month

### DIFF
--- a/packages/calendar/src/date-table.vue
+++ b/packages/calendar/src/date-table.vue
@@ -50,7 +50,7 @@ export default {
 
     getCellClass({ text, type}) {
       const classes = [type];
-      if (type === 'current') {
+      if (type === 'current' || (this.isInRange && type === 'next')) {
         const date = this.getFormateDate(text, type);
         if (date === this.selectedDay) {
           classes.push('is-selected');


### PR DESCRIPTION
Calendar：fix the part of dates cannot be selected when it sets range attributes and is cross-month

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Closes #19564