### PR TITLE
Select:add closable prop to option

### DIFF
--- a/packages/select/src/option.vue
+++ b/packages/select/src/option.vue
@@ -37,6 +37,10 @@
       disabled: {
         type: Boolean,
         default: false
+      },
+      closable: {
+        type: Boolean,
+        default: true
       }
     },
 

--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -32,7 +32,7 @@
         <el-tag
           v-for="item in selected"
           :key="getValueKey(item)"
-          :closable="!selectDisabled"
+          :closable="!selectDisabled && item.closable"
           :size="collapseTagSize"
           :hit="item.hitState"
           type="info"


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
问题描述：在实际的业务场景中，经常有这样的需求：el-select 为下拉多选，默认值不可删除，或者指定值不可删除。然而现有代码仅支持在el-select disabled情况下，tags不可删除，不能满足广泛的业务需求
更改后：默认值不可删除，只需传入closable : true
