### PR TITLE
el-table-column: 其他标签包裹 el-table-column 时，此列数据在页面中总是出现在倒数第二的位置上问题修复

### DIFF
--- a/packages/table/src/store/index.js
+++ b/packages/table/src/store/index.js
@@ -34,7 +34,7 @@ Watcher.prototype.mutations = {
       if (!array) array = parent.children = [];
     }
 
-    if (typeof index !== 'undefined') {
+    if (typeof index !== 'undefined' && index !== -1) {
       array.splice(index, 0, column);
     } else {
       array.push(column);

--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -113,7 +113,31 @@ export default {
     },
 
     getColumnElIndex(children, child) {
-      return [].indexOf.call(children, child);
+      for (let i = 0, len = children.length; i < len; i++) {
+        const item = children[i];
+        if (item === child) {
+          return i;
+        } else if (item.children && item.children.length) {
+          if (this.generateColumn(item.children, child)) {
+            return i;
+          }
+        }
+      }
+      return -1;
+    },
+
+    generateColumn(children, child) {
+      for (let i = 0, len = children.length; i < len; i++) {
+        const item = children[i];
+        if (item === child) {
+          return true;
+        } else if (item.children && item.children.length) {
+          if (this.generateColumn(item.children, child)) {
+            return true;
+          }
+        }
+      }
+      return false;
     },
 
     setColumnWidth(column) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
问题描述：在el-table组件中，用其他标签（如span、div）包裹 el-table-column时，在渲染到页面中后会出现该数据列在表格中的位置有问题：总是出现在倒数第二列。
解决方案：查找 column项 对应的下标时，增加查找子标签逻辑，以兼容标签嵌套；如果没找到，即下标为 -1 时，将对应 column项 添加到最后。