### PR TITLE
fix(Table): fix repeatedly updating the flexible columns' width

### DIFF
--- a/packages/table/src/table-layout.js
+++ b/packages/table/src/table-layout.js
@@ -161,14 +161,25 @@ class TableLayout {
           const flexWidthPerPixel = totalFlexWidth / allColumnsWidth;
           let noneFirstWidth = 0;
 
+          // 标记是否有任一列缩窄了
+          let isAnyColNarrower = false;
           flexColumns.forEach((column, index) => {
             if (index === 0) return;
             const flexWidth = Math.floor((column.minWidth || 80) * flexWidthPerPixel);
             noneFirstWidth += flexWidth;
-            column.realWidth = (column.minWidth || 80) + flexWidth;
+            const realWidth = (column.minWidth || 80) + flexWidth;
+            if (!isAnyColNarrower) isAnyColNarrower = column.realWidth > realWidth;
+            column.realWidth = realWidth;
           });
 
-          flexColumns[0].realWidth = (flexColumns[0].minWidth || 80) + totalFlexWidth - noneFirstWidth;
+          const firstRealWidth = (flexColumns[0].minWidth || 80) + totalFlexWidth - noneFirstWidth;
+          // 由于上面使用了 Math.floor 对 flexWidth 进行取整，那么可能导致 firstRealWidth 计算结果产生偏差（窗口缩小，但 firstRealWidth 却变大了）
+          // 在临界窗口大小的情况下（页面即将出现滚动条 且 有某一列数据即将换行）会反复出现滚动条，进而触发重新计算宽度，产生表格闪烁的问题
+          // 所以这里判断下，如果其他列缩窄了，那么当 firstRealWidth 也缩窄了才去更新 realWidth
+          // see: https://github.com/ElemeFE/element/issues/16167
+          if (!isAnyColNarrower || firstRealWidth < flexColumns[0].realWidth) {
+            flexColumns[0].realWidth = firstRealWidth;
+          }
         }
       } else { // HAVE HORIZONTAL SCROLL BAR
         this.scrollX = true;

--- a/packages/table/src/table-layout.js
+++ b/packages/table/src/table-layout.js
@@ -170,10 +170,11 @@ class TableLayout {
 
           const isBoxSmaller = !!this._lastTotalFlexWidth && this._lastTotalFlexWidth > totalFlexWidth;
           const firstRealWidth = (flexColumns[0].minWidth || 80) + totalFlexWidth - noneFirstWidth;
-          // If the container box gets smaller and the result of `firstRealWidth` is greater than before,
-          // we don't update the first flexible column's `realWidth`.
-          // In some cases, the result of `firstRealWidth` will be greater than before, even if the container gets smaller.
-          // Probably because of the decimal of the rest of columns' `realWidth` are rounded down?
+          // If the container box becomes smaller and the value of `firstRealWidth` increases,
+          // we shouldn't update the `realWidth` of the first flexible column.
+          // In certain situations, the `firstRealWidth` value may increase despite the container getting smaller
+          // due to the rounding down of decimal values in the remaining columns' `realWidth`.
+          // This can cause the columns' width to be repeatedly updated, leading to behavior like that seen in issue #16167.
           // See: https://github.com/ElemeFE/element/issues/16167
           if (!isBoxSmaller || firstRealWidth < flexColumns[0].realWidth) {
             flexColumns[0].realWidth = firstRealWidth;

--- a/packages/table/src/table-layout.js
+++ b/packages/table/src/table-layout.js
@@ -173,9 +173,10 @@ class TableLayout {
           });
 
           const firstRealWidth = (flexColumns[0].minWidth || 80) + totalFlexWidth - noneFirstWidth;
-          // 由于上面使用了 Math.floor 对 flexWidth 进行取整，那么可能导致 firstRealWidth 计算结果产生偏差（窗口缩小，但 firstRealWidth 却变大了）
-          // 在临界窗口大小的情况下（页面即将出现滚动条 且 有某一列数据即将换行）会反复出现滚动条，进而触发重新计算宽度，产生表格闪烁的问题
-          // 所以这里判断下，如果其他列缩窄了，那么当 firstRealWidth 也缩窄了才去更新 realWidth
+          // 由于上面使用了 Math.floor 对 flexWidth 进行取整，那么可能导致 firstRealWidth 计算结果产生偏差：
+          //   -> 窗口（父容器）缩小，但 firstRealWidth 却变大了，这将影响内容是否换行
+          // 在边界情况下，列内容换行会影响垂直滚动条的出现，触发重新计算宽度，进而产生表格闪烁的问题
+          // 所以这里判断下，如果某一列缩窄了，那么仅在 firstRealWidth 也减小的情况下才更新 realWidth 来避免上述问题
           // see: https://github.com/ElemeFE/element/issues/16167
           if (!isAnyColNarrower || firstRealWidth < flexColumns[0].realWidth) {
             flexColumns[0].realWidth = firstRealWidth;


### PR DESCRIPTION
Fix #16167

https://github.com/ElemeFE/element/blob/f14b5ba5406b0f682499663fc5d6fb10864b3146/packages/table/src/table-layout.js?plain=1#L159-L172

这个问题产生的原因在于，`L161` `flexWidthPerPixel` 是大概率带小数的，而 `L166` 在计算 `flexColumns`（除第一个以外）的 `realWidth` 时使用 `Math.floor` 对计算结果进行取整，那么这些被约掉的小数则会加到第一个弹性列的宽度中，所以即使父容器缩小了，第一列的 `realWidth` 也有可能比之前大。

e.g. 缩小窗口，第一列在缩小前可能已经换行了，缩小后却反而一行就能显示完

当被约掉的小数值恰好能够影响第一列的内容是否换行，并且换行后将导致出现垂直滚动条时，就会产生一直在计算宽度的问题，页面的表现为不断闪烁。