### PR TITLE
cascader-panel:添加限制，让查询value时的数据为当前层级

### DIFF
--- a/packages/cascader-panel/src/cascader-panel.vue
+++ b/packages/cascader-panel/src/cascader-panel.vue
@@ -316,7 +316,7 @@ export default {
           const leafKey = this.config.leaf;
 
           if (Array.isArray(dataList) && dataList.filter(item => item[valueKey] === nodeValue).length > 0) {
-            const checkedNode = this.store.getNodeByValue(nodeValue);
+            const checkedNode = this.store.getNodeByValue(nodeValue, node.level + 1);
 
             if (!checkedNode.data[leafKey]) {
               this.lazyLoad(checkedNode, () => {

--- a/packages/cascader-panel/src/store.js
+++ b/packages/cascader-panel/src/store.js
@@ -50,9 +50,9 @@ export default class Store {
       : flatNodes(this.nodes, leafOnly);
   }
 
-  getNodeByValue(value) {
+  getNodeByValue(value, level = -1) {
     const nodes = this.getFlattedNodes(false, !this.config.lazy)
-      .filter(node => (valueEquals(node.path, value) || node.value === value));
+      .filter(node => (valueEquals(node.path, value) || (node.value === value && (level === -1 || node.level === level))));
     return nodes && nodes.length ? nodes[0] : null;
   }
 }


### PR DESCRIPTION
当级联数据为相同value时，比如v-model为[5, 5]，会出现子集重复添加的问题。
