### PR TITLE
修复notification组件，当项目同时存在设置了offset和没设置offset的通知弹窗，导致通知弹窗重叠的问题

### DIFF
--- a/packages/notification/src/main.js
+++ b/packages/notification/src/main.js
@@ -37,7 +37,7 @@ const Notification = function(options) {
 
   let verticalOffset = options.offset || 0;
   instances.filter(item => item.position === position).forEach(item => {
-    verticalOffset += item.$el.offsetHeight + 16;
+    verticalOffset += item.offset + item.$el.offsetHeight + 16;
   });
   verticalOffset += 16;
   instance.verticalOffset = verticalOffset;


### PR DESCRIPTION
修改bug： notification弹窗重叠
场景：项目中有多个通知弹窗，有些通知设置了offset且不会自动消失，有些没有设置offset
定位原因：element计算新通知位置时，没有将已存在通知的offset加上，其他类型的弹窗可能也有类似问题