### PR TITLE
tooltip应该有个width来控制宽度

### DIFF
--- a/packages/tooltip/src/main.js
+++ b/packages/tooltip/src/main.js
@@ -52,6 +52,10 @@ export default {
     tabindex: {
       type: Number,
       default: 0
+    },
+    width: {
+      type: String,
+      default: ''
     }
   },
 
@@ -91,7 +95,8 @@ export default {
             v-show={!this.disabled && this.showPopper}
             class={
               ['el-tooltip__popper', 'is-' + this.effect, this.popperClass]
-            }>
+            }
+            style={{width: this.width}}>
             { this.$slots.content || this.content }
           </div>
         </transition>);


### PR DESCRIPTION
您好，我是京东的一名coder，正在用您们的element-ui，感觉很棒，昨天测试提了一个bug说tooltip太长，导致全凭显示不换行，用户体验不好，是否可以考虑传入一个props来控制tooltip的宽度，希望能够采纳，谢谢