### PR TITLE
Cascader: fix lazy loading, check radio first, lower menu display 'no…

### DIFF
--- a/packages/cascader-panel/src/cascader-node.vue
+++ b/packages/cascader-panel/src/cascader-node.vue
@@ -62,7 +62,12 @@
             // do not use cached leaf value here, invoke this.isLeaf to get new value.
             const { isLeaf } = this;
 
-            if (!isLeaf) this.handleExpand();
+            if (!isLeaf) {
+              this.handleExpand();
+            } else {
+              panel.handleExpand(node);
+            }
+
             if (multiple) {
               // if leaf sync checked state, else clear checked state
               const checked = isLeaf ? node.checked : false;
@@ -75,9 +80,9 @@
       },
 
       handleCheckChange() {
-        const { panel, value, node } = this;
+        const { panel, value } = this;
         panel.handleCheckChange(value);
-        panel.handleExpand(node);
+        this.handleExpand();
       },
 
       handleMultiCheckChange(checked) {


### PR DESCRIPTION
       … data'。

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
#20869 

Cascader Attributes 'props.lazy' and 'props.checkStrictly' is true,  the first time you click on the radio button of a node, the subordinate menu will show 'No data yet'. It makes people think that there is really no data. But, in fact, the data of the subordinate menu is not loaded. When clicked a second time, the display is normal.
![firstTimeClick](https://user-images.githubusercontent.com/13249888/111120987-0b447300-85a7-11eb-89fb-e3e94819d1b2.png)
![secondTimeClick](https://user-images.githubusercontent.com/13249888/111121003-11d2ea80-85a7-11eb-9da4-f82f90855cc7.png)


