### PR TITLE
DatePicker: fix `placement` changed error #21941 #21922 #21908

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -98,12 +98,17 @@ const NewPopper = {
     offset: Popper.props.offset,
     boundariesPadding: Popper.props.boundariesPadding,
     arrowOffset: Popper.props.arrowOffset,
-    placement: Popper.props.placement,
     transformOrigin: Popper.props.transformOrigin
   },
   methods: Popper.methods,
   data() {
     return merge({ visibleArrow: true }, Popper.data);
+  },
+  computed: {
+    // fix: 21941 Fix the `placement` change error, which makes the component unusable `bug`
+    placement() {
+      return PLACEMENT_MAP[this.align] || PLACEMENT_MAP.left;
+    }
   },
   beforeDestroy: Popper.beforeDestroy
 };
@@ -580,7 +585,6 @@ export default {
       boundariesPadding: 0,
       gpuAcceleration: false
     };
-    this.placement = PLACEMENT_MAP[this.align] || PLACEMENT_MAP.left;
 
     this.$on('fieldReset', this.handleFieldReset);
   },


### PR DESCRIPTION
1、`props` 是只读属性，我们不能再 `created` 中进行变更
2、我发现修改 `align` 属性并不能够动态切换对齐方式，这好像是因为 createPopper 只会调用一次，这可能是为了避免重复创建实例，节约性能，有考虑过优化实现这个功能吗?

#21941 #21922 #21941
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
