### PR TITLE
Button: fix web-types type props

### DIFF
--- a/web-types.json
+++ b/web-types.json
@@ -371,7 +371,7 @@
             {
               "name": "type",
               "description": "Button type",
-              "type": "'primary' | 'success' | 'warning' | 'danger' | 'info' | 'text"
+              "type": "'primary' | 'success' | 'warning' | 'danger' | 'info' | 'text'"
             },
             {
               "name": "plain",


### PR DESCRIPTION
type属性少了个引号，会导致webstorm无法识别type="text"的情况

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
