### PR TITLE
[table]:fix diaplay when there is no content after table filtering

### DIFF
--- a/packages/table/src/table.vue
+++ b/packages/table/src/table.vue
@@ -46,7 +46,7 @@
         }">
       </table-body>
       <div
-        v-if="!data || data.length === 0"
+        v-if="!data || data.length === 0 || tableData.length === 0"
         class="el-table__empty-block"
         ref="emptyBlock"
         :style="emptyBlockStyle">


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
issue #22679 
表格有筛选的时候，当筛选条件选中后表格没有数据的时候，如果有滚动条，会看不见了，也没有暂无数据的提示
我在table.vue文件49行的v-if里面添加了|| tableData.length === 0就可以解决这个问题
