### PR TITLE
Alert: content 默认充满剩余空间

### DIFF
--- a/packages/alert/src/main.vue
+++ b/packages/alert/src/main.vue
@@ -8,9 +8,9 @@
     >
       <i class="el-alert__icon" :class="[ iconClass, isBigIcon ]" v-if="showIcon"></i>
       <div class="el-alert__content">
-        <span class="el-alert__title" :class="[ isBoldTitle ]" v-if="title || $slots.title">
+        <div class="el-alert__title" :class="[ isBoldTitle ]" v-if="title || $slots.title">
           <slot name="title">{{ title }}</slot>
-        </span>
+        </div>
         <p class="el-alert__description" v-if="$slots.default && !description"><slot></slot></p>
         <p class="el-alert__description" v-if="description && !$slots.default">{{ description }}</p>
         <i class="el-alert__closebtn" :class="{ 'is-customed': closeText !== '', 'el-icon-close': closeText === '' }" v-show="closable" @click="close()">{{closeText}}</i>

--- a/packages/theme-chalk/src/alert.scss
+++ b/packages/theme-chalk/src/alert.scss
@@ -120,6 +120,10 @@
     }
   }
 
+  & .el-alert__content {
+    flex: 1 1 auto;
+  }
+
   & .el-alert__description {
     font-size: $--alert-description-font-size;
     margin: 5px 0 0 0;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [X] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [X] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

## 问题
- 由于 el-alert__content 本身没有充满剩余空间，导致布局只能是 inline 的形式
- 由于 el-alert__title 是内联标签，同样导致仅能支持 inline 形式布局

## 诉求
- 在 el-alert__content 有需要使用整个剩余空间进行布局的情况

## 建议修改
- el-alert__content 撑满剩余空间
- el-alert__title 使用块标签

## 结论
这样既能维持原有的使用效果，又能让用户灵活进行 content 部分的布局
