### PR TITLE
解决DateTimePicker 的 clear 属性设置为 false 时，不能隐藏弹出层中的 clear 按钮问题https://github.com/ElemeFE/element/pull/22990

### DIFF
--- a/packages/date-picker/src/panel/date-range.vue
+++ b/packages/date-picker/src/panel/date-range.vue
@@ -168,6 +168,7 @@
       </div>
       <div class="el-picker-panel__footer" v-if="showTime">
         <el-button
+          v-if="clearable"
           size="mini"
           type="text"
           class="el-picker-panel__link-btn"

--- a/packages/date-picker/src/picker.vue
+++ b/packages/date-picker/src/picker.vue
@@ -858,10 +858,13 @@ export default {
       this.picker.selectionMode = this.selectionMode;
       this.picker.unlinkPanels = this.unlinkPanels;
       this.picker.arrowControl = this.arrowControl || this.timeArrowControl || false;
+      this.picker.clearable = this.clearable;
       this.$watch('format', (format) => {
         this.picker.format = format;
       });
-
+      this.$watch('clearable', (clearable) => {
+        this.picker.clearable = clearable;
+      });
       const updateOptions = () => {
         const options = this.pickerOptions;
 


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you follow Element's contributing guide ([中文](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.zh-CN.md) | [English](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.en-US.md) | [Español](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/ElemeFE/element/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [ ] Make sure you are merging your commits to `dev` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
