### PR TITLE
fix(upload): 修复进度条引起跨域导致文件上传失败问题

### DIFF
--- a/packages/upload/src/ajax.js
+++ b/packages/upload/src/ajax.js
@@ -36,7 +36,7 @@ export default function upload(option) {
   const xhr = new XMLHttpRequest();
   const action = option.action;
 
-  if (xhr.upload) {
+  if (xhr.upload && option.onProgress(false) !== false) {
     xhr.upload.onprogress = function progress(e) {
       if (e.total > 0) {
         e.percent = e.loaded / e.total * 100;

--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -173,10 +173,14 @@ export default {
       this.onChange(file, this.uploadFiles);
     },
     handleProgress(ev, rawFile) {
-      const file = this.getFile(rawFile);
-      this.onProgress(ev, file, this.uploadFiles);
-      file.status = 'uploading';
-      file.percentage = ev.percent || 0;
+      if (ev === false) {
+        return this.onProgress();
+      } else {
+        const file = this.getFile(rawFile);
+        this.onProgress(ev, file, this.uploadFiles);
+        file.status = 'uploading';
+        file.percentage = ev.percent || 0;
+      }
     },
     handleSuccess(res, rawFile) {
       const file = this.getFile(rawFile);

--- a/packages/upload/src/upload.vue
+++ b/packages/upload/src/upload.vue
@@ -142,7 +142,7 @@ export default {
         filename: this.name,
         action: this.action,
         onProgress: e => {
-          this.onProgress(e, rawFile);
+          return this.onProgress(e, rawFile);
         },
         onSuccess: res => {
           this.onSuccess(res, rawFile);


### PR DESCRIPTION
由于WEB后端配置CORS未处理OPTION，upload进度条效果引起跨域导致文件上传失败，故增加隐藏进度条选项来解决：回调函数onProgress() {return false} 即可