### PR TITLE
Form: Fix label-position left failure caused by label-width auto bug

### DIFF
--- a/packages/form/src/label-wrap.vue
+++ b/packages/form/src/label-wrap.vue
@@ -14,7 +14,7 @@ export default {
     if (this.isAutoWidth) {
       const autoLabelWidth = this.elForm.autoLabelWidth;
       const style = {};
-      if (autoLabelWidth && autoLabelWidth !== 'auto') {
+      if (autoLabelWidth && this.elForm.labelPosition !== 'left') {
         const marginLeft = parseInt(autoLabelWidth, 10) - this.computedWidth;
         if (marginLeft) {
           style.marginLeft = marginLeft + 'px';


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.

问题描述：当设置了 label-width 为 auto 时，label-position 设置的 left 失效了，标签的对齐方式还是右对齐。
修复情况：修复了 packages/form/src/label-wrap.vue 文件的第17行，将原先的 autoLabelWidth && autoLabelWidth !== 'auto' 判断改为了 autoLabelWidth && this.elForm.labelPosition !== 'left'。
修复原因：
1. 从 Form 组件获取的 autoLabelWidth 不可能是 auto，只可能是0、空字符串或者一个具体的包含px单位的宽度，所以把 autoLabelWidth !== 'auto' 删除了。
2. 如果 label-position 设置为 left 时，标签需要左对齐，不需要计算 margin-left 的距离去让标签右对齐，所以加上了 this.elForm.labelPosition !== 'left' 的判断。
