### PR TITLE
fix: 解决父组件非table-column组件（自定义的递归组件）情况下，未正确动态删除列的问题

### DIFF
--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -300,8 +300,8 @@ export default {
   mounted() {
     const owner = this.owner;
     const parent = this.columnOrTableParent;
-    const children = this.isSubColumn ? parent.$el.children : parent.$refs.hiddenColumns.children;
-    const columnIndex = this.getColumnElIndex(children, this.$el);
+    const children = this.$parent.$children;
+    const columnIndex = this.getColumnElIndex(children, this);
 
     owner.store.commit('insertColumn', this.columnConfig, columnIndex, this.isSubColumn ? parent.columnConfig : null);
   },


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8044303/86138117-9caaac80-bb20-11ea-8728-a87993f96f3c.png)

当table-column组件之间存在递归组件，由于无法正确获取父table-column组件，导致动态删除列出错。

具体实现如下：
```javascript
<template>
  <div>
    <template v-for="item in pruneNodes">
      <el-table-column v-if="item.children.length" :label="item.node_name" :key="item.node_name">
        <FilterColumns :pruneNodes="item.children" :field="field"/>
      </el-table-column>
      <el-table-column v-else :prop="item.node_name" :label="item.node_name" :key="item.node_name">
        <template slot-scope="scope">
          {{scope.row.flattenNodes[item.node_name][field]}}
        </template>
      </el-table-column>
    </template>
  </div>
</template>
<script>
export default {
  name: 'FilterColumns',
  props: {
    pruneNodes: {
      type: Array,
      default: []
    },
    field: {
      type: String,
      default: ''
    }
  }
};
</script>
```