### PR TITLE
Tabs: fix 路由切换导致实例丢失的问题

### DIFF
--- a/packages/tabs/src/tabs.vue
+++ b/packages/tabs/src/tabs.vue
@@ -47,7 +47,7 @@
         if (this.$refs.nav) {
           this.$nextTick(() => {
             this.$refs.nav.$nextTick(_ => {
-              this.$refs.nav.scrollToActiveTab();
+              this.$refs.nav && this.$refs.nav.scrollToActiveTab();
             });
           });
         }
@@ -171,7 +171,7 @@
         </div>
       );
     },
-  
+
     created() {
       if (!this.currentName) {
         this.setCurrentName('0');


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

如果tab切换后route也切换，tab重新渲染，之前的实例就丢了。nexttick后访问不到_this.$refs.nav。
[Vue warn]: Error in nextTick: "TypeError: Cannot read properties of undefined (reading 'scrollToActiveTab')"

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
