### PR TITLE
el-time-select:picker-options: allow reverse time displays

### DIFF
--- a/packages/date-picker/src/panel/time-select.vue
+++ b/packages/date-picker/src/panel/time-select.vue
@@ -153,7 +153,7 @@
 
     computed: {
       items() {
-        const reverse = compareTime(this.start, this.end) > 0
+        const reverse = compareTime(this.start, this.end) > 0;
         const start = reverse ? this.end : this.start;
         const end = reverse ? this.start : this.end;
         const step = this.step;

--- a/packages/date-picker/src/panel/time-select.vue
+++ b/packages/date-picker/src/panel/time-select.vue
@@ -153,8 +153,9 @@
 
     computed: {
       items() {
-        const start = this.start;
-        const end = this.end;
+        const reverse = compareTime(this.start, this.end) > 0
+        const start = reverse ? this.end : this.start;
+        const end = reverse ? this.start : this.end;
         const step = this.step;
 
         const result = [];
@@ -171,7 +172,7 @@
           }
         }
 
-        return result;
+        return reverse ? result.reverse() : result;
       }
     }
   };


### PR DESCRIPTION
Allow reverse time displays
example: from 23:30 down to 22:00 with step 00:30 will be rendered as
23:30
23:00
22:30
22:00

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
