### PR TITLE
日期范围

### DIFF
--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -406,8 +406,9 @@
           this.minDate = null;
           this.maxDate = null;
         } else if (Array.isArray(newVal)) {
-          this.minDate = isDate(newVal[0]) ? new Date(newVal[0]) : null;
-          this.maxDate = isDate(newVal[1]) ? new Date(newVal[1]) : null;
+          const defaultTime = this.defaultTime || [];
+          this.minDate = isDate(newVal[0]) ? modifyWithTimeString(new Date(newVal[0]), defaultTime[0]) : null;
+          this.maxDate = isDate(newVal[1]) ? modifyWithTimeString(new Date(newVal[1]), defaultTime[1]) : null;
           if (this.minDate) {
             this.leftDate = this.minDate;
             if (this.unlinkPanels && this.maxDate) {
@@ -658,7 +659,7 @@
         return Array.isArray(value) &&
           value && value[0] && value[1] &&
           isDate(value[0]) && isDate(value[1]) &&
-          value[0].getTime() <= value[1].getTime() && (
+          new Date(value[0]).getTime() <= new Date(value[1]).getTime() && (
           typeof this.disabledDate === 'function'
             ? !this.disabledDate(value[0]) && !this.disabledDate(value[1])
             : true

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -766,7 +766,15 @@ export default {
       // Enter
       if (keyCode === 13) {
         if (this.userInput === '' || this.isValidValue(this.parseString(this.displayValue))) {
-          this.handleChange();
+          if (this.type === 'daterange') {
+            this.picker.value = this.displayValue;
+            this.$nextTick(() => {
+              this.emitInput([this.picker.minDate, this.picker.maxDate]);
+              this.emitChange([this.picker.minDate, this.picker.maxDate]);
+            });
+          } else {
+            this.handleChange();
+          }
           this.pickerVisible = this.picker.visible = false;
           this.blur();
         }


### PR DESCRIPTION
DatePicker: Fix for date-picker(type="daterang" :default-time ="['00:00:00', '23:59:59']") DefaultTime parameter is invalid after manually entering date

修复 date-picker(type="daterang" :default-time	="['00:00:00', '23:59:59']") 时手动输入日期后 defaultTime 参数无效

我在使用 DatePicker 时发现手动输入日期并回车后, 定义的 default-time 没有生效