### PR TITLE
Select: fixed hoverIndex calculation error

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -437,6 +437,7 @@
         if (this.defaultFirstOption && (this.filterable || this.remote) && this.filteredOptionsCount) {
           this.checkDefaultFirstOption();
         }
+        this.resetHoverIndex();
       }
     },
 


### PR DESCRIPTION
1. Solved the problem that the Select component that supports remote search selects inconsistent options before and after changes in options data
2. When v-for traversal generates option, do not configure key. Add pr this time, and solve issue#19557