### PR TITLE
Cascader: fix多选状态下，首次输入搜索词，选中项目后，搜索词被清空

### DIFF
--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -329,7 +329,7 @@ export default {
       deep: true
     },
     presentText(val) {
-      this.inputValue = val;
+      if(!this.multiple) this.inputValue = val;
     },
     presentTags(val, oldVal) {
       if (this.multiple && (val.length || oldVal.length)) {


### PR DESCRIPTION
多选可搜索时，首次输入搜索词，选中下拉列表的项目后，input框中搜索词被清空