### PR TITLE
Tree: Fix drop indicator position

### DIFF
--- a/packages/tree/src/tree.vue
+++ b/packages/tree/src/tree.vue
@@ -422,12 +422,13 @@
           dropType = 'none';
         }
 
+        const nodeContentPosition = dropNode.$el.querySelector('.el-tree-node__content').getBoundingClientRect();
         const iconPosition = dropNode.$el.querySelector('.el-tree-node__expand-icon').getBoundingClientRect();
         const dropIndicator = this.$refs.dropIndicator;
         if (dropType === 'before') {
-          indicatorTop = iconPosition.top - treePosition.top;
+          indicatorTop = nodeContentPosition.top - treePosition.top;
         } else if (dropType === 'after') {
-          indicatorTop = iconPosition.bottom - treePosition.top;
+          indicatorTop = nodeContentPosition.bottom - treePosition.top;
         }
         dropIndicator.style.top = indicatorTop + 'px';
         dropIndicator.style.left = (iconPosition.right - treePosition.left) + 'px';


### PR DESCRIPTION
The `Tree` component computes the position of the dragged node using the chevron icon as reference. This works in most of the cases but, when the content in a row is taller than the icon, the line appears in the wrong position (see screenshot below, in the "Before" section).

This fix uses the `<div>` wrapping the entire row's content to compute the vertical position of the indicator (see screenshot in the "After" section).

## Before
<img width="1048" alt="drop-position__BEFORE" src="https://user-images.githubusercontent.com/54443499/87557433-32654080-c6b8-11ea-8409-ef1470eb5f54.png">


## After
<img width="1072" alt="drop-position__AFTER" src="https://user-images.githubusercontent.com/54443499/87557455-37c28b00-c6b8-11ea-98c1-11bb16d7be3e.png">


* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.
