### PR TITLE
Chrome warn 'popup-manager' add 'passive' to make the page more respo…

### DIFF
--- a/src/utils/popup/popup-manager.js
+++ b/src/utils/popup/popup-manager.js
@@ -18,7 +18,7 @@ const getModal = function() {
     modalDom.addEventListener('touchmove', function(event) {
       event.preventDefault();
       event.stopPropagation();
-    });
+    }, { passive:true } );
 
     modalDom.addEventListener('click', function() {
       PopupManager.doOnModalClick && PopupManager.doOnModalClick();


### PR DESCRIPTION

```
popup-manager.js?5814:27 [Violation] Added non-passive event listener to a scroll-blocking 'touchmove' event. Consider marking event handler as 'passive' to make the page more responsive. 
```

https://github.com/ElemeFE/element/issues/5942

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
