### PR TITLE
MessageBox: fix $prompt verification style error

### DIFF
--- a/packages/theme-chalk/src/message-box.scss
+++ b/packages/theme-chalk/src/message-box.scss
@@ -86,7 +86,7 @@
     padding-top: 15px;
 
     & input.invalid,
-    & textarea.invalid{
+    & textarea.invalid {
       border-color: $--color-danger;
       &:focus {
         border-color: $--color-danger;

--- a/packages/theme-chalk/src/message-box.scss
+++ b/packages/theme-chalk/src/message-box.scss
@@ -85,7 +85,8 @@
   @include e(input) {
     padding-top: 15px;
 
-    & input.invalid {
+    & input.invalid,
+    & textarea.invalid{
       border-color: $--color-danger;
       &:focus {
         border-color: $--color-danger;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
MessageBox when the inputType of $prompt is textarea and the input box verification fails, the border does not turn red

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
