### PR TITLE
Page header: Fix title displaying for bigger content

### DIFF
--- a/packages/theme-chalk/src/page-header.scss
+++ b/packages/theme-chalk/src/page-header.scss
@@ -31,6 +31,8 @@
     @include e(title) {
       font-size: 14px;
       font-weight: 500;
+      display: flex;
+      align-items: center;
     }
   }
 


### PR DESCRIPTION
In case the content's height of page header is bigger than it's title, title will not be centered vertically. This PR will fix this issue

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
