### PR TITLE
Cascader: fix the problem of search term retention

### DIFF
--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -332,7 +332,7 @@ export default {
       deep: true
     },
     presentText(val) {
-      this.inputValue = val;
+      if (!this.multiple) this.inputValue = val;
     },
     presentTags(val, oldVal) {
       if (this.multiple && (val.length || oldVal.length)) {


### PR DESCRIPTION
Cascader多选可搜索时，首次输入搜索词，选中下拉列表的项后，input框中搜索词被清空