### PR TITLE
Utils: fix isScroll

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -183,7 +183,7 @@ export const isScroll = (el, vertical) => {
       : getStyle(el, 'overflow-x')
     : getStyle(el, 'overflow');
 
-  return overflow.match(/(scroll|auto)/);
+  return overflow.match(/(scroll|auto|overlay)/);
 };
 
 export const getScrollContainer = (el, vertical) => {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

`overlay` behaves the same as `auto`, but now `isScroll` method can't match the scroll wrap with `overlay`.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
