### PR TITLE
InfiniteScroll: fix shouldTrigger error when then container is window

### DIFF
--- a/packages/infinite-scroll/src/main.js
+++ b/packages/infinite-scroll/src/main.js
@@ -92,8 +92,10 @@ const handleScroll = function(cb) {
 
   if (disabled) return;
 
-  const containerInfo = container.getBoundingClientRect();
-  if (!containerInfo.width && !containerInfo.height) return;
+  if(container !== window) {
+    const containerInfo = container.getBoundingClientRect();
+    if (!containerInfo.width && !containerInfo.height) return;
+  }
 
   let shouldTrigger = false;
 

--- a/packages/infinite-scroll/src/main.js
+++ b/packages/infinite-scroll/src/main.js
@@ -92,7 +92,7 @@ const handleScroll = function(cb) {
 
   if (disabled) return;
 
-  if(container !== window) {
+  if (container !== window) {
     const containerInfo = container.getBoundingClientRect();
     if (!containerInfo.width && !containerInfo.height) return;
   }

--- a/packages/infinite-scroll/src/main.js
+++ b/packages/infinite-scroll/src/main.js
@@ -9,18 +9,18 @@ import {
   getScrollContainer
 } from 'element-ui/src/utils/dom';
 
-const getStyleComputedProperty = (element, property) => {
-  if (element === window) {
-    element = document.documentElement;
-  }
+// const getStyleComputedProperty = (element, property) => {
+//   if (element === window) {
+//     element = document.documentElement;
+//   }
 
-  if (element.nodeType !== 1) {
-    return [];
-  }
-  // NOTE: 1 DOM access here
-  const css = window.getComputedStyle(element, null);
-  return property ? css[property] : css;
-};
+//   if (element.nodeType !== 1) {
+//     return [];
+//   }
+//   // NOTE: 1 DOM access here
+//   const css = window.getComputedStyle(element, null);
+//   return property ? css[property] : css;
+// };
 
 const entries = (obj) => {
   return Object.keys(obj || {})

--- a/packages/infinite-scroll/src/main.js
+++ b/packages/infinite-scroll/src/main.js
@@ -84,9 +84,7 @@ const getScrollOptions = (el, vm) => {
   }, {});
 };
 
-const getElementTop = el => {
-  return el === window ? 0 : el.getBoundingClientRect().top;
-};
+const getElementTop = el => el.getBoundingClientRect().top;
 
 const handleScroll = function(cb) {
   const { el, vm, container, observer } = this[scope];
@@ -104,10 +102,10 @@ const handleScroll = function(cb) {
     const scrollBottom = container.scrollTop + getClientHeight(container);
     shouldTrigger = container.scrollHeight - scrollBottom <= distance;
   } else {
-    const heightBelowTop = getOffsetHeight(el) + getElementTop(el) - getElementTop(container);
-    const offsetHeight = getOffsetHeight(container);
-    const borderBottom = Number.parseFloat(getStyleComputedProperty(container, 'borderBottomWidth'));
-    shouldTrigger = heightBelowTop - offsetHeight + borderBottom <= distance;
+    const containerTop = container === window ? 0 : getElementTop(container);
+    const heightBelowTop = getOffsetHeight(el) + getElementTop(el) - containerTop;
+    const offsetHeight = getClientHeight(container);
+    shouldTrigger = heightBelowTop - offsetHeight <= distance;
   }
 
   if (shouldTrigger && isFunction(cb)) {

--- a/packages/infinite-scroll/src/main.js
+++ b/packages/infinite-scroll/src/main.js
@@ -84,7 +84,9 @@ const getScrollOptions = (el, vm) => {
   }, {});
 };
 
-const getElementTop = el => el.getBoundingClientRect().top;
+const getElementTop = el => {
+  return el === window ? 0 : el.getBoundingClientRect().top;
+}
 
 const handleScroll = function(cb) {
   const { el, vm, container, observer } = this[scope];

--- a/packages/infinite-scroll/src/main.js
+++ b/packages/infinite-scroll/src/main.js
@@ -86,7 +86,7 @@ const getScrollOptions = (el, vm) => {
 
 const getElementTop = el => {
   return el === window ? 0 : el.getBoundingClientRect().top;
-}
+};
 
 const handleScroll = function(cb) {
   const { el, vm, container, observer } = this[scope];


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

v-infinite-scroll can not get getBoundingClientRect property when the el is window
