### PR TITLE
fix: Tree组件，默认勾选的前N项子节点（N>1），则该父节点的所有子节点都将被默认勾选

### DIFF
--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -244,6 +244,8 @@ export default class Node {
       this.childNodes.splice(index, 0, child);
     }
 
+    reInitChecked(this);
+
     this.updateLeafState();
   }
 


### PR DESCRIPTION
…ltCheckedKeys, but all childNodes of the parent are checked

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
