### PR TITLE
fix:  default-first-option behavior when typing Chinese

### DIFF
--- a/packages/select/src/select.vue
+++ b/packages/select/src/select.vue
@@ -452,7 +452,6 @@
         const text = event.target.value;
         if (event.type === 'compositionend') {
           this.isOnComposition = false;
-          this.$nextTick(_ => this.handleQueryChange(text));
         } else {
           const lastCharacter = text[text.length - 1] || '';
           this.isOnComposition = !isKorean(lastCharacter);


### PR DESCRIPTION
…' is ineffective when using Chinese input for searching

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
远程搜索时输入中文，default-first-option无效，修复 #21366 制造出来的问题
输入英文时没影响，输入中文第一个无法选中
复现地址 https://codepen.io/shihao-zhao/pen/LYqJWQq