### PR TITLE
fix: Update Ukrainian locale (ua.js)

### DIFF
--- a/src/locale/lang/ua.js
+++ b/src/locale/lang/ua.js
@@ -1,7 +1,7 @@
 export default {
   el: {
     colorpicker: {
-      confirm: 'OK',
+      confirm: 'Обрати',
       clear: 'Очистити'
     },
     datepicker: {
@@ -107,14 +107,14 @@ export default {
       hasCheckedFormat: '{checked}/{total} вибрано'
     },
     image: {
-      error: 'FAILED' // to be translated
+      error: 'ПОМИЛКА'
     },
     pageHeader: {
-      title: 'Back' // to be translated
+      title: 'Назад'
     },
     popconfirm: {
-      confirmButtonText: 'Yes', // to be translated
-      cancelButtonText: 'No' // to be translated
+      confirmButtonText: 'Так',
+      cancelButtonText: 'Ні'
     }
   }
 };


### PR DESCRIPTION
Translated missing translations in "colorpicker.confirm", "image.error",  "pageHeader. title", "popconfirm. confirmButtonText" and "popconfirm. cancelButtonText"
Fixed translation in "colorpicker.confirm", because a "OK" is a anglicism, in ukrainian correct to say "Обрати".

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
