### PR TITLE
Popover: fix 触发方式为manual且v-model初始值为true时显示异常问题

### DIFF
--- a/src/utils/vue-popper.js
+++ b/src/utils/vue-popper.js
@@ -69,11 +69,15 @@ export default {
       }
     },
 
-    showPopper(val) {
-      if (this.disabled) return;
-      val ? this.updatePopper() : this.destroyPopper();
-      this.$emit('input', val);
-    }
+    showPopper: {
+      immediate: true,
+      handler(val) {
+        this.$nextTick(() => {
+          if (this.disabled) return;
+          val ? this.updatePopper() : this.destroyPopper();
+          this.$emit('input', val);
+        })
+      }
   },
 
   methods: {

--- a/src/utils/vue-popper.js
+++ b/src/utils/vue-popper.js
@@ -78,6 +78,7 @@ export default {
           this.$emit('input', val);
         })
       }
+    }
   },
 
   methods: {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

**问题描述**：el-popover组件采用manual模式时如果初始值就是true组件不能正常显示
**bug复现地址**：https://codepen.io/yimijianfang/pen/PobeJxZ