### PR TITLE
Table: fix table header slot not reactive

### DIFF
--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -306,6 +306,16 @@ export default {
     owner.store.commit('insertColumn', this.columnConfig, columnIndex, this.isSubColumn ? parent.columnConfig : null);
   },
 
+  beforeUpdate() {
+    // #20453
+    if (this.$slots.header && this.$scopedSlots.header) {
+      this.columnConfig.renderHeader = (h, scope) => {
+        const renderHeader = this.$scopedSlots.header;
+        return renderHeader ? renderHeader(scope) : this.columnConfig.label;
+      };
+    }
+  },
+
   destroyed() {
     if (!this.$parent) return;
     const parent = this.$parent;


### PR DESCRIPTION
close #20453
只有slot的情况下，table-header无法收集到slot组件下的依赖信息，造成了data的改变没有触发table-header更新。
pr里的解决方案是：有设置slot情况下，在beforeUpdate时，重新给renderHeader赋值，触发table-header的更新。

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
