### PR TITLE
fixed #19871 导航菜单没有跳转，却被设置为选中状态

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -258,18 +258,18 @@
         const oldActiveIndex = this.activeIndex;
         const hasIndex = item.index !== null;
 
-        if (hasIndex) {
-          this.activeIndex = item.index;
-        }
-
-        this.$emit('select', index, indexPath, item);
-
-        if (this.mode === 'horizontal' || this.collapse) {
-          this.openedMenus = [];
-        }
-
         if (this.router && hasIndex) {
-          this.routeToItem(item, (error) => {
+          this.routeToItem(item, () => {
+            if (hasIndex) {
+              this.activeIndex = item.index;
+            }
+
+            this.$emit('select', index, indexPath, item);
+
+            if (this.mode === 'horizontal' || this.collapse) {
+              this.openedMenus = [];
+            }
+          }, (error) => {
             this.activeIndex = oldActiveIndex;
             if (error) {
               // vue-router 3.1.0+ push/replace cause NavigationDuplicated error 
@@ -296,10 +296,10 @@
           submenu && this.openMenu(index, submenu.indexPath);
         });
       },
-      routeToItem(item, onError) {
+      routeToItem(item, onComplete = () => {}, onError) {
         let route = item.route || item.index;
         try {
-          this.$router.push(route, () => {}, onError);
+          this.$router.push(route, onComplete, onError);
         } catch (e) {
           console.error(e);
         }


### PR DESCRIPTION
只有跳转成功后，才能设置导航菜单选中状态，  
没有跳转成功，则不会设置导航菜单的选中状态。

所以设置菜单的选中状态应该写在跳转成功的回调函数中，而不是先设置选中状态，却不管有没有跳转成功。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
