### PR TITLE
Cascader: fix lazyLoad value zero error

### DIFF
--- a/packages/cascader-panel/src/store.js
+++ b/packages/cascader-panel/src/store.js
@@ -1,5 +1,6 @@
 import Node from './node';
 import { coerceTruthyValueToArray, valueEquals } from 'element-ui/src/utils/util';
+import { isDef } from 'element-ui/src/utils/shared'
 
 const flatNodes = (data, leafOnly) => {
   return data.reduce((res, node) => {
@@ -51,7 +52,7 @@ export default class Store {
   }
 
   getNodeByValue(value) {
-    if (value) {
+    if (isDef(value)) {
       const nodes = this.getFlattedNodes(false, !this.config.lazy)
         .filter(node => (valueEquals(node.path, value) || node.value === value));
       return nodes && nodes.length ? nodes[0] : null;


### PR DESCRIPTION
修复 cascader 开启 lazyLoad 以后数据里面 value 有 0 的情况下报错的问题

Please make sure these boxes are checked before submitting your PR, thank you!

* [Y] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [Y] Make sure you are merging your commits to `dev` branch.
* [Y] Add some descriptions and refer relative issues for you PR.
