### PR TITLE
Popper: add support for shadow dom

### DIFF
--- a/src/utils/popper.js
+++ b/src/utils/popper.js
@@ -1057,6 +1057,11 @@
             return element;
         }
 
+        // if the type of parent is document-fragment, go on with it's host element
+        if (parent.nodeType === 11) {
+          return getScrollParent(parent.host);
+        }
+
         if (parent === root.document) {
             // Firefox puts the scrollTOp value on `documentElement` instead of `body`, we then check which of them is
             // greater than 0 and return the proper element
@@ -1090,7 +1095,8 @@
      * @returns {Boolean} answer to "isFixed?"
      */
     function isFixed(element) {
-        if (element === root.document.body) {
+        // document.body and document-fragment(nodetype is 11) are not fixed
+        if (element === root.document.body || element.nodeType === 11) {
             return false;
         }
         if (getStyleComputedProperty(element, 'position') === 'fixed') {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

===============================================

when popper is rendered in shadow dom，the rootNode of it's reference is a shadow root, which type is document-fragment. getComputedStyle is not allowd to pass in document-fragment as argument. so, check the element's type and return if it is document-fragment.

btw，there should be a global config for 'appendToBody'
