### PR TITLE
ElUpload: fix code exception when use custom http-request to upload file

### DIFF
--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -174,31 +174,30 @@ export default {
     },
     handleProgress(ev, rawFile) {
       const file = this.getFile(rawFile);
-      this.onProgress(ev, file, this.uploadFiles);
-      file.status = 'uploading';
-      file.percentage = ev.percent || 0;
+      if (file) {
+        this.onProgress(ev, file, this.uploadFiles);
+        file.status = 'uploading';
+        file.percentage = ev.percent || 0;
+      }
     },
     handleSuccess(res, rawFile) {
       const file = this.getFile(rawFile);
-
       if (file) {
         file.status = 'success';
         file.response = res;
-
         this.onSuccess(res, file, this.uploadFiles);
         this.onChange(file, this.uploadFiles);
       }
     },
     handleError(err, rawFile) {
       const file = this.getFile(rawFile);
-      const fileList = this.uploadFiles;
-
-      file.status = 'fail';
-
-      fileList.splice(fileList.indexOf(file), 1);
-
-      this.onError(err, file, this.uploadFiles);
-      this.onChange(file, this.uploadFiles);
+      if (file) {
+        const fileList = this.uploadFiles;
+        file.status = 'fail';
+        fileList.splice(fileList.indexOf(file), 1);
+        this.onError(err, file, this.uploadFiles);
+        this.onChange(file, this.uploadFiles);
+      }
     },
     handleRemove(file, raw) {
       if (raw) {

--- a/packages/upload/src/upload.vue
+++ b/packages/upload/src/upload.vue
@@ -122,12 +122,13 @@ export default {
       if (file) {
         let uid = file;
         if (file.uid) uid = file.uid;
-        if (reqs[uid]) {
+        if (reqs[uid] && typeof reqs[uid].abort === 'function') {
           reqs[uid].abort();
         }
+        delete reqs[uid];
       } else {
         Object.keys(reqs).forEach((uid) => {
-          if (reqs[uid]) reqs[uid].abort();
+          if (reqs[uid] && typeof reqs[uid].abort === 'function') reqs[uid].abort();
           delete reqs[uid];
         });
       }


### PR DESCRIPTION
ElUpload组件，解决当使用`http-request`自定义上传时，程序抛异常的问题。
场景分析如下：
# 场景1
    文件在上传中时，点击`x`图标取消上传。
此时会触发`remove`事件 --> 然后执行`handleRemove` --> `doRemove`方法。 `doRemove`会先调用`this.abort`方法 -->然后调用`upload.vue`中的`abort`方法 -->然后执行`reqs[uid].abort()`方法。`req[uid]`是`http-request`执行后的返回值，默认情况下是一个`xhr`对象。但如果是用户自定义的`http-reequest`，返回值可能是任何类型的值，不一定拥有`abort`方法，此时执行`reqs[uid].abort()`方法，程序会抛异常。

# 场景2
    上传第一个分片，在服务器响应前，取消上传。
利用ElUpload做分片上传，此时我们选择设置分片较大（（例如100M的文件，分10片，循环上传）），或者利用chrome降低网络环境。
我们利用以下伪代码说明：
    此时ElUpload会执行`场景1`的操作并删除文件。并且回调我们设置的`promise.abort`方法，由于我们在`promise.abort`中执行了`rejectFn`，此时会触发`this.onError`（upload.vue中的`options.onError`方法）-->然后执行内部代码`handleError`（upload\src\index.vue中定义），此时未判断`file`是否`为undefined`，代码抛异常。
同样，由于我们是通过`rejected`变量的方式停止了循环，并未执行`cancelRequest()` 来取消这个上传请求。因此在响应到达后，执行伪代码中的`onProgress`，执行内部`handleProgress`，代码内部会抛异常。
```js
let { file, data, filename, onProgress } = options;
    let totalChunks = 10;
    let offset = 0;
    let rejected = false;
    // reject函数
    let rejectFn = () => { };
    // 用于取消axios的请求
    // let cancelRequest = null;
    const loadNextChunk = (offset, resolve, reject) => {
        if (rejected) return;
        let formData = {};
        // 伪代码，模拟上传
        axios.post('upload-url',formData, {
            cancelToken: new CancelToken(function executor (c) {
                // cancelRequest = c;
            })
        }).then(res => {
            // cancelRequest = null;
            offset++;
            if (offset == totalChunks) {
                onProgress({ percent: 100 });
                resolve();
            } else {
                // 如果没有取消xhr请求，服务器响应后，依然会执行onProgress方法，ElUpload内部会报错。
                onProgress({ percent: offset * 100 / totalChunks });
                loadNextChunk(offset, resolve, reject);
            }
        }).catch(err => {
            cancelRequest = null;
            rejected = true;
            reject(err);
        });
    };
    let promise = new Promise((resolve, reject) => {
        rejectFn = reject;
        loadNextChunk(offset, resolve, reject);
    });
    // 返回的对象添加abort方法
    promise.abort = () => {
        rejected = true;
        rejectFn();
        // cancelRequest && cancelRequest('i canceled the request');
    };
    return promise;
```
