### PR TITLE
Progress: fix progress 百分比归零时动画消失的bug

### DIFF
--- a/packages/progress/src/progress.vue
+++ b/packages/progress/src/progress.vue
@@ -36,7 +36,7 @@
           :stroke="stroke"
           fill="none"
           :stroke-linecap="strokeLinecap"
-          :stroke-width="percentage ? relativeStrokeWidth : 0"
+          :stroke-width="relativeStrokeWidth"
           :style="circlePathStyle"></path>
       </svg>
     </div>


### PR DESCRIPTION
[bug地址](https://element.eleme.cn/#/zh-CN/component/progress#yi-biao-pan-xing-jin-du-tiao)
当仪表板从10%到0%时，动画消失，原因为stroke-width突变为0
* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
