### PR TITLE
fix(utils-clickoutside.js): 去除不必要的判断逻辑

### DIFF
--- a/src/utils/clickoutside.js
+++ b/src/utils/clickoutside.js
@@ -21,7 +21,6 @@ function createDocumentHandler(el, binding, vnode) {
       !mousedown.target ||
       el.contains(mouseup.target) ||
       el.contains(mousedown.target) ||
-      el === mouseup.target ||
       (vnode.context.popperElm &&
       (vnode.context.popperElm.contains(mouseup.target) ||
       vnode.context.popperElm.contains(mousedown.target)))) return;


### PR DESCRIPTION
1. 当el === mouseup.target时，el.contains(mouseup.target)是成立的，所以el === mouseup.targe是多余的判断。
2. 参考： document.body.contains(document.body) === true 和CDN链接：https://developer.mozilla.org/zh-CN/docs/Web/API/Node/contains。
3. 如果el === mouseup.targe是必要的，希望能给个解释说明，谢谢
