### PR TITLE
Table: When the type of data is not Array, the page will stuck (#22197)

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -624,7 +624,14 @@
       data: {
         immediate: true,
         handler(value) {
-          this.store.commit('setData', value);
+          if (Array.isArray(value)) {
+            this.store.commit('setData', value);
+          } else {
+            console.error('Type check failed for prop "data". Expected Array, got ' +
+            typeof value +
+            ', In order to let the page continue, we changed "data" to [] !');
+            this.store.commit('setData', []);
+          }
         }
       },
 


### PR DESCRIPTION
close #22197
解决方式： 在传入data后进行格式校验，如果不合法则向后传递空数组以至于不卡死页面。

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
