### PR TITLE
Utils: fix table bodyWidth resizing latency (#21818)

### DIFF
--- a/src/utils/resize-event.js
+++ b/src/utils/resize-event.js
@@ -1,5 +1,4 @@
 import ResizeObserver from 'resize-observer-polyfill';
-import { debounce } from 'throttle-debounce';
 
 const isServer = typeof window === 'undefined';
 
@@ -8,9 +7,7 @@ const resizeHandler = function(entries) {
   for (let entry of entries) {
     const listeners = entry.target.__resizeListeners__ || [];
     if (listeners.length) {
-      listeners.forEach(fn => {
-        fn();
-      });
+      listeners.forEach(fn => window.requestAnimationFrame(() => fn()));
     }
   }
 };
@@ -20,7 +17,7 @@ export const addResizeListener = function(element, fn) {
   if (isServer) return;
   if (!element.__resizeListeners__) {
     element.__resizeListeners__ = [];
-    element.__ro__ = new ResizeObserver(debounce(16, resizeHandler));
+    element.__ro__ = new ResizeObserver(resizeHandler);
     element.__ro__.observe(element);
   }
   element.__resizeListeners__.push(fn);


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

PR [#21255](https://github.com/ElemeFE/element/pull/21255) using debounce leads to table body resizing latency. See https://github.com/ElemeFE/element/issues/21818#issuecomment-1104687479.