### PR TITLE
popconfirm: fix invalid emit onConfirm and onCancel, use kebab-case event name #19450

### DIFF
--- a/packages/popconfirm/src/main.vue
+++ b/packages/popconfirm/src/main.vue
@@ -87,11 +87,11 @@ export default {
   methods: {
     confirm() {
       this.visible = false;
-      this.$emit('onConfirm');
+      this.$emit('on-confirm');
     },
     cancel() {
       this.visible = false;
-      this.$emit('onCancel');
+      this.$emit('on-cancel');
     }
   }
 };


### PR DESCRIPTION
* [x] Make sure you follow Element's contributing guide 
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.


The PR fix #19450 onConfirm event mentioned and the onCancel event does not take effect.

![image](https://user-images.githubusercontent.com/20190812/85226086-2f07cd80-b408-11ea-9f73-d77e5eecebd3.png)

The [vue official document](https://vuejs.org/v2/guide/components-custom-events.html#Event-Names) mentions that it is best to use kebab-case for custom event names, to prevent the impact of DOM templates will be automatically transformed to lowercase 