### PR TITLE
Style: fixed bug while compiling scss style with dart-sass. (#21980)

### DIFF
--- a/packages/theme-chalk/src/common/var.scss
+++ b/packages/theme-chalk/src/common/var.scss
@@ -1016,13 +1016,13 @@ $--breakpoints: (
 $--breakpoints-spec: (
   'xs-only' : (max-width: $--sm - 1),
   'sm-and-up' : (min-width: $--sm),
-  'sm-only': "(min-width: #{$--sm}) and (max-width: #{$--md - 1})",
+  'sm-only': (min-width: #{$--sm}) and (max-width: #{$--md - 1}),
   'sm-and-down': (max-width: $--md - 1),
   'md-and-up' : (min-width: $--md),
-  'md-only': "(min-width: #{$--md}) and (max-width: #{$--lg - 1})",
+  'md-only': (min-width: #{$--md}) and (max-width: #{$--lg - 1}),
   'md-and-down': (max-width: $--lg - 1),
   'lg-and-up' : (min-width: $--lg),
-  'lg-only': "(min-width: #{$--lg}) and (max-width: #{$--xl - 1})",
+  'lg-only': (min-width: #{$--lg}) and (max-width: #{$--xl - 1}),
   'lg-and-down': (max-width: $--xl - 1),
   'xl-only' : (min-width: $--xl),
 );


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
This pr is related to  issue #21980
When i handled .scss file with dart-sass, error occured with message below:
```
ERROR  expected "(". 
 @media only screen and "(min-width: 768px) and (max-width: 991px)"{
                                            ^
```
The reason is that the quotes around `(min-width) and (max-width) ` is valid with node-sass, but invalid with dart-sass.
Once the quotes around removed, both of node-sass and dart-sass work!
 
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English] #(https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
