### PR TITLE
Fix: Dialog组件，关闭dialog的同时打开其他的dialog，lockScroll失效

### DIFF
--- a/src/utils/popup/index.js
+++ b/src/utils/popup/index.js
@@ -8,6 +8,8 @@ let idSeed = 1;
 
 let scrollBarWidth;
 
+let lockScrollCount = 0;
+
 export default {
   props: {
     visible: {
@@ -132,6 +134,7 @@ export default {
         }
         PopupManager.openModal(this._popupId, PopupManager.nextZIndex(), this.modalAppendToBody ? undefined : dom, props.modalClass, props.modalFade);
         if (props.lockScroll) {
+          lockScrollCount++;
           this.withoutHiddenClass = !hasClass(document.body, 'el-popup-parent--hidden');
           if (this.withoutHiddenClass) {
             this.bodyPaddingRight = document.body.style.paddingRight;
@@ -204,11 +207,11 @@ export default {
     },
 
     restoreBodyStyle() {
-      if (this.modal && this.withoutHiddenClass) {
+      lockScrollCount--;
+      if (lockScrollCount === 0) {
         document.body.style.paddingRight = this.bodyPaddingRight;
         removeClass(document.body, 'el-popup-parent--hidden');
       }
-      this.withoutHiddenClass = true;
     }
   }
 };


### PR DESCRIPTION
假设页面上有两个dialog，设置dialog1的visible为false的同时，设置另一个dialog2的visible为true，lockScroll会失效

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
