### PR TITLE
popper: fix 关闭状态下不必要的update

### DIFF
--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -222,6 +222,9 @@
      * @memberof Popper
      */
     Popper.prototype.update = function() {
+        if (typeof this._options.beforeUpdate === 'function' && this._options.beforeUpdate() === false) {
+            return;
+        }
         var data = { instance: this, styles: {} };
 
         // store placement inside the data object, modifiers will be able to edit `placement` if needed

--- a/src/utils/vue-popper.js
+++ b/src/utils/vue-popper.js
@@ -84,6 +84,9 @@ export default {
         return;
       }
 
+      if (this.popperOptions.beforeUpdate === undefined) {
+        this.popperOptions.beforeUpdate = () => this.value;
+      }
       const options = this.popperOptions;
       const popper = this.popperElm = this.popperElm || this.popper || this.$refs.popper;
       let reference = this.referenceElm = this.referenceElm || this.reference || this.$refs.reference;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [O] Make sure you follow Element's contributing guide .
* [O] Make sure you are merging your commits to `dev` branch.
* [O] Add some descriptions and refer relative issues for you PR.

https://github.com/ElemeFE/element/issues/20353

popperjs监听了scroll/resize事件去更新位置

原有逻辑是在弹窗收起的动画结束后，才销毁popperJS对象

导致在调用隐藏到动画结束的期间，容器有scroll/resize事件，

就会触发popper去重新计算位置，导致闪烁
