### PR TITLE
 date-picker: fix  modify props "placement" error

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -98,7 +98,6 @@ const NewPopper = {
     offset: Popper.props.offset,
     boundariesPadding: Popper.props.boundariesPadding,
     arrowOffset: Popper.props.arrowOffset,
-    placement: Popper.props.placement,
     transformOrigin: Popper.props.transformOrigin
   },
   methods: Popper.methods,


### PR DESCRIPTION
!!! This error is on the current production version 2.15.9 , please quick fix

fix this error
![image](https://user-images.githubusercontent.com/9134671/172334924-9c722383-8d7c-4993-903b-542a8bcab929.png)

```
vue.runtime.esm.js?2b0e:619 [Vue warn]: Avoid mutating a prop directly since the value will be overwritten whenever the parent component re-renders. Instead, use a data or computed property based on the prop's value. Prop being mutated: "placement"

found in

---> <ElDatePicker> at packages/date-picker/src/picker.vue

```

because this PR https://github.com/ElemeFE/element/pull/21806  add props `placement` to erroneously changed "placement" `data` -> `props`
detail in issues https://github.com/ElemeFE/element/issues/21905


* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
