### PR TITLE
Table: 修复 el-table-column 中切换 type DOM 不更新以及多选框表头与内容不对齐的问题

### DIFF
--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -195,7 +195,7 @@ export default {
     },
 
     registerNormalWatchers() {
-      const props = ['label', 'property', 'filters', 'filterMultiple', 'sortable', 'index', 'formatter', 'className', 'labelClassName', 'showOverflowTooltip'];
+      const props = ['type', 'label', 'property', 'filters', 'filterMultiple', 'sortable', 'index', 'formatter', 'className', 'labelClassName', 'showOverflowTooltip'];
       // 一些属性具有别名
       const aliases = {
         prop: 'property',
@@ -213,6 +213,9 @@ export default {
 
         this.$watch(key, (newVal) => {
           this.columnConfig[columnKey] = newVal;
+          if (key === 'type') {
+            compose(this.setColumnRenders, this.setColumnWidth, this.setColumnForcedProps)(this.columnConfig);
+          }
         });
       });
     },

--- a/packages/theme-chalk/src/table-column.scss
+++ b/packages/theme-chalk/src/table-column.scss
@@ -3,7 +3,7 @@
 @import "tag";
 @import "common/var";
 
-@include b(table-column) {
+@include b(el-table table-column) {
   @include m(selection) {
     .cell {
       padding-left: 14px;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

[这里](https://codepen.io/dev-sheng/pen/powXaRL)是复现的链接，点击下方的「Change」按钮可以发现，Table 第一个 Column  的 type 已经从 selection 变成了 index，但页面没有变化，经观察代码，发现是 `columnConfig` 没有更新的问题，所以尝试修复了这个问题。

---

此外，还有一个小细节，就是表头中的多选框和表格内容里的多选框没有对齐，看下图（来自[官方文档](https://element.eleme.io/#/zh-CN/component/table#duo-xuan)）：

![image](https://user-images.githubusercontent.com/10683193/136037136-1821affa-5384-405d-946d-abdb9a9b5cc2.png)

观察 CSS，发现是选择器的优先级混乱，selection 相关的样式被表头的覆盖了：

![image](https://user-images.githubusercontent.com/10683193/136037613-f25d566a-1749-44b1-a055-de20566b1488.png)

表头的左边距是 10px，表格内容的左边距是 14px，导致对不齐。经考虑，决定统一使用表头的样式，也就是说将内容也改成 10px，变为下面这样：

![image](https://user-images.githubusercontent.com/10683193/136037796-02755d05-c222-4e7c-9a51-b72ed00f52b1.png)

欢迎指正。


