### PR TITLE
Table: fix when used in a dialog, close dialog trigger resize

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -460,6 +460,10 @@
         }
 
         if (shouldUpdateLayout) {
+          // FIX: When used in a dialog, closing the dialog will trigger a resize. the fixed column height will be calculated incorrectly
+          if (!width && !height) {
+            return;
+          }
           this.resizeState.width = width;
           this.resizeState.height = height;
           this.doLayout();


### PR DESCRIPTION
fix when used in a dialog, closing the dialog will trigger a resize. the fixed column height will be calculated incorrectly
1. first time open
![image](https://user-images.githubusercontent.com/35555140/136503277-3f3c0850-e691-45da-8a67-ab3cfa5ccd0a.png)
2. first time close(will trigger resize to minus 17px height )
3. sceond time open
![image](https://user-images.githubusercontent.com/35555140/136503632-2425c750-62ca-4106-8fba-991c7dd31c6c.png)

see more [#21366](https://github.com/ElemeFE/element/issues/21366)
---
Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.
