### PR TITLE
fix#transfer组件数据量大卡顿优化

### DIFF
--- a/packages/transfer/src/main.vue
+++ b/packages/transfer/src/main.vue
@@ -138,12 +138,25 @@
       },
   
       sourceData() {
-        return this.data.filter(item => this.value.indexOf(item[this.props.key]) === -1);
+        let valueObj = {}
+        this.value.forEach((item,index)=>{
+          valueObj[item] = true
+        })
+        return this.data.filter(
+          (item) => !valueObj[item[this.props.key]]
+        );
       },
 
       targetData() {
         if (this.targetOrder === 'original') {
-          return this.data.filter(item => this.value.indexOf(item[this.props.key]) > -1);
+          let valueObj = {}
+          this.value.forEach((item,index)=>{
+            valueObj[item] = true
+          })
+          let data =  this.data.filter(
+            (item) => valueObj[item[this.props.key]]
+          );
+          return data
         } else {
           return this.value.reduce((arr, cur) => {
             const val = this.dataObj[cur];
@@ -203,18 +216,27 @@
         let currentValue = this.value.slice();
         const itemsToBeMoved = [];
         const key = this.props.key;
-        this.data.forEach(item => {
+
+        let leftCheckedKeyPropsObj = {};
+        this.leftChecked.forEach((item, index) => {
+          leftCheckedKeyPropsObj[item] = true;
+        });
+
+        let valueKeyPropsObj = {};
+        this.value.forEach((item, index) => {
+          valueKeyPropsObj[item] = true;
+        });
+        this.data.forEach((item) => {
           const itemKey = item[key];
-          if (
-            this.leftChecked.indexOf(itemKey) > -1 &&
-            this.value.indexOf(itemKey) === -1
-          ) {
+          if ( 
+            leftCheckedKeyPropsObj[itemKey] && 
+            !valueKeyPropsObj[itemKey] ) {
             itemsToBeMoved.push(itemKey);
           }
         });
         currentValue = this.targetOrder === 'unshift'
-          ? itemsToBeMoved.concat(currentValue)
-          : currentValue.concat(itemsToBeMoved);
+            ? itemsToBeMoved.concat(currentValue)
+            : currentValue.concat(itemsToBeMoved);
         this.$emit('input', currentValue);
         this.$emit('change', currentValue, 'right', this.leftChecked);
       },

--- a/packages/transfer/src/transfer-panel.vue
+++ b/packages/transfer/src/transfer-panel.vue
@@ -230,9 +230,18 @@
 
     methods: {
       updateAllChecked() {
-        const checkableDataKeys = this.checkableData.map(item => item[this.keyProp]);
-        this.allChecked = checkableDataKeys.length > 0 &&
-          checkableDataKeys.every(item => this.checked.indexOf(item) > -1);
+        let start = new Date().getTime();
+        let checkObj = {};
+        this.checked.forEach((item, index) => {
+          checkObj[item] = true;
+        });
+        // 通过对象的k-v对应，n(1)的方式寻找数组中是否存在某元素
+        this.allChecked =
+          this.checkableData.length > 0 &&
+          this.checked.length > 0 &&
+          this.checkableData.every((item) => checkObj[item[this.keyProp]]);
+        // 上面被注释的源码是最耗时的，所有一直看耗时就可以了
+        console.log("updateAllCheckedEnd", new Date().getTime() - start);
       },
 
       handleAllCheckedChange(value) {


### PR DESCRIPTION
当transfer组件渲染很多数据量的时候（上千），即便我做了分页或者懒加载操作，消耗主要在script，也就是源码的数组比较。源码的数据比较大量存在n^2方即便，所以很卡，优化成2n的复杂度即可。