### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -49,14 +49,14 @@
   function shorten(arr, sLen) {
     var newArr = [];
     for (var i = 0, len = arr.length; i < len; i++) {
-      newArr.push(arr[i].substr(0, sLen));
+      newArr.push(arr[i].slice(0, sLen));
     }
     return newArr;
   }
 
   function monthUpdate(arrName) {
     return function (d, v, i18n) {
-      var index = i18n[arrName].indexOf(v.charAt(0).toUpperCase() + v.substr(1).toLowerCase());
+      var index = i18n[arrName].indexOf(v.charAt(0).toUpperCase() + v.slice(1).toLowerCase());
       if (~index) {
         d.month = index;
       }
@@ -122,7 +122,7 @@
       return i18n.monthNames[dateObj.getMonth()];
     },
     yy: function(dateObj) {
-      return pad(String(dateObj.getFullYear()), 4).substr(2);
+      return pad(String(dateObj.getFullYear()), 4).slice(2);
     },
     yyyy: function(dateObj) {
       return pad(dateObj.getFullYear(), 4);
@@ -183,7 +183,7 @@
       d.month = v - 1;
     }],
     yy: [twoDigits, function (d, v) {
-      var da = new Date(), cent = +('' + da.getFullYear()).substr(0, 2);
+      var da = new Date(), cent = +('' + da.getFullYear()).slice(0, 2);
       d.year = '' + (v > 68 ? cent - 1 : cent) + v;
     }],
     h: [twoDigits, function (d, v) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

## Description
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.