### PR TITLE
Collapse: add icon trigger attribute

### DIFF
--- a/packages/collapse/src/collapse-item.vue
+++ b/packages/collapse/src/collapse-item.vue
@@ -23,6 +23,7 @@
       >
         <slot name="title">{{title}}</slot>
         <i
+          @click.stop="handleIconClick"
           class="el-collapse-item__arrow el-icon-arrow-right"
           :class="{'is-active': isActive}">
         </i>
@@ -75,6 +76,7 @@
 
     props: {
       title: String,
+      trigger: String,
       name: {
         type: [String, Number],
         default() {
@@ -85,6 +87,9 @@
     },
 
     computed: {
+      triggerTarget() {
+        return this.trigger || (this.collapse || {}).trigger;
+      },
       isActive() {
         return this.collapse.activeNames.indexOf(this.name) > -1;
       }
@@ -101,13 +106,19 @@
         }, 50);
       },
       handleHeaderClick() {
-        if (this.disabled) return;
+        if (this.disabled || this.triggerTarget === 'icon') return;
         this.dispatch('ElCollapse', 'item-click', this);
         this.focusing = false;
         this.isClick = true;
       },
       handleEnterClick() {
         this.dispatch('ElCollapse', 'item-click', this);
+      },
+      handleIconClick() {
+        if (this.disabled) return;
+        this.dispatch('ElCollapse', 'item-click', this);
+        this.focusing = false;
+        this.isClick = true;
       }
     }
   };

--- a/packages/collapse/src/collapse.vue
+++ b/packages/collapse/src/collapse.vue
@@ -10,6 +10,7 @@
     componentName: 'ElCollapse',
 
     props: {
+      trigger: String,
       accordion: Boolean,
       value: {
         type: [Array, String, Number],


### PR DESCRIPTION
Collapse adds the `trigger` attribute.  
When users use custom content with title `slot`, they donot want the title triggers the collapse event, but only the icon arrow. See #14936 
Now setting `trigger="icon"` on the `<el-collapse />` or `<el-collapse-item />` components will help.