### PR TITLE
Input: fix maxLength with native type number

### DIFF
--- a/packages/input/src/input.vue
+++ b/packages/input/src/input.vue
@@ -237,7 +237,7 @@
       isWordLimitVisible() {
         return this.showWordLimit &&
           this.$attrs.maxlength &&
-          (this.type === 'text' || this.type === 'textarea') &&
+          (this.type === 'text' || this.type === 'number' || this.type === 'textarea') &&
           !this.inputDisabled &&
           !this.readonly &&
           !this.showPassword;


### PR DESCRIPTION
Property maxLength does not work with native type number

