### PR TITLE
fix: DateTimePicker clearable hide the clear button in the popup layer

### DIFF
--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -168,6 +168,7 @@
       </div>
       <div class="el-picker-panel__footer" v-if="showTime">
         <el-button
+          v-if="clearable"
           size="mini"
           type="text"
           class="el-picker-panel__link-btn"

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -858,6 +858,7 @@ export default {
       this.picker.selectionMode = this.selectionMode;
       this.picker.unlinkPanels = this.unlinkPanels;
       this.picker.arrowControl = this.arrowControl || this.timeArrowControl || false;
+      this.picker.clearable = this.clearable;
       this.$watch('format', (format) => {
         this.picker.format = format;
       });

--- a/packages/date-picker/src/picker/date-picker.js
+++ b/packages/date-picker/src/picker/date-picker.js
@@ -22,6 +22,10 @@ export default {
       type: String,
       default: 'date'
     },
+    clearable: {
+      type: Boolean,
+      default: true
+    },
     timeArrowControl: Boolean
   },
 


### PR DESCRIPTION
When the clearable property of DateTimePicker is set to false, it is not possible to hide the clear button in the popup layer.

fix: https://github.com/ElemeFE/element/issues/22989

![图片](https://github.com/user-attachments/assets/140ded8f-98bd-4a19-a1e1-00229e524f6e)


Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer relative issues for you PR.
