### PR TITLE
Dialog: only destroy slot when destroyOnClose is true

### DIFF
--- a/packages/dialog/src/component.vue
+++ b/packages/dialog/src/component.vue
@@ -9,7 +9,6 @@
       @click.self="handleWrapperClick">
       <div
         role="dialog"
-        :key="key"
         aria-modal="true"
         :aria-label="title || 'dialog'"
         :class="['el-dialog', { 'is-fullscreen': fullscreen, 'el-dialog--center': center }, customClass]"
@@ -112,8 +111,7 @@
 
     data() {
       return {
-        closed: false,
-        key: 0
+        closed: false
       };
     },
 
@@ -133,9 +131,7 @@
           this.$el.removeEventListener('scroll', this.updatePopper);
           if (!this.closed) this.$emit('close');
           if (this.destroyOnClose) {
-            this.$nextTick(() => {
-              this.key++;
-            });
+            this.rendered = false;
           }
         }
       }


### PR DESCRIPTION
destroyOnClose would destroy and recreate slot when dialog closed, this commit only destroy slot

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

- Related Issues
#18957 