### PR TITLE
DatePicker: fix the memory leak when showTime is set to true

### DIFF
--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -610,6 +610,10 @@ export default {
     this.$on('fieldReset', this.handleFieldReset);
   },
 
+  beforeDestroy() {
+    this.unmountPicker();
+  },
+
   methods: {
     focus() {
       if (!this.ranged) {
@@ -919,7 +923,9 @@ export default {
         if (typeof this.unwatchPickerOptions === 'function') {
           this.unwatchPickerOptions();
         }
-        this.picker.$el.parentNode.removeChild(this.picker.$el);
+        if (this.picker.$el.parentNode) {
+          this.picker.$el.parentNode.removeChild(this.picker.$el);
+        }
       }
     },
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.

fix: https://github.com/ElemeFE/element/issues/20167

date picker type为date时能正常释放内存，type含有time时内存无法回收


原因：
DatePicker中picker属性上的实例正常情况下会在当前实例销毁时自动回收(但是picker没有走正常的生命周期方法)。
当panel中含有time时，内部的v-clickoutside会在闭包变量nodeList中持有picker的$el，导致整个实例无法销毁。
