### PR TITLE
[ENHANCE] progress  components support custom define stroke's color

### DIFF
--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -26,7 +26,7 @@
         <path
           class="el-progress-circle__track"
           :d="trackPath"
-          stroke="#e5e9f2"
+          stroke="strokeColor"
           :stroke-width="relativeStrokeWidth"
           fill="none"
           :style="trailPathStyle"></path>
@@ -68,6 +68,10 @@
       status: {
         type: String,
         validator: val => ['success', 'exception', 'warning'].indexOf(val) > -1
+      },
+      strokeColor: {
+        type: String,
+        default: '#e5e9f2'
       },
       strokeWidth: {
         type: Number,


### PR DESCRIPTION
The progress components support custom define strokeColor attribute; the default value is '#e5e9f2'

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
