### PR TITLE
fix: calculate width and height with decimal

### DIFF
--- a/packages/carousel/src/item.vue
+++ b/packages/carousel/src/item.vue
@@ -61,7 +61,7 @@
       },
 
       calcCardTranslate(index, activeIndex) {
-        const parentWidth = this.$parent.$el.offsetWidth;
+        const parentWidth = this.$parent.$el.getBoundingClientRect().width;
         if (this.inStage) {
           return parentWidth * ((2 - CARD_SCALE) * (index - activeIndex) + 1) / 4;
         } else if (index < activeIndex) {
@@ -72,7 +72,7 @@
       },
 
       calcTranslate(index, activeIndex, isVertical) {
-        const distance = this.$parent.$el[isVertical ? 'offsetHeight' : 'offsetWidth'];
+        const distance = this.$parent.$el.getBoundingClientRect()[isVertical ? 'height' : 'width'];
         return distance * (index - activeIndex);
       },
 


### PR DESCRIPTION
carousel组件在计算宽高度的时候使用的是offsetWidth和offsetHeight，计算出来的只会是整数，但在有些情况下实际的宽度和高度会存在小数，例如在使用rem等为单位的情况下，误差零点几px的情况在chrome浏览器下（其他浏览器未进行测试）会导致当前页面展示了部分下一个非激活carousel-item的部分内容,比如carousel-item内元素的的最左侧存在border，会在当前active的carosuel-item的最右侧出现下一个非激活carousel-item的border，情况出现在使用offsetWidth计算出的宽度小于实际宽度的时候，也就是说比如当实际宽度是800.44而offsetWidth得到的值是800的时候会出现问题，而实际宽度是800.97offsetWidth得到的值是801的时候不会出现上述问题