### PR TITLE
fix(RadioGroup): used in component causes exception #17908

### DIFF
--- a/packages/radio/src/radio-group.vue
+++ b/packages/radio/src/radio-group.vue
@@ -43,7 +43,9 @@
         return (this.elFormItem || {}).elFormItemSize;
       },
       _elTag() {
-        return (this.$vnode.data || {}).tag || 'div';
+        let tag = (this.$vnode.data || {}).tag;
+        if (!tag || tag === 'component') tag = 'div';
+        return tag;
       },
       radioGroupSize() {
         return this.size || this._elFormItemSize || (this.$ELEMENT || {}).size;


### PR DESCRIPTION
Use `<component :id="'el-radio-group'">` causes exception. fix #17908
```vue
<template>  
  <component
    :is="tag"
  >
  </component>
</template>

<script>
export default {
  data() {
    return {
      tag: 'el-radio-group'
    }
  }
}
</script>
```
```bash
[Vue warn]: Unknown custom element: <component> - did you register the component correctly? For recursive components, make sure to provide the "name" option.

found in

---> <ElRadioGroup> at packages/radio/src/radio-group.vue
```
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
