### PR TITLE
修复动态加载数据为空数组之前数据缓存问题

### DIFF
--- a/packages/table/src/store/tree.js
+++ b/packages/table/src/store/tree.js
@@ -198,9 +198,7 @@ export default {
           treeData[key].loading = false;
           treeData[key].loaded = true;
           treeData[key].expanded = true;
-          if (data.length) {
-            this.$set(lazyTreeNodeMap, key, data);
-          }
+          this.$set(lazyTreeNodeMap, key, data);
           this.table.$emit('expand-change', row, true);
         });
       }


### PR DESCRIPTION
场景：删除只有一个子菜单下的子菜单，接口返回空数组，无法更新该节点下数据

Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
