### PR TITLE
fix: cascader lazyLoad radio check expand panel

### DIFF
--- a/packages/cascader-panel/src/cascader-node.vue
+++ b/packages/cascader-panel/src/cascader-node.vue
@@ -75,9 +75,11 @@
       },
 
       handleCheckChange() {
-        const { panel, value, node } = this;
+        const { panel, value, node, config } = this;
         panel.handleCheckChange(value);
-        panel.handleExpand(node);
+        if (!config.lazy) {
+          panel.handleExpand(node);
+        }
       },
 
       handleMultiCheckChange(checked) {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
cascader 使用 lazyLoad 且checkStrictly为 true 时，选中radio会展开下一级panel，但不执行lazyLoad函数，导致下一级数据为空，与多选时行为不一致，因此改为不展开下一级panel
