### PR TITLE
fix(dropdown): menu popup again before the settimeout end in hover mode

### DIFF
--- a/packages/dropdown/src/dropdown.vue
+++ b/packages/dropdown/src/dropdown.vue
@@ -235,6 +235,7 @@
         }
       },
       handleMenuItemClick(command, instance) {
+        clearTimeout(this.timeout);
         if (this.hideOnClick) {
           this.visible = false;
         }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

问题描述：

hover模式下，菜单展开有默认150ms的定时器，如果在定时器结束前点击item关闭，菜单会再次打开，如下图所示：

![chrome-capture-2023-2-10 (1)](https://user-images.githubusercontent.com/20423068/224253205-a0298b03-a1e1-45dd-988e-e26a104ffd47.gif)

解决方案：

在执行`handleMenuItemClick` 时，将定时器清空即可。


