### PR TITLE
修改slider组件聚焦状态

### DIFF
--- a/packages/slider/src/button.vue
+++ b/packages/slider/src/button.vue
@@ -226,7 +226,9 @@
         value = parseFloat(value.toFixed(this.precision));
         this.$emit('input', value);
         this.$nextTick(() => {
-          this.displayTooltip();
+          if (this.hovering) {
+            this.displayTooltip();
+          }
           this.$refs.tooltip && this.$refs.tooltip.updatePopper();
         });
         if (!this.dragging && this.value !== this.oldValue) {


### PR DESCRIPTION
当拖动slider组件至最大最小值时，在组件外松开鼠标，tooltip仍然为显示状态
