### PR TITLE
Select: Add default value to loadingText

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -280,7 +280,10 @@
       loading: Boolean,
       popperClass: String,
       remote: Boolean,
-      loadingText: String,
+      loadingText: {
+        type: String,
+        default: 'Loading'
+      },
       noMatchText: String,
       noDataText: String,
       remoteMethod: Function,


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

According to [Document](https://element.eleme.io/#/en-US/component/select), default value of `loadingText` is 'Loading'. But that default value is not exist.
<img width="868" alt="image" src="https://user-images.githubusercontent.com/75117116/189019795-99bc207c-40ee-44bf-b78f-e6651b74858d.png">
