### PR TITLE
Table: fix table summary bug when property is nested object properties

### DIFF
--- a/packages/table/src/table-footer.js
+++ b/packages/table/src/table-footer.js
@@ -16,7 +16,19 @@ export default {
           sums[index] = this.sumText;
           return;
         }
-        const values = this.store.states.data.map(item => Number(item[column.property]));
+        const values = this.store.states.data.map(item => {
+          if (column.property && column.property.includes('.')) {
+            const paths = column.property.split('.');
+            let prop;
+            for (let index = 0; index <= paths.length; index++) {
+              prop = paths.shift();
+              item = item[prop];
+            }
+            return Number(item);
+          } else {
+            return Number(item[column.property]);
+          }
+        });
         const precisions = [];
         let notNumber = true;
         values.forEach(value => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

When prop attribute of  'el-table-column' is nested object properties.  eg:`prop='obj.status'` or `prop='obj.xxx.xxx'`
The default  table summary method doesn't work
