### PR TITLE
CheckboxGroup: fix 组件设置min>=2 时无法选中

### DIFF
--- a/packages/checkbox/src/checkbox.vue
+++ b/packages/checkbox/src/checkbox.vue
@@ -91,9 +91,6 @@
         set(val) {
           if (this.isGroup) {
             this.isLimitExceeded = false;
-            (this._checkboxGroup.min !== undefined &&
-              val.length < this._checkboxGroup.min &&
-              (this.isLimitExceeded = true));
 
             (this._checkboxGroup.max !== undefined &&
               val.length > this._checkboxGroup.max &&


### PR DESCRIPTION
CheckboxGroup组件设置min>=2时,如果不给默认值，单个Checkbox无法选中
