### PR TITLE
[MessageBox] Fix #22610: In the MessageBox, the class of "Confirm" button should not contain two different types

### DIFF
--- a/packages/message-box/src/main.vue
+++ b/packages/message-box/src/main.vue
@@ -64,6 +64,7 @@
           <el-button
             :loading="confirmButtonLoading"
             ref="confirm"
+            type="primary"
             :class="[ confirmButtonClasses ]"
             v-show="showConfirmButton"
             :round="roundButton"
@@ -140,7 +141,7 @@
       },
 
       confirmButtonClasses() {
-        return `el-button--primary ${ this.confirmButtonClass }`;
+        return `${ this.confirmButtonClass }`;
       },
       cancelButtonClasses() {
         return `${ this.cancelButtonClass }`;


### PR DESCRIPTION
### Description
Fix #22610: In the MessageBox, the class of "Confirm" button should not contain two different types  

### Screenshot 
   ![image](https://github.com/ElemeFE/element/assets/33945539/05c35267-4d49-40d7-bb45-c777a7a97958)

### Checklist
  * [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
  * [x] Make sure you are merging your commits to `dev` branch.
  * [x] Add some descriptions and refer relative issues for you PR.
