### PR TITLE
date-table: fixed offsetFromStart falsy w/ getStartDateOfMonth/firstD…

### DIFF
--- a/packages/date-picker/src/basic/date-table.vue
+++ b/packages/date-picker/src/basic/date-table.vue
@@ -106,8 +106,9 @@
     computed: {
       offsetDay() {
         const week = this.firstDayOfWeek;
-        // 周日为界限，左右偏移的天数，3217654 例如周一就是 -1，目的是调整前两行日期的位置
-        return week > 3 ? 7 - week : -week;
+        const startDate = this.startDate;
+        const firstDay = getFirstDayOfMonth(new Date(this.year, this.month, 1));
+        return (startDate - firstDay) > 60 * 60 * 24 * 7 ? 7 - week : -week;
       },
 
       WEEKS() {


### PR DESCRIPTION
…ayOfMonth on the same row and 1 < firstDayOfWeek < 4

Fix https://github.com/ElemeFE/element/issues/20362

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
