### PR TITLE
Table: fix reserve-selection bug

### DIFF
--- a/packages/table/src/store/watcher.js
+++ b/packages/table/src/store/watcher.js
@@ -156,7 +156,9 @@ export default Vue.extend({
     },
 
     toggleRowSelection(row, selected, emitChange = true) {
-      const changed = toggleRowStatus(this.states.selection, row, selected);
+      const rowKey = this.states.rowKey;
+      const rowId = getRowIdentity(row, rowKey);
+      const changed = toggleRowStatus(this.states.selection, row, selected, rowId);
       if (changed) {
         const newSelection = (this.states.selection || []).slice();
         // 调用 API 修改选中值，不触发 select 事件

--- a/packages/table/src/util.js
+++ b/packages/table/src/util.js
@@ -195,9 +195,9 @@ export function compose(...funcs) {
   return funcs.reduce((a, b) => (...args) => a(b(...args)));
 }
 
-export function toggleRowStatus(statusArr, row, newVal) {
+export function toggleRowStatus(statusArr, row, newVal, rowId) {
   let changed = false;
-  const index = statusArr.indexOf(row);
+  const index = rowId ? statusArr.findIndex(item => item[rowId] === row[rowId]) : statusArr.indexOf(row);
   const included = index !== -1;
 
   const addRow = () => {


### PR DESCRIPTION
When reserve `selection = false`,· @selection-change`  throws a value of checked to true. However, when `reserve selection = true`, `@selection-change` throws a value of checked to true and false. Consider a scenario in which the dialog sets a table and refreshes tabledata every time `dialogvisible = true`. In this case, the `indexof (row)` in the source code always returns false, It will lead to state error, and it should be judged according to rowkey