### PR TITLE
fix: 新用户拉下来代码后安装，copy-webpack-plugin版本不会更新到5.1.2，而是5.0.0。从而触发bug：修改./…

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "babel-regenerator-runtime": "^6.5.0",
     "chai": "^4.2.0",
     "chokidar": "^1.7.0",
-    "copy-webpack-plugin": "^5.0.0",
+    "copy-webpack-plugin": "^5.1.2",
     "coveralls": "^3.0.3",
     "cp-cli": "^1.0.2",
     "cross-env": "^3.1.3",


### PR DESCRIPTION
【bug修复】
新用户拉下来代码后执行npm run dev安装，copy-webpack-plugin版本不会更新到5.1.2，而是5.0.0。
从而触发bug：修改examples/entry.js时热更新失效。具体原因为该module构建时间被copy-webpack-plugin插件更改，导致模块没有正确执行热更新的逻辑。

Element UI ：2.15.10
Vue：2.5.21
yarn: 1.22.4
操作系统：版本	Windows 10 家庭中文版 21H2
浏览器: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 Safari/537.36'

