### PR TITLE
DatePicker: fix handleClear #21301

### DIFF
--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -441,8 +441,9 @@
 
     methods: {
       handleClear() {
-        this.minDate = null;
-        this.maxDate = null;
+        // popper hide call resetView
+        // this.minDate = null;
+        // this.maxDate = null;
         this.leftDate = calcDefaultValue(this.defaultValue)[0];
         this.rightDate = nextMonth(this.leftDate);
         this.$emit('pick', null);


### PR DESCRIPTION
datetimepick selects only one date. When it is cleared, clicking again is invalid #21301

Please make sure these boxes are checked before submitting your PR, thank you!

- [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
- [x] Make sure you are merging your commits to `dev` branch.
- [x] Add some descriptions and refer relative issues for you PR.

fix: #21301

or
``` 
     handleClear() {
        this.minDate = null;
        this.maxDate = null;
        this.rangeState.selecting = false;
        this.leftDate = calcDefaultValue(this.defaultValue)[0];
        this.rightDate = nextMonth(this.leftDate);
        this.$emit('pick', null);
      },
```

[The code of month range may also have problems](https://github.com/ElemeFE/element/blob/dev/packages/date-picker/src/panel/month-range.vue#L197)