### PR TITLE
FormItem: fix the line-wrapping problem of form input under IE 11

### DIFF
--- a/packages/form/src/label-wrap.vue
+++ b/packages/form/src/label-wrap.vue
@@ -30,8 +30,8 @@ export default {
 
   methods: {
     getLabelWidth() {
-      if (this.$el && this.$el.firstElementChild) {
-        const computedWidth = window.getComputedStyle(this.$el.firstElementChild).width;
+      if (this.$el) {
+        const computedWidth = window.getComputedStyle(this.$el).width;
         return Math.ceil(parseFloat(computedWidth));
       } else {
         return 0;


### PR DESCRIPTION
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Fix: https://github.com/ElemeFE/element/issues/21427

此问题是由于对label容器的宽度计算不正确导致的，IE 11下计算其子元素宽度时，padding-right没有被包括在内，导致右侧input框的margin-left太小而换行，现在改成直接计算整个label容器的宽度即可修复此问题。
重现方法：
设置form的label-width为auto后，使用IE 11查看即可看到input被换行换行

修复前：
![image](https://user-images.githubusercontent.com/20365169/139813490-4e78c977-afbe-4b45-bf79-82f6291467d0.png)
![image](https://user-images.githubusercontent.com/20365169/139813531-bc199a08-2d22-4786-b73f-d28bbbe3fee4.png)

修复后：
![image](https://user-images.githubusercontent.com/20365169/139813873-aeae526b-6295-4939-a949-d10113e4ce9a.png)
![image](https://user-images.githubusercontent.com/20365169/139813751-a296a149-e5dc-4a4a-8b0a-8efe6881f8bc.png)
