### PR TITLE
fix: select组件开启filterable后，输入框点击失焦问题

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -50,6 +50,7 @@
         :autocomplete="autoComplete || autocomplete"
         @focus="handleFocus"
         @blur="softFocus = false"
+        @click.stop="() => {}"
         @keyup="managePlaceholder"
         @keydown="resetInputState"
         @keydown.down.prevent="navigateOptions('next')"


### PR DESCRIPTION
fix: select组件开启filterable后，输入框点击失焦问题

select组件在filterable为false时点击输入框是切换下拉选项的显示隐藏。
当filterable为true时, 复用了这个逻辑，会导致用户想要修改搜索关键词，使用左键点击定位光标位置时直接隐藏下拉选项，并且失焦。
当前pull request 修复了这个问题，在当filterable为true时， 可以使用鼠标可以正常的聚焦。

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
