### PR TITLE
style(docs): official page foot picture size is incorrect (#22765)

### DIFF
--- a/examples/components/footer.vue
+++ b/examples/components/footer.vue
@@ -144,7 +144,7 @@
     }
 
     img {
-      size: 100px;
+      width: 100px;
       margin: 10px;
     }
   }


### PR DESCRIPTION
Element official page footer tooltips wechat icon size error display
![element-footer](https://github.com/ElemeFE/element/assets/44578302/00f78ea4-36bf-41c9-812d-83ada92e3d87)
