### PR TITLE
Cascader: fix Cascader getCheckedNodes data sort

### DIFF
--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -356,13 +356,15 @@ export default {
     },
     getCheckedNodes(leafOnly) {
       const { checkedValue, multiple } = this;
+
+      if (isEmpty(checkedValue)) {
+        return [];
+      }
+
       if (multiple) {
-        const nodes = this.getFlattedNodes(leafOnly);
-        return nodes.filter(node => node.checked);
+        return checkedValue.map(val => this.getNodeByValue(val, leafOnly));
       } else {
-        return isEmpty(checkedValue)
-          ? []
-          : [this.getNodeByValue(checkedValue)];
+        return [this.getNodeByValue(checkedValue)];
       }
     },
     clearCheckedNodes() {

--- a/packages/cascader-panel/src/store.js
+++ b/packages/cascader-panel/src/store.js
@@ -50,9 +50,9 @@ export default class Store {
       : flatNodes(this.nodes, leafOnly);
   }
 
-  getNodeByValue(value) {
+  getNodeByValue(value, leafOnly = false) {
     if (value) {
-      const nodes = this.getFlattedNodes(false, !this.config.lazy)
+      const nodes = this.getFlattedNodes(leafOnly, !this.config.lazy)
         .filter(node => (valueEquals(node.path, value) || node.value === value));
       return nodes && nodes.length ? nodes[0] : null;
     }


### PR DESCRIPTION
修复Cascader getCheckedNodes 返回的勾选节点顺序和value传入值的顺序不一致的问题。该问题会导致多选模式下未按节点深度优先遍历顺序传入value值的情况下，删除tag标签会错误删除勾选数据问题。