### PR TITLE
cascader-panel: Fix the two-way binding echo problem of cascader in lazy mode

### DIFF
--- a/packages/cascader-panel/src/cascader-node.vue
+++ b/packages/cascader-panel/src/cascader-node.vue
@@ -58,7 +58,7 @@
         if (!checkStrictly && isDisabled || node.loading) return;
 
         if (config.lazy && !node.loaded) {
-          panel.lazyLoad(node, () => {
+          panel.lazyLoad(node, panel.checkedValue, () => {
             // do not use cached leaf value here, invoke this.isLeaf to get new value.
             const { isLeaf } = this;
 

--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -105,7 +105,7 @@ export default {
 
   data() {
     return {
-      checkedValue: null,
+      checkedValue: this.value,
       checkedNodePaths: [],
       store: [],
       menus: [],
@@ -156,12 +156,6 @@ export default {
     }
   },
 
-  mounted() {
-    if (!isEmpty(this.value)) {
-      this.syncCheckedValue();
-    }
-  },
-
   methods: {
     initStore() {
       const { config, options } = this;
@@ -174,8 +168,16 @@ export default {
       }
     },
     syncCheckedValue() {
-      const { value, checkedValue } = this;
-      if (!isEqual(value, checkedValue)) {
+      const { value, checkedValue, config, options } = this;
+      if (isEqual(value, checkedValue)) {
+        return
+      }
+      if (config.lazy && isEmpty(options)) {
+        const [nodeValue] = value.filter((item, index) => (!checkedValue || checkedValue[index] !== item));
+        const checkedNode = this.store.getNodeByValue(nodeValue);
+        this.checkedValue = value;
+        this.lazyLoad(checkedNode,this.checkedValue)
+      } else {
         this.checkedValue = value;
         this.syncMenuState();
       }
@@ -286,7 +288,7 @@ export default {
     handleCheckChange(value) {
       this.checkedValue = value;
     },
-    lazyLoad(node, onFullfiled) {
+    lazyLoad(node, checkedValue, onFullfiled) {
       const { config } = this;
       if (!node) {
         node = node || { root: true, level: 0 };
@@ -294,6 +296,7 @@ export default {
         this.menus = [this.store.getNodes()];
       }
       node.loading = true;
+      checkedValue = checkedValue || this.checkedValue;
       const resolve = dataList => {
         const parent = node.root ? null : node;
         dataList && dataList.length && this.store.appendNodes(dataList, parent);
@@ -301,8 +304,8 @@ export default {
         node.loaded = true;
 
         // dispose default value on lazy load mode
-        if (Array.isArray(this.checkedValue)) {
-          const nodeValue = this.checkedValue[this.loadCount++];
+        if (Array.isArray(checkedValue)) {
+          const nodeValue = checkedValue[node.level];
           const valueKey = this.config.value;
           const leafKey = this.config.leaf;
 
@@ -310,12 +313,12 @@ export default {
             const checkedNode = this.store.getNodeByValue(nodeValue);
 
             if (!checkedNode.data[leafKey]) {
-              this.lazyLoad(checkedNode, () => {
+              this.lazyLoad(checkedNode, checkedValue, () => {
                 this.handleExpand(checkedNode);
               });
             }
 
-            if (this.loadCount === this.checkedValue.length) {
+            if (node.level === this.checkedValue.length - 1) {
               this.$parent.computePresentText();
             }
           }


### PR DESCRIPTION
…azy mode

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Cascader 级联选择器 动态加载时只有在初始化时可以设定默认值，而当默认值是异步返回选择器已初始化完成时。则无法通过直接改变与级联选择器双向绑定的数据从而改变级联选择器的回显数据。
此次pr修复了这个问题。