### PR TITLE
Update getPropByPath to support braces and object keys with special characters #22175, #10293, and #17893

### DIFF
--- a/packages/form/src/form-item.vue
+++ b/packages/form/src/form-item.vue
@@ -149,10 +149,6 @@
         if (!model || !this.prop) { return; }
 
         let path = this.prop;
-        if (path.indexOf(':') !== -1) {
-          path = path.replace(/:/, '.');
-        }
-
         return getPropByPath(model, path, true).v;
       },
       isRequired() {
@@ -234,10 +230,6 @@
         let model = this.form.model;
         let value = this.fieldValue;
         let path = this.prop;
-        if (path.indexOf(':') !== -1) {
-          path = path.replace(/:/, '.');
-        }
-
         let prop = getPropByPath(model, path, true);
 
         this.validateDisabled = true;

--- a/src/utils/util.js
+++ b/src/utils/util.js
@@ -46,10 +46,15 @@ export const getValueByPath = function(object, prop) {
 
 export function getPropByPath(obj, path, strict) {
   let tempObj = obj;
-  path = path.replace(/\[(\w+)\]/g, '.$1');
-  path = path.replace(/^\./, '');
+  let matcher = /(?:\[['"])(.+)(?=['"]\])|(\w+)(?!['"]\])/g;
+  let match;
+  let keyArr = [];
 
-  let keyArr = path.split('.');
+  do {
+    match = matcher.exec(path);
+    if (match) { keyArr.push(match[1] || match[0]); }
+  } while (match);
+
   let i = 0;
   for (let len = keyArr.length; i < len - 1; ++i) {
     if (!tempObj && !strict) break;

--- a/test/unit/specs/util.spec.js
+++ b/test/unit/specs/util.spec.js
@@ -1,0 +1,28 @@
+import { getPropByPath } from 'element-ui/src/utils/util';
+
+describe('utils.getPropByPath', () => {
+  it('getPropByPath', () => {
+
+    const target = {
+      mountains: {
+        'Mt. Fiji': 1,
+        'Mountain: Mt. Blanca': 2,
+        'mt fiji': 3,
+        'fiji': 4,
+        'A Very \'Strange\' ["key"]': 5
+      }
+    };
+
+    expect(getPropByPath(target, 'mountains[\'Mt. Fiji\']').v).to.equal(1);
+    expect(getPropByPath(target, 'mountains[\'Mountain: Mt. Blanca\']').v).to.equal(2);
+    expect(getPropByPath(target, 'mountains[\'mt fiji\']').v).to.equal(3);
+    expect(getPropByPath(target, 'mountains["Mt. Fiji"]').v).to.equal(1);
+    expect(getPropByPath(target, 'mountains["Mountain: Mt. Blanca"]').v).to.equal(2);
+    expect(getPropByPath(target, 'mountains["mt fiji"]').v).to.equal(3);
+    expect(getPropByPath(target, 'mountains[fiji]').v).to.equal(4);
+    expect(getPropByPath(target, 'mountains.fiji').v).to.equal(4);
+    expect(getPropByPath(target, 'mountains["A Very \'Strange\' ["key"]"]').v).to.equal(5);
+
+  });
+
+});


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

This PR is related to #22175, #10293, and #17893. Although it's rare, some of us need to lookup props using brace notation and keys that contain special characters. For example when our data looks like this and we need to validate the mountains['Mountain: Mt. Blanca'] property.

```
{
  mountains: {
    'Mt. Fiji': 1,
    'Mountain: Mt. Blanca': 2
  }
}
```

This PR updates getPropByPath so it can parse object key paths using brace notation and parse keys containing special characters. It also adds test cases for the getPropByPath function.

I do have an outstanding question related to this code in form-item.vue.

```
if (path.indexOf(':') !== -1) {
  path = path.replace(/:/, '.');
}
```

This code will prevent the use of semicolons in object keys. Do you think there is a way to safely remove this? Is there an alternative? This conversions seem like an undocumented feature that the users shouldn't be relying on, but I don't know the code well enough to be certain.