### PR TITLE
fix(tree): fix dropping to the root of lazy tree

### DIFF
--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -407,7 +407,9 @@ export default class Node {
   }
 
   getChildren(forceInit = false) { // this is data
-    if (this.level === 0) return this.data;
+    if (this.level === 0) {
+      return forceInit ? (this.data || []) : this.data;
+    }
     const data = this.data;
     if (!data) return null;
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

This commit fixes an issue of dropping to the root of lazy tree. When dropping to the root, first `insertChild` is called and then `this.getChildren(true)`, so `forceInit` is set to true. However, since we are dropping to the `root this.level === 0`. Before fix `this.data` was returned and in case of null value dropping resulted to the error message "Can not read property indexOf of undefined".
