### PR TITLE
InfiniteScroll: 修复 ie11 不支持 Number.isNaN和Number.parseFloat语法

### DIFF
--- a/packages/infinite-scroll/src/main.js
+++ b/packages/infinite-scroll/src/main.js
@@ -71,7 +71,7 @@ const getScrollOptions = (el, vm) => {
     switch (type) {
       case Number:
         value = Number(value);
-        value = Number.isNaN(value) ? defaultValue : value;
+        value = isNaN(value) ? defaultValue : value;
         break;
       case Boolean:
         value = isDefined(value) ? value === 'false' ? false : Boolean(value) : defaultValue;

--- a/packages/infinite-scroll/src/main.js
+++ b/packages/infinite-scroll/src/main.js
@@ -104,7 +104,7 @@ const handleScroll = function(cb) {
   } else {
     const heightBelowTop = getOffsetHeight(el) + getElementTop(el) - getElementTop(container);
     const offsetHeight = getOffsetHeight(container);
-    const borderBottom = Number.parseFloat(getStyleComputedProperty(container, 'borderBottomWidth'));
+    const borderBottom = parseFloat(getStyleComputedProperty(container, 'borderBottomWidth'));
     shouldTrigger = heightBelowTop - offsetHeight + borderBottom <= distance;
   }
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
