### PR TITLE
PopConfirm：fix ’onConfirm‘&’onCancel‘ to ’on-confirm‘&’on-cancel‘

### DIFF
--- a/packages/popconfirm/src/main.vue
+++ b/packages/popconfirm/src/main.vue
@@ -87,11 +87,11 @@ export default {
   methods: {
     confirm() {
       this.visible = false;
-      this.$emit('onConfirm');
+      this.$emit('on-confirm');
     },
     cancel() {
       this.visible = false;
-      this.$emit('onCancel');
+      this.$emit('on-cancel');
     }
   }
 };


### PR DESCRIPTION
$emit()方法里不支持带大写的参数名。
Vue.prototype.$emit = function (event) {
……
var lowerCaseEvent = event.toLowerCase();
……
}

Please make sure these boxes are checked before submitting your PR, thank you!

* [√] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [√] Make sure you are merging your commits to `dev` branch.
* [√] Add some descriptions and refer relative issues for you PR.
