### PR TITLE
Spinner:fix prop's  strokeColor not take effect.

### DIFF
--- a/packages/theme-chalk/src/spinner.scss
+++ b/packages/theme-chalk/src/spinner.scss
@@ -15,7 +15,6 @@
   height: 50px;
 
   & .path {
-    stroke: #ececec;
     stroke-linecap: round;
     animation: dash 1.5s ease-in-out infinite;
   }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.

the descriptions   for this PR.

spinner's  `<circle>`  element  defines the style class `path`, its `stroke` attribute defines the default value `stroke: #ececec;`, causing the component attribute `strokeColor`  to fail to take effect.

Remove the CSS style 'stroke' property make   'strokeColor' property to take effect。
