### PR TITLE
Table: fix 修复 table 多级表头在固定时一级表头宽度不随子级表头宽度拖拽更新问题

### DIFF
--- a/packages/table/src/table-layout.js
+++ b/packages/table/src/table-layout.js
@@ -129,6 +129,13 @@ class TableLayout {
     return false;
   }
 
+  getFixedColumnWidth(column) {
+    if (column.children) {
+      return column.children.reduce((pre, cur) => pre + this.getFixedColumnWidth(cur), 0);
+    }
+    return column.realWidth || column.width;
+  }
+
   updateColumnsWidth() {
     if (Vue.prototype.$isServer) return;
     const fit = this.fit;
@@ -198,8 +205,8 @@ class TableLayout {
 
     if (fixedColumns.length > 0) {
       let fixedWidth = 0;
-      fixedColumns.forEach(function(column) {
-        fixedWidth += column.realWidth || column.width;
+      fixedColumns.forEach((column) => {
+        fixedWidth += this.getFixedColumnWidth(column);
       });
 
       this.fixedWidth = fixedWidth;
@@ -208,8 +215,8 @@ class TableLayout {
     const rightFixedColumns = this.store.states.rightFixedColumns;
     if (rightFixedColumns.length > 0) {
       let rightFixedWidth = 0;
-      rightFixedColumns.forEach(function(column) {
-        rightFixedWidth += column.realWidth || column.width;
+      rightFixedColumns.forEach((column) => {
+        rightFixedWidth += this.getFixedColumnWidth(column);
       });
 
       this.rightFixedWidth = rightFixedWidth;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
修复 table 多级表头在固定时一级表头宽度不随子级表头宽度拖拽更新问题，这个问题在横向滚动表格时会出现