### PR TITLE
Upload: fix remove bug: when double click remove

### DIFF
--- a/packages/upload/src/index.vue
+++ b/packages/upload/src/index.vue
@@ -207,7 +207,12 @@ export default {
       let doRemove = () => {
         this.abort(file);
         let fileList = this.uploadFiles;
-        fileList.splice(fileList.indexOf(file), 1);
+        let index = fileList.indexOf(file)
+
+        if (index >= 0) {
+          fileList.splice(index, 1);
+        }
+      
         this.onRemove(file, fileList);
       };
 


### PR DESCRIPTION
一、bug场景。
当upload list有2个文件时，对第二个文件 快速点击2次删除，。触发2次handleRomove


二、代码示例：
let arr = [1,2];
arr.splice(1,1);
arr.splice(-1,1);
console.log(arr); // []

三、结果：导致第一个文件也被删除。

四、 提交修复代码

