### PR TITLE
Avatar: set img tag's width attribute

### DIFF
--- a/packages/theme-chalk/src/avatar.scss
+++ b/packages/theme-chalk/src/avatar.scss
@@ -15,6 +15,7 @@
 
   >img {
     display: block;
+    width: 100%;
     height: 100%;
     vertical-align: middle;
   }


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

The object-fit property requires the element to have explicit width and height in order to perform fitting operations based on its dimensions. 
There is currently an issue with the [fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) attribute.  [docs](https://element.eleme.cn/#/en-US/component/avatar#how-the-image-fit-its-container)


