### PR TITLE
fix: fix color-picker predefine not be selected

### DIFF
--- a/packages/color-picker/src/main.vue
+++ b/packages/color-picker/src/main.vue
@@ -140,6 +140,10 @@
         this.resetColor();
       },
       resetColor() {
+        this.color = new Color({
+          enableAlpha: this.showAlpha,
+          format: this.colorFormat
+        });
         this.$nextTick(_ => {
           if (this.value) {
             this.color.fromString(this.value);


### PR DESCRIPTION
Steps：
1.After selecting a predefine color,
2.click the clear button
3.and then choose the last selected color

you will find the color can not be selected