### PR TITLE
Fix for [Bug Report] When using a 2 digit date format, typing a 4 digit date truncates the year instead of using the last 2 digits #20390

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -34,7 +34,7 @@
    */
   var fecha = {};
   var token = /d{1,4}|M{1,4}|yy(?:yy)?|S{1,3}|Do|ZZ|([HhMsDm])\1?|[aA]|"[^"]*"|'[^']*'/g;
-  var twoDigits = '\\d\\d?';
+  var twoDigits = '\\d\\d?\\d?\\d?';
   var threeDigits = '\\d{3}';
   var fourDigits = '\\d{4}';
   var word = '[^\\s]+';


### PR DESCRIPTION
[Bug Report] When using a 2 digit date format, typing a 4 digit date truncates the year instead of using the last 2 digits #20390
https://github.com/ElemeFE/element/issues/20390

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
