### PR TITLE
Table: fix repeatedly updating the flexible columns' width

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -513,8 +513,8 @@
       },
 
       bodyWidth() {
-        const { bodyWidth, scrollY, gutterWidth } = this.layout;
-        return bodyWidth ? bodyWidth - (scrollY ? gutterWidth : 0) + 'px' : '';
+        const { bodyWidth, scrollY, gutterWidth, bodyWidthOffset } = this.layout;
+        return bodyWidth ? bodyWidth - (scrollY ? gutterWidth : 0) - bodyWidthOffset + 'px' : '';
       },
 
       bodyHeight() {


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

---

Fix #16167

https://github.com/ElemeFE/element/blob/f14b5ba5406b0f682499663fc5d6fb10864b3146/packages/table/src/table-layout.js?plain=1#L159-L172

这个问题产生的原因在于，`L161` `flexWidthPerPixel` 是大概率带小数的，而 `L166` 在计算 `flexColumns`（除第一个以外）的 `realWidth` 时使用 `Math.floor` 对计算结果进行取整，那么这些被约掉的小数则会加到第一个弹性列的宽度中，所以即使父容器缩小了，第一列的 `realWidth` 也有可能比之前大。

例如：缩小窗口，第一列在缩小前可能已经换行了，缩小后却反而一行就能显示完。

当被约掉的小数值恰好能够影响第一列的内容是否换行，并且换行后将导致出现垂直滚动条时，就会产生一直在计算宽度的问题，页面的表现为不断闪烁。