### PR TITLE
[date-util.js]: fixing issue #19660

### DIFF
--- a/src/utils/date-util.js
+++ b/src/utils/date-util.js
@@ -89,8 +89,8 @@ export const getStartDateOfMonth = function(year, month) {
   const result = new Date(year, month, 1);
   const day = result.getDay();
 
-  if (day === 0) {
-    return prevDate(result, 7);
+  if (day === 1) {
+    return prevDate(result, 8);
   } else {
     return prevDate(result, day);
   }


### PR DESCRIPTION
The change fixes the bug mentioned in issue #19660 - choosing wrong week when firstDayOfWeek is 2 and the begining of the month is Monday.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
