### PR TITLE
fix: button component open in codepen display incorrect bug

### DIFF
--- a/examples/components/demo-block.vue
+++ b/examples/components/demo-block.vue
@@ -184,6 +184,9 @@
   import compoLang from '../i18n/component.json';
   import Element from 'main/index.js';
   import { stripScript, stripStyle, stripTemplate } from '../util';
+  import config from '../../package.json';
+  // 获取当前package.json中vue的版本好
+  const vueVersion = config.devDependencies['vue'];
   const { version } = Element;
 
   export default {
@@ -205,7 +208,8 @@
       goCodepen() {
         // since 2.6.2 use code rather than jsfiddle https://blog.codepen.io/documentation/api/prefill/
         const { script, html, style } = this.codepen;
-        const resourcesTpl = '<scr' + 'ipt src="//unpkg.com/vue/dist/vue.js"></scr' + 'ipt>' +
+        // 将版本号拼接到链接中，获取vue在线包
+        const resourcesTpl = '<scr' + 'ipt src="//unpkg.com/vue@' + vueVersion + '/dist/vue.js"></scr' + 'ipt>' +
         '\n<scr' + `ipt src="//unpkg.com/element-ui@${ version }/lib/index.js"></scr` + 'ipt>';
         let jsTpl = (script || '').replace(/export default/, 'var Main =').trim();
         let htmlTpl = `${resourcesTpl}\n<div id="app">\n${html.trim()}\n</div>`;


### PR DESCRIPTION
when visit [element.io ](https://element.eleme.cn/) in components part，click button component tab，then click running online link，but in codepen can't display correct style and show a message "Vue is not defined".

solution: chanage zhe vue link in demo-block.vue
