### PR TITLE
fix cascader bug when clearing

### DIFF
--- a/packages/cascader/src/cascader.vue
+++ b/packages/cascader/src/cascader.vue
@@ -450,6 +450,8 @@ export default {
     handleClear() {
       this.presentText = '';
       this.panel.clearCheckedNodes();
+      this.panel.activePath = [];
+      this.panel.menus = this.panel.menus.length ? this.panel.menus.splice(0, 1) : [];
     },
     handleExpandChange(value) {
       this.$nextTick(this.updatePopper.bind(this));


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
问题描述：在实际业务场景中发现Cascader组件清空时，不能回到原始状态，导致用户对此产生误解，不太友好
更改后：清空后，面板只展示第一级，选中高亮消失