### PR TITLE
DatePicker: fix emitInput "ti0e0tam0p" when type is week and value-format is timestamp

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -611,6 +611,9 @@ export default {
     formatToValue(date) {
       const isFormattable = isDateObject(date) || (Array.isArray(date) && date.every(isDateObject));
       if (this.valueFormat && isFormattable) {
+        if (this.valueFormat === "timestamp") {
+          return Array.isArray(date) ? date.map(d => d.getTime()) : date.getTime();
+        }
         return formatAsFormatAndType(date, this.valueFormat, this.type, this.rangeSeparator);
       } else {
         return date;

--- a/src/utils/date-util.js
+++ b/src/utils/date-util.js
@@ -40,6 +40,7 @@ export const isDateObject = function(val) {
 export const formatDate = function(date, format) {
   date = toDate(date);
   if (!date) return '';
+  format = format === 'timestamp' ? undefined : format;
   return fecha.format(date, format || 'yyyy-MM-dd', getI18nSettings());
 };
 


### PR DESCRIPTION
Fix emitInput "ti0e0tam0p" problem in date-picker when type is **week** and value-format is **timestamp**

like #16669 said

below code show this error:

template
```vue
<el-date-picker
  :value="value"
  @input="fn"
  value-format="timestamp"
  type="week">
</el-date-picker>
```
javascript
```javascript
export default {
  data() {
    return {
      value: Date.now(),
    };
  },
  methods: {
    fn(v) {
      console.log(v) // "ti0e0tam0p"
    },
  },
}
```

![Jul-17-2022 02-29-22](https://user-images.githubusercontent.com/21165139/179367739-6d00209f-565b-448f-9ca5-3a25bb4f4572.gif)

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
