### PR TITLE
fix: “cascader” repair unexpected error

### DIFF
--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -136,16 +136,16 @@ export default {
   },
 
   watch: {
+    value() {
+      this.syncCheckedValue();
+      this.checkStrictly && this.calculateCheckedNodePaths();
+    },
     options: {
       handler: function() {
         this.initStore();
       },
       immediate: true,
       deep: true
-    },
-    value() {
-      this.syncCheckedValue();
-      this.checkStrictly && this.calculateCheckedNodePaths();
     },
     checkedValue(val) {
       if (!isEqual(val, this.value)) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

Scenes:
  "cascader" changes depending on the change of a certain A field. After returning, change the A field, clear the "value" of "cascader" and the "options" of "cascader", and initiate an interface request at the same time, get data A after the request, and put the data A is assigned to "cascader options", and an error occurs
problem causes:
The watch queue of the cascader-panel file is ["options", "value"]. When the value is cleared and the options are cleared, the execution order is the options monitoring event, and then the value monitoring event. The function call chain in the options monitoring event is as follows,
Function call chain:
  options(handler) > initStore > syncMenuState > syncActivePath > getNodeByValue(node.getValue()) get [ null ] > expandNodes > handleExpand
[Reproduce address](https://codepen.io/louiebb/pen/XWVXyJM)
[Detailed article](https://juejin.cn/post/7076013718017933348)
solution:
  The watch queue is modified to [ "value", "options"]
