### PR TITLE
Input: fix cursor bug in mac safari browser(#19893)

### DIFF
--- a/packages/theme-chalk/src/input.scss
+++ b/packages/theme-chalk/src/input.scss
@@ -114,7 +114,6 @@
     display: inline-block;
     font-size: inherit;
     height: $--input-height;
-    line-height: $--input-height;
     outline: none;
     padding: 0 15px;
     transition: $--border-transition-base;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for your PR.

This problem is caused by line-height property that affects the input cursor height in the safari browser on Mac. So, I deleted the line-height property which has no side effect to other components.