### PR TITLE
Table : fix table draggable

### DIFF
--- a/packages/table/src/table-header.js
+++ b/packages/table/src/table-header.js
@@ -429,7 +429,7 @@ export default {
         let rect = target.getBoundingClientRect();
 
         const bodyStyle = document.body.style;
-        if (rect.width > 12 && rect.right - event.pageX < 8) {
+        if (rect.width > 12 && rect.right - event.clientX < 8) {
           bodyStyle.cursor = 'col-resize';
           if (hasClass(target, 'is-sortable')) {
             target.style.cursor = 'col-resize';


### PR DESCRIPTION
when a horizontal scroll bar appears on the page and the position of the El table needs to be scrolled horizontally to be displayed, the whole header of the table becomes draggable. 

https://github.com/ElemeFE/element/issues/21421

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
