### PR TITLE
fix The predefined color which is checked before clear can not checked after clear (#20866)

### DIFF
--- a/packages/color-picker/src/main.vue
+++ b/packages/color-picker/src/main.vue
@@ -94,8 +94,8 @@
       },
       color: {
         deep: true,
-        handler() {
-          this.showPanelColor = true;
+        handler(color) {
+          this.showPanelColor = !!color.value;
         }
       },
       displayedColor(val) {
@@ -144,6 +144,7 @@
           if (this.value) {
             this.color.fromString(this.value);
           } else {
+            this.color.value = '';
             this.showPanelColor = false;
           }
         });


### PR DESCRIPTION
colorPicker: fix The predefined color which is checked before clear can not checked after clear (#20866)

