### PR TITLE
DatePicker: el-range-input inherts background-color by theme

### DIFF
--- a/packages/theme-chalk/src/date-picker/picker.scss
+++ b/packages/theme-chalk/src/date-picker/picker.scss
@@ -64,6 +64,7 @@
     text-align: center;
     font-size: $--font-size-base;
     color: $--color-text-regular;
+    background-color: $--input-background-color;
 
     &::placeholder {
       color: $--color-text-placeholder;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

When I custom the theme, I found a style of background-color was  missing in the DatePicker component.
The el-range-input have not inherted the background-color by theme。

Here is the screenshot.

![el-range-picker-no-background.png](https://i.loli.net/2020/08/31/Njn1TvAFgq4JOP3.png)

When I use my custom theme, I found the el-range-input have not  inherted the background-color by theme.

![el-date-picker.png](https://i.loli.net/2020/08/31/KcBVHuIMJ1FDh3y.png)

![el-range-input-no-background-result.png](https://i.loli.net/2020/08/31/NePoxiOFXRwJ1Cb.png)

So I add the background-color property to the el-range-input, like this.

![el-range-input-add-background-result.png](https://i.loli.net/2020/08/31/WYiTusgH5abAnLz.png)

Change this scss file : `packages/theme-chalk/src/date-picker/picker.scss`

```
.el-range-input {
    appearance: none;
    border: none;
    outline: none;
    display: inline-block;
    height: 100%;
    margin: 0;
    padding: 0;
    width: 39%;
    text-align: center;
    font-size: $--font-size-base;
    color: $--color-text-regular;
    background-color: $--input-background-color;

    &::placeholder {
      color: $--color-text-placeholder;
    }
  }
```

It seems to be working normally .
