### PR TITLE
Create sr-Latn.js

### DIFF
--- a/src/locale/lang/sr-Latn.js
+++ b/src/locale/lang/sr-Latn.js
@@ -1,0 +1,120 @@
+export default {
+  el: {
+    colorpicker: {
+      confirm: 'OK',
+      clear: 'Poništi'
+    },
+    datepicker: {
+      now: 'Sad',
+      today: 'Danas',
+      cancel: 'Otkaži',
+      clear: 'Briši',
+      confirm: 'OK',
+      selectDate: 'Izaberi datum',
+      selectTime: 'Izaberi vreme',
+      startDate: 'Datum početka',
+      startTime: 'Vreme početka',
+      endDate: 'Datum završetka',
+      endTime: 'Vreme završetka',
+      prevYear: 'Prethodna godina',
+      nextYear: 'Sledeća godina',
+      prevMonth: 'Prethodni mesec',
+      nextMonth: 'Sledeći mesec',
+      year: 'godina',
+      month1: 'januar',
+      month2: 'februar',
+      month3: 'mart',
+      month4: 'april',
+      month5: 'maj',
+      month6: 'jun',
+      month7: 'jul',
+      month8: 'avgust',
+      month9: 'septembar',
+      month10: 'oktobar',
+      month11: 'novembar',
+      month12: 'decembar',
+      week: 'sedmica',
+      weeks: {
+        sun: 'Ned',
+        mon: 'Pon',
+        tue: 'Uto',
+        wed: 'Sre',
+        thu: 'Čet',
+        fri: 'Pet',
+        sat: 'Sub'
+      },
+      months: {
+        jan: 'jan',
+        feb: 'feb',
+        mar: 'mar',
+        apr: 'apr',
+        may: 'maj',
+        jun: 'jun',
+        jul: 'jul',
+        aug: 'avg',
+        sep: 'sep',
+        oct: 'okt',
+        nov: 'nov',
+        dec: 'dec'
+      }
+    },
+    select: {
+      loading: 'Učitavanje',
+      noMatch: 'Nema rezultata',
+      noData: 'Nema podataka',
+      placeholder: 'Izaberi'
+    },
+    cascader: {
+      noMatch: 'Nema rezultata',
+      loading: 'Učitavanje',
+      placeholder: 'Izaberi',
+      noData: 'Nema podataka'
+    },
+    pagination: {
+      goto: 'Idi na',
+      pagesize: '/strani',
+      total: 'Ukupno {total}',
+      pageClassifier: ''
+    },
+    messagebox: {
+      title: 'Poruka',
+      confirm: 'OK',
+      cancel: 'Otkaži',
+      error: 'Neispravan unos'
+    },
+    upload: {
+      deleteTip: 'pritisni BRIŠI da obrišeš',
+      delete: 'Briši',
+      preview: 'Vidi',
+      continue: 'Nastavi'
+    },
+    table: {
+      emptyText: 'Nema podataka',
+      confirmFilter: 'Potvrdi',
+      resetFilter: 'Resetuj',
+      clearFilter: 'Sve',
+      sumText: 'Zbir'
+    },
+    tree: {
+      emptyText: 'Nema podataka'
+    },
+    transfer: {
+      noMatch: 'Nema rezultata',
+      noData: 'Nema podataka',
+      titles: ['Lista 1', 'Lista 2'],
+      filterPlaceholder: 'Unesi ključnu reč',
+      noCheckedFormat: '{total} stavki',
+      hasCheckedFormat: '{checked}/{total} obeleženih'
+    },
+    image: {
+      error: 'NIJE USPEO'
+    },
+    pageHeader: {
+      title: 'Nazad'
+    },
+    popconfirm: {
+      confirmButtonText: 'Da',
+      cancelButtonText: 'Ne'
+    }
+  }
+};


### PR DESCRIPTION
Adding translation to Latin version of Serbian alphabet. Serbian is practically the only European standard language whose speakers are fully functionally digraphic, using both Cyrillic and Latin alphabets.

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
