### PR TITLE
Fix typechecking with typescript 4.9.5

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -18,6 +18,9 @@ jobs:
           node-version: '10.15.0'
           registry-url: https://registry.npmjs.com/
 
+      - name: Check types
+        run: npm run check-types
+
       - name: Build
         run: npm run bootstrap && npm run deploy:build
         

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "deepmerge": "^1.2.0",
     "normalize-wheel": "^1.0.1",
     "resize-observer-polyfill": "^1.5.0",
-    "throttle-debounce": "^1.0.1"
+    "throttle-debounce": "^1.0.1",
+    "typescript": "^4.9.5"
   },
   "peerDependencies": {
     "vue": "^2.5.17"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dist": "npm run clean && npm run build:file && npm run lint && webpack --config build/webpack.conf.js && webpack --config build/webpack.common.js && webpack --config build/webpack.component.js && npm run build:utils && npm run build:umd && npm run build:theme",
     "i18n": "node build/bin/i18n.js",
     "lint": "eslint src/**/* test/**/* packages/**/* build/**/* --quiet",
+    "check-types": "tsc --noEmit -p .",
     "pub": "npm run bootstrap && sh build/git-release.sh && sh build/release.sh && node build/bin/gen-indices.js",
     "test": "npm run lint && npm run build:theme && cross-env CI_ENV=/dev/ BABEL_ENV=test karma start test/unit/karma.conf.js --single-run",
     "test:watch": "npm run build:theme && cross-env BABEL_ENV=test karma start test/unit/karma.conf.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": true,
+    "noEmit": true,
+    "paths": {
+      "resize-observer-polyfill": ["./types/overrides/resize-observer-polyfill"]
+    }
+  },
+  "include": ["src/**/*", "packages/**/*", "types/**/*"],
+  "exclude": ["node_modules/**/*"]
+}

--- a/types/element-ui.d.ts
+++ b/types/element-ui.d.ts
@@ -316,7 +316,7 @@ export class Tooltip extends ElTooltip {}
 export class Transfer extends ElTransfer {}
 
 /** Tree Component */
-export class Tree<K = any, D = TreeData> extends ElTree<K, D> {}
+export class Tree<K = any, D extends TreeData = TreeData> extends ElTree<K, D> {}
 
 /** Upload Component */
 export class Upload extends ElUpload {}

--- a/types/overrides/resize-observer-polyfill/index.d.ts
+++ b/types/overrides/resize-observer-polyfill/index.d.ts
@@ -1,0 +1,36 @@
+// resize-observer-polyfill types conflict with typescript's own typings on typescript > 4.2.2
+// See https://github.com/que-etc/resize-observer-polyfill/issues/83
+//
+// So we override the typings for resize-observer-polyfill and remove the DOMRectReadOnly interface
+// definition
+// https://raw.githubusercontent.com/que-etc/resize-observer-polyfill/master/src/index.d.ts
+
+declare global {
+    interface ResizeObserverCallback {
+        (entries: ResizeObserverEntry[], observer: ResizeObserver): void
+    }
+
+    interface ResizeObserverEntry {
+        readonly target: Element;
+        readonly contentRect: DOMRectReadOnly;
+    }
+
+    interface ResizeObserver {
+        observe(target: Element): void;
+        unobserve(target: Element): void;
+        disconnect(): void;
+    }
+}
+
+declare var ResizeObserver: {
+    prototype: ResizeObserver;
+    new(callback: ResizeObserverCallback): ResizeObserver;
+}
+
+interface ResizeObserver {
+    observe(target: Element): void;
+    unobserve(target: Element): void;
+    disconnect(): void;
+}
+
+export default ResizeObserver;


### PR DESCRIPTION
This fixes typechecking with typescript 4.9.5 (#22401), in particular two things:
- Typescript 4.9.5 complains that the TreeData type is incorrect (missing `extends TreeData`)
- Typescript 4.9.5 ships with custom typings for `resize-observer-polyfill` which conflict with the types of the `resize-observer-polyfill` dependency that ElementUI has. I followed the workaround mentioned [in this issue](https://github.com/que-etc/resize-observer-polyfill/issues/83) to fix that.

This also adds typescript type checking as a CI step - which would be useful to avoid future issues like this. I think I need approval to be able to test this on the CI.

If you do not want to run typescript typechecking on the CI, I'm happy to remove this part and just focus on fixing the typing.

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
