### PR TITLE
Table: fix 修复table有fixed列时expand展开的内容会被错误截断的问题

### DIFF
--- a/packages/table/src/table-body.js
+++ b/packages/table/src/table-body.js
@@ -380,11 +380,15 @@ export default {
         // 使用二维数组，避免修改 $index
         return [[
           tr,
-          <tr key={'expanded-row__' + tr.key}>
-            <td colspan={ this.columnsCount } class="el-table__cell el-table__expanded-cell">
-              { renderExpanded(this.$createElement, { row, $index, store: this.store }) }
-            </td>
-          </tr>]];
+          !this.fixed
+            ? (
+              <tr key={'expanded-row__' + tr.key}>
+                <td colspan={ this.columnsCount } class="el-table__cell el-table__expanded-cell">
+                  { renderExpanded(this.$createElement, { row, $index, store: this.store }) }
+                </td>
+              </tr>
+            ) : (<tr></tr>)
+        ]];
       } else if (Object.keys(treeData).length) {
         assertRowKey();
         // TreeTable 时，rowKey 必须由用户设定，不使用 getKeyOfRow 计算


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

Fix #21833 #21788

当table有fixed列时，展开expand列会导致fixed列重复渲染，最后效果就是展开的内容被截断了。