### PR TITLE
Button: fix 第一次输入值与第二次输入值完全时一样无法触发重新筛选 bug

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -459,7 +459,7 @@
         }
       },
       handleQueryChange(val) {
-        if (this.previousQuery === val || this.isOnComposition) return;
+        if (this.isOnComposition) return;
         if (
           this.previousQuery === null &&
           (typeof this.filterMethod === 'function' || typeof this.remoteMethod === 'function')


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

descriptions
搜索模式下 当上一次输入的值与本次输入值一样时，无法触发搜索框的重新筛选。 例如#21628 提到的bug。
举个例子：比如列表中有龙须面、龙须面1、龙须面2。第一次输入龙须面，选择了龙须面，但是第二次我想选择龙须面1，所以当我再次输入龙须面时却无法触发列表筛选。https://codepen.io/future23365/pen/jOGdBwL。
所以，建议将此处的对比条件清除。