### PR TITLE
Tree:fix Tree懒加载默认选中问题 issue(#21932)

### DIFF
--- a/packages/tree/src/model/node.js
+++ b/packages/tree/src/model/node.js
@@ -23,7 +23,7 @@ export const getChildState = node => {
 };
 
 const reInitChecked = function(node) {
-  if (node.childNodes.length === 0) return;
+  if (node.childNodes.length === 0 || node.loading) return;
 
   const {all, none, half} = getChildState(node.childNodes);
   if (all) {
@@ -463,12 +463,11 @@ export default class Node {
       this.loading = true;
 
       const resolve = (children) => {
-        this.loaded = true;
-        this.loading = false;
         this.childNodes = [];
 
         this.doCreateChildren(children, defaultProps);
-
+        this.loaded = true;
+        this.loading = false;
         this.updateLeafState();
         if (callback) {
           callback.call(this, children);


### PR DESCRIPTION
#### 问题：
[issue(#21932)](https://github.com/ElemeFE/element/issues/21932)
#### bug产生原因：
由于懒加载后doCreateChildren函数使用foreach的方式新增child，每次新增一个child都会执行reInitChecked函数对父节点的选中状态重置。所已第一个child选中后，第二个节点在选中时reInitChecked认为所有子节点（本来有n>2个子节点，只是foreach刚创建2个而已）都选中了，然后导致后面所有新增的child都会因为父节点已选中而被设置为选中。
#### 解决方法：
将节点的loading状态放到doCreateChildren函数完成之后并在reInitChecked计算父节点选中状态时对loading中的节点不处理。等loading完成后由回调函数重新计算父节点的选中状态。

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
