### PR TITLE
Table: fix toggleAllSelection when nodata (#21267)

### DIFF
--- a/packages/table/src/store/watcher.js
+++ b/packages/table/src/store/watcher.js
@@ -170,6 +170,8 @@ export default Vue.extend({
     _toggleAllSelection() {
       const states = this.states;
       const { data = [], selection } = states;
+      // prevent action when no data
+      if (data.length === 0) return;
       // when only some rows are selected (but not all), select or deselect all of them
       // depending on the value of selectOnIndeterminate
       const value = states.selectOnIndeterminate


### PR DESCRIPTION
close [#21267](https://github.com/ElemeFE/element/issues/21267)
表格的全选组件在无数据的时候，会禁用组件点击，但全选操作绑定的是原生事件，所以依旧会触发
解决方案是在操作处理方法中进行判定并阻止

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.