### PR TITLE
Chore(deps): upgrade async-validator from 1.8.1 to 4.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "unpkg": "lib/index.js",
   "style": "lib/theme-chalk/index.css",
   "dependencies": {
-    "async-validator": "~1.8.1",
+    "async-validator": "~4.0.7",
     "babel-helper-vue-jsx-merge-props": "^2.0.0",
     "deepmerge": "^1.2.0",
     "normalize-wheel": "^1.0.1",


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Upgrade `async-validator` to the latest version due to the ReDOS vulnerability in version bellow 4.0.4

please see: https://security.snyk.io/vuln/SNYK-JS-ASYNCVALIDATOR-2311201