### PR TITLE
fix(Autocomplete): fix highlight method in autocomplete fails to navigate to the specified line

### DIFF
--- a/packages/autocomplete/src/autocomplete.vue
+++ b/packages/autocomplete/src/autocomplete.vue
@@ -250,15 +250,10 @@
         const suggestionList = suggestion.querySelectorAll('.el-autocomplete-suggestion__list li');
 
         let highlightItem = suggestionList[index];
-        let scrollTop = suggestion.scrollTop;
         let offsetTop = highlightItem.offsetTop;
 
-        if (offsetTop + highlightItem.scrollHeight > (scrollTop + suggestion.clientHeight)) {
-          suggestion.scrollTop += highlightItem.scrollHeight;
-        }
-        if (offsetTop < scrollTop) {
-          suggestion.scrollTop -= highlightItem.scrollHeight;
-        }
+        suggestion.scrollTop = offsetTop;
+
         this.highlightedIndex = index;
         let $input = this.getInput();
         $input.setAttribute('aria-activedescendant', `${this.id}-item-${this.highlightedIndex}`);

--- a/test/unit/specs/autocomplete.spec.js
+++ b/test/unit/specs/autocomplete.spec.js
@@ -396,7 +396,7 @@ describe('Autocomplete', () => {
         let suggestionsList = suggestions.querySelectorAll('.el-autocomplete-suggestion__list li');
         let highlightedItem = suggestionsList[8];
         expect(highlightedItem.classList.contains('highlighted')).to.be.true;
-        expect(suggestions.scrollTop === highlightedItem.scrollHeight).to.be.true;
+        expect(suggestions.scrollTop === highlightedItem.offsetTop).to.be.true;
         done();
       });
     }, 500);


### PR DESCRIPTION
希望调用 AutoComplete 中的 highlight 方法来将列表滚动至指定的高亮行，但是只会导致指定的行有高亮的效果，不能滚动到指定的行位置
`const autocomplete = this.$refs.autocomplete;`
`const inputElm = autocomplete.$el.querySelector("input");`
`inputElm.focus();`
`setTimeout((_) => {`
 `  autocomplete.highlight(8);`
`}, 500);`
