### PR TITLE
removeResizeListener should ignore the function which is non-existen …

### DIFF
--- a/src/utils/resize-event.js
+++ b/src/utils/resize-event.js
@@ -28,6 +28,7 @@ export const addResizeListener = function(element, fn) {
 /* istanbul ignore next */
 export const removeResizeListener = function(element, fn) {
   if (!element || !element.__resizeListeners__) return;
+  if (element.__resizeListeners__.indexOf(fn) === -1) return;
   element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn), 1);
   if (!element.__resizeListeners__.length) {
     element.__ro__.disconnect();


### PR DESCRIPTION
…in the  element.__resizeListeners_

If the function does not exist in the element.__resizeListeners__, This operation element.__resizeListeners__.indexOf(fn) yields a negative one. And then, element.__resizeListeners__.splice(-1, 1) cause the existing functions to be deleted;

在removeResizeListener函数中，执行element.__resizeListeners__.splice(element.__resizeListeners__.indexOf(fn),1)操作前，应先判断，element.__resizeListeners__.indexOf(fn)的结果是否为-1 ，因为 element.__resizeListeners__.splice(-1, 1)会导致删除element.__resizeListeners__中已存在的fn。

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
