### PR TITLE
Table: fix#21366.Table fixed height calculated incorrectly

### DIFF
--- a/packages/table/src/table-layout.js
+++ b/packages/table/src/table-layout.js
@@ -171,7 +171,7 @@ class TableLayout {
 
           flexColumns[0].realWidth = (flexColumns[0].minWidth || 80) + totalFlexWidth - noneFirstWidth;
         }
-      } else { // HAVE HORIZONTAL SCROLL BAR
+      } else if (bodyWidth && scrollYWidth) { // HAVE HORIZONTAL SCROLL BAR
         this.scrollX = true;
         flexColumns.forEach(function(column) {
           column.realWidth = column.minWidth;


### PR DESCRIPTION
When Table with fixed column used in a dialog, closing the dialog will trigger a resize. the fixed column height will be calculated incorrectly
> see more [#21366](https://github.com/ElemeFE/element/issues/21366)    


Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [X] Add some descriptions and refer relative issues for you PR.
