### PR TITLE
Image: 修复图片预览组件 mouseup 事件重复注册问题

### DIFF
--- a/packages/image/src/image-viewer.vue
+++ b/packages/image/src/image-viewer.vue
@@ -243,11 +243,13 @@ export default {
         this.transform.offsetY = offsetY + ev.pageY - startY;
       });
       on(document, 'mousemove', this._dragHandler);
-      on(document, 'mouseup', ev => {
-        off(document, 'mousemove', this._dragHandler);
-      });
+      on(document, 'mouseup', this.handleMouseUp);
 
       e.preventDefault();
+    },
+    handleMouseUp(e) {
+      off(document, 'mousemove', this._dragHandler);
+      off(document, 'mouseup', this.handleMouseUp);
     },
     handleMaskClick() {
       if (this.maskClosable) {


### PR DESCRIPTION
### Bug：
在 Image 组件的大图预览功能中，如果多次拖拽图片，会导致组件中的 mouseup 事件重复注册，而且这些事件在关闭大图预览功能后仍然会在鼠标抬起时继续执行。
