### PR TITLE
fix(Tabs): Cannot read property 'scrollToActiveTab' of undefined"

### DIFF
--- a/packages/tabs/src/tabs.vue
+++ b/packages/tabs/src/tabs.vue
@@ -47,7 +47,7 @@
         if (this.$refs.nav) {
           this.$nextTick(() => {
             this.$refs.nav.$nextTick(_ => {
-              this.$refs.nav.scrollToActiveTab();
+              this.$refs.nav && this.$refs.nav.scrollToActiveTab();
             });
           });
         }


### PR DESCRIPTION
vue.runtime.esm.js:619 [Vue warn]: Error in nextTick: "TypeError: Cannot read property 'scrollToActiveTab' of undefined"
found in
---> <TabNav> at packages/tabs/src/tab-nav.vue
       <ElTabs> at packages/tabs/src/tabs.vue