### PR TITLE
Table: fix table header slot not reactive #21297

### DIFF
--- a/packages/table/src/table-column.js
+++ b/packages/table/src/table-column.js
@@ -306,6 +306,15 @@ export default {
     owner.store.commit('insertColumn', this.columnConfig, columnIndex, this.isSubColumn ? parent.columnConfig : null);
   },
 
+  beforeUpdate() {
+    if (this.$slots.header && this.$scopedSlots.header) {
+      this.columnConfig.renderHeader = (h, scope) => {
+        const renderHeader = this.$scopedSlots.header;
+        return renderHeader ? renderHeader(scope) : this.columnConfig.label;
+      };
+    }
+  },
+
   destroyed() {
     if (!this.$parent) return;
     const parent = this.$parent;


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!
在Table自定义表头中用el-checkbox 勾选与取消勾选不生效
示例代码：
<el-table-column align="center">
  <template slot="header">
  <el-checkbox v-model="selectAllView" @change="selectAllViewFunc(row)">显示</el-checkbox>
  </template>
</el-table-column>

通常解决方法：加上slot-scope="{ row }"
<el-table-column align="center">
  <template slot="header" slot-scope="{ row }">
  <el-checkbox v-model="selectAllView" @change="selectAllViewFunc(row)">显示</el-checkbox>
  </template>
</el-table-column>

但很多人不知道为什么这样去解决，或者说不清楚如何解决，提出了相对应的issue问题
现在我补充了代码使可以不加slot-scope="{ row }"依然能正常使用checkbox等组件

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https:github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français] (https:github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR