### PR TITLE
ElMenu:修复添加router属性后，activeIndex不自动跟随router

### DIFF
--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -314,7 +314,7 @@
     },
     created() {
       if(!this.router || this.$router === null) return;
-      this.$router.afterHooks.push(to => this.activeIndex = to.path);
+      this.$router.afterEach(to => this.activeIndex = to.path);
     },
     mounted() {
       this.initOpenedMenu();

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -159,7 +159,7 @@
 
       router: {
         handler(value) {
-        if (value && !this.haveRouterHook) {
+          if (value && !this.haveRouterHook) {
             this.haveRouterHook = true;
             this.$router.afterEach(to => {
               if (this.router) this.updateActiveIndex(to.path)

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -155,6 +155,18 @@
       collapse(value) {
         if (value) this.openedMenus = [];
         this.broadcast('ElSubmenu', 'toggle-collapse', value);
+      },
+
+      router: {
+        handler(value) {
+        if (value && !this.haveRouterHook) {
+            this.haveRouterHook = true;
+            this.$router.afterEach(to => {
+              if (this.router) this.updateActiveIndex(to.path)
+            });
+          }
+        },
+        immediate: true
       }
     },
     methods: {
@@ -311,10 +323,6 @@
       close(index) {
         this.closeMenu(index);
       }
-    },
-    created() {
-      if(!this.router || this.$router === null) return;
-      this.$router.afterEach(to => this.activeIndex = to.path);
     },
     mounted() {
       this.initOpenedMenu();

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -109,6 +109,7 @@
       defaultOpeneds: Array,
       uniqueOpened: Boolean,
       router: Boolean,
+      followRouter: Boolean,
       menuTrigger: {
         type: String,
         default: 'hover'
@@ -157,12 +158,14 @@
         this.broadcast('ElSubmenu', 'toggle-collapse', value);
       },
 
-      router: {
+      followRouter: {
         handler(value) {
           if (value && !this.haveRouterHook) {
             this.haveRouterHook = true;
             this.$router.afterEach(to => {
-              if (this.router) this.updateActiveIndex(to.path)
+              if (this.followRouter && this.router) {
+                this.updateActiveIndex(to.path);
+              }
             });
           }
         },

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -124,7 +124,7 @@
     },
     data() {
       return {
-        activeIndex: this.defaultActive,
+        activeIndex: this.router ? this.$router.currentRoute.path : this.defaultActive,
         openedMenus: (this.defaultOpeneds && !this.collapse) ? this.defaultOpeneds.slice(0) : [],
         items: {},
         submenus: {}
@@ -311,6 +311,10 @@
       close(index) {
         this.closeMenu(index);
       }
+    },
+    created() {
+      if(!this.router || this.$router === null) return;
+      this.$router.afterHooks.push(to => this.activeIndex = to.path);
     },
     mounted() {
       this.initOpenedMenu();

--- a/packages/menu/src/menu.vue
+++ b/packages/menu/src/menu.vue
@@ -125,7 +125,7 @@
     },
     data() {
       return {
-        activeIndex: this.router ? this.$router.currentRoute.path : this.defaultActive,
+        activeIndex: this.defaultActive === '' && this.followRouter && this.router ? this.$router.currentRoute.path : this.defaultActive,
         openedMenus: (this.defaultOpeneds && !this.collapse) ? this.defaultOpeneds.slice(0) : [],
         items: {},
         submenus: {}


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

## 变更说明
在设置router属性后理想状况是menu激活项与router同步切换，而通过单击menu项以外的其他方式切换router后，menu的激活项可能出现与当前页面不同步，为减少变更带来的影响，因此增加了follow-router属性来手动开启menu激活项跟随router切换。