### PR TITLE
Table：修改 table-body, table-header, 在slot-scope中提供fixed属性

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -348,6 +348,7 @@ export default {
             const data = {
               store: this.store,
               _self: this.context || this.table.$vnode.context,
+              fixed: this.fixed,
               column: columnData,
               row,
               $index

--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -110,7 +110,7 @@ export default {
                     <div class={ ['cell', column.filteredValue && column.filteredValue.length > 0 ? 'highlight' : '', column.labelClassName] }>
                       {
                         column.renderHeader
-                          ? column.renderHeader.call(this._renderProxy, h, { column, $index: cellIndex, store: this.store, _self: this.$parent.$vnode.context })
+                          ? column.renderHeader.call(this._renderProxy, h, { column, fixed: this.fixed, $index: cellIndex, store: this.store, _self: this.$parent.$vnode.context })
                           : column.label
                       }
                       {


### PR DESCRIPTION
在有fixed列的table中，使用了含有popover的自定义头，展示popover时会展示两个，并且会错位，所以想使用fixed属性来判断是否渲染popover