### PR TITLE
Skeleton: fix row set up two,display effect as one line

### DIFF
--- a/packages/theme-chalk/src/skeleton-item.scss
+++ b/packages/theme-chalk/src/skeleton-item.scss
@@ -42,7 +42,7 @@
     }
 
     @include when(first) {
-      width: 33%;
+      width: 53%;
     }
   }
 


### PR DESCRIPTION
Fix row set up two,display effect as one line.

Fix : https://github.com/ElemeFE/element/issues/21810

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
