### PR TITLE
Fix top position

### DIFF
--- a/packages/theme-chalk/src/loading.scss
+++ b/packages/theme-chalk/src/loading.scss
@@ -38,7 +38,7 @@
 }
 
 @include b(loading-spinner) {
-  top: 50%;
+  top: 50vh;
   margin-top: #{math.div(-$--loading-spinner-size, 2)};
   width: 100%;
   text-align: center;


### PR DESCRIPTION
When the height of the element is greater then the viewport height, the spinner will not be visible, to fix this bug you have to use **vh** unit

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
