### PR TITLE
Cascader: fix bug只有一个子节点且该子节点默认选中且默认禁止勾选时，父级没有选中样式

### DIFF
--- a/packages/cascader-panel/src/node.js
+++ b/packages/cascader-panel/src/node.js
@@ -125,7 +125,7 @@ export default class Node {
 
   onChildCheck() {
     const { children } = this;
-    const validChildren = children.filter(child => !child.isDisabled);
+    const validChildren = children.filter(child => !child.isDisabled || (child.isDisabled && child.checked));
     const checked = validChildren.length
       ? validChildren.every(child => child.checked)
       : false;


### PR DESCRIPTION
Cascader 组件，
在父节点只有一个子节点，且该子节点默认选择并且该子节点为禁止编辑时，父节点没有对应的勾选样式