### PR TITLE
ColorPicker: fix hex format color valid error (#22596)

### DIFF
--- a/packages/color-picker/src/color.js
+++ b/packages/color-picker/src/color.js
@@ -249,7 +249,7 @@ export default class Color {
       }
     } else if (value.indexOf('#') !== -1) {
       const hex = value.replace('#', '').trim();
-      if (!/^(?:[0-9a-fA-F]{3}){1,2}|[0-9a-fA-F]{8}$/.test(hex)) return;
+      if (!/^((?:[0-9a-fA-F]{3}){1,2}|[0-9a-fA-F]{8})$/.test(hex)) return;
       let r, g, b;
 
       if (hex.length === 3) {


### PR DESCRIPTION
Closes #22596
因在PR #20710 中引入了ColorPicker对八位hex格式的颜色支持，该校验正则存在问题导致非法格式（如#000ag）也能通过校验，造成选色面板无法正常点击取值。
/^(?:[0-9a-fA-F]{3}){1,2}|[0-9a-fA-F]{8}$/因优先级原因实际为/(^(?:[0-9a-fA-F]{3}){1,2})|([0-9a-fA-F]{8}$)/与实际要求不符合。
应修改为/^((?:[0-9a-fA-F]{3}){1,2}|[0-9a-fA-F]{8})$/。